### PR TITLE
Fix clang-tidy filtering + warning cleanup

### DIFF
--- a/src/App/ProcessColumnConfig.h
+++ b/src/App/ProcessColumnConfig.h
@@ -48,33 +48,33 @@ constexpr auto getColumnInfo(ProcessColumn col) -> ProcessColumnInfo
     // clang-format off
     constexpr std::array<ProcessColumnInfo, static_cast<size_t>(ProcessColumn::Count)> infos = {{
         // PID - always visible
-        {"PID", "pid", 60.0F, true, false, "Process ID"},
+        {.name="PID", .configKey="pid", .defaultWidth=60.0F, .defaultVisible=true, .canHide=false, .description="Process ID"},
         // User
-        {"User", "user", 80.0F, true, true, "Process owner"},
+        {.name="User", .configKey="user", .defaultWidth=80.0F, .defaultVisible=true, .canHide=true, .description="Process owner"},
         // CPU%
-        {"CPU %", "cpu_percent", 55.0F, true, true, "CPU usage percentage"},
+        {.name="CPU %", .configKey="cpu_percent", .defaultWidth=55.0F, .defaultVisible=true, .canHide=true, .description="CPU usage percentage"},
         // MEM%
-        {"MEM %", "mem_percent", 55.0F, true, true, "Memory usage as percentage of total RAM"},
+        {.name="MEM %", .configKey="mem_percent", .defaultWidth=55.0F, .defaultVisible=true, .canHide=true, .description="Memory usage as percentage of total RAM"},
         // VIRT
-        {"VIRT", "virtual", 80.0F, false, true, "Virtual memory size"},
+        {.name="VIRT", .configKey="virtual", .defaultWidth=80.0F, .defaultVisible=false, .canHide=true, .description="Virtual memory size"},
         // RES
-        {"RES", "resident", 80.0F, true, true, "Resident memory (physical RAM used)"},
+        {.name="RES", .configKey="resident", .defaultWidth=80.0F, .defaultVisible=true, .canHide=true, .description="Resident memory (physical RAM used)"},
         // SHR
-        {"SHR", "shared", 70.0F, false, true, "Shared memory size"},
+        {.name="SHR", .configKey="shared", .defaultWidth=70.0F, .defaultVisible=false, .canHide=true, .description="Shared memory size"},
         // TIME+
-        {"TIME+", "cpu_time", 85.0F, true, true, "Cumulative CPU time (H:MM:SS.cc)"},
+        {.name="TIME+", .configKey="cpu_time", .defaultWidth=85.0F, .defaultVisible=true, .canHide=true, .description="Cumulative CPU time (H:MM:SS.cc)"},
         // State
-        {"S", "state", 25.0F, true, true, "Process state (R=Running, S=Sleeping, etc.)"},
+        {.name="S", .configKey="state", .defaultWidth=25.0F, .defaultVisible=true, .canHide=true, .description="Process state (R=Running, S=Sleeping, etc.)"},
         // Name
-        {"Name", "name", 120.0F, true, false, "Process name"},
+        {.name="Name", .configKey="name", .defaultWidth=120.0F, .defaultVisible=true, .canHide=false, .description="Process name"},
         // PPID
-        {"PPID", "ppid", 60.0F, false, true, "Parent process ID"},
+        {.name="PPID", .configKey="ppid", .defaultWidth=60.0F, .defaultVisible=false, .canHide=true, .description="Parent process ID"},
         // Nice
-        {"NI", "nice", 35.0F, false, true, "Nice value (priority, -20 to 19)"},
+        {.name="NI", .configKey="nice", .defaultWidth=35.0F, .defaultVisible=false, .canHide=true, .description="Nice value (priority, -20 to 19)"},
         // Threads
-        {"THR", "threads", 45.0F, false, true, "Thread count"},
+        {.name="THR", .configKey="threads", .defaultWidth=45.0F, .defaultVisible=false, .canHide=true, .description="Thread count"},
         // Command
-        {"Command", "command", 0.0F, true, true, "Full command line (0 = stretch)"},
+        {.name="Command", .configKey="command", .defaultWidth=0.0F, .defaultVisible=true, .canHide=true, .description="Full command line (0 = stretch)"},
     }};
     // clang-format on
 

--- a/src/App/UserConfig.h
+++ b/src/App/UserConfig.h
@@ -46,6 +46,11 @@ class UserConfig
     /// Get the singleton instance
     static auto get() -> UserConfig&;
 
+    UserConfig(const UserConfig&) = delete;
+    auto operator=(const UserConfig&) -> UserConfig& = delete;
+    UserConfig(UserConfig&&) = delete;
+    auto operator=(UserConfig&&) -> UserConfig& = delete;
+
     /// Load settings from config file (call on startup)
     void load();
 
@@ -79,11 +84,6 @@ class UserConfig
   private:
     UserConfig();
     ~UserConfig() = default;
-
-    UserConfig(const UserConfig&) = delete;
-    auto operator=(const UserConfig&) -> UserConfig& = delete;
-    UserConfig(UserConfig&&) = delete;
-    auto operator=(UserConfig&&) -> UserConfig& = delete;
 
     std::filesystem::path m_ConfigPath;
     UserSettings m_Settings;

--- a/src/UI/Theme.cpp
+++ b/src/UI/Theme.cpp
@@ -341,7 +341,7 @@ auto Theme::heatmapColor(double percent) const -> ImVec4
         idx = 3;
     }
 
-    const double localT = (t - static_cast<double>(idx) * STEP) / STEP;
+    const double localT = (t - (static_cast<double>(idx) * STEP)) / STEP;
 
     const ImVec4& c1 = colors[idx];
     const ImVec4& c2 = colors[idx + 1];

--- a/src/UI/Theme.h
+++ b/src/UI/Theme.h
@@ -146,8 +146,8 @@ struct DiscoveredTheme
 struct FontSizeConfig
 {
     std::string_view name;
-    float regularPt; // Body text
-    float largePt;   // Headings
+    float regularPt = 0.0F; // Body text
+    float largePt = 0.0F;   // Headings
 };
 
 /// Global theme manager - provides access to color schemes and font settings
@@ -156,6 +156,11 @@ class Theme
   public:
     /// Get the singleton instance
     static auto get() -> Theme&;
+
+    Theme(const Theme&) = delete;
+    auto operator=(const Theme&) -> Theme& = delete;
+    Theme(Theme&&) = delete;
+    auto operator=(Theme&&) -> Theme& = delete;
 
     /// Initialize themes by loading from TOML files
     /// @param themesDir Path to themes directory (e.g., "assets/themes")
@@ -241,11 +246,6 @@ class Theme
   private:
     Theme();
     ~Theme() = default;
-
-    Theme(const Theme&) = delete;
-    auto operator=(const Theme&) -> Theme& = delete;
-    Theme(Theme&&) = delete;
-    auto operator=(Theme&&) -> Theme& = delete;
 
     std::vector<DiscoveredTheme> m_DiscoveredThemes;
     std::vector<ColorScheme> m_LoadedSchemes;

--- a/src/UI/ThemeLoader.cpp
+++ b/src/UI/ThemeLoader.cpp
@@ -69,7 +69,13 @@ auto parseColorNode(const toml::node& node) -> ImVec4
 {
     if (node.is_string())
     {
-        return ThemeLoader::hexToImVec4(*node.value<std::string>());
+        const auto str = node.value<std::string>();
+        if (str.has_value())
+        {
+            return ThemeLoader::hexToImVec4(*str);
+        }
+        spdlog::warn("Invalid color string node");
+        return errorColor();
     }
 
     if (node.is_array())
@@ -94,7 +100,13 @@ auto parseColorView(toml::node_view<const toml::node> view) -> ImVec4
 {
     if (view.is_string())
     {
-        return ThemeLoader::hexToImVec4(*view.value<std::string>());
+        const auto str = view.value<std::string>();
+        if (str.has_value())
+        {
+            return ThemeLoader::hexToImVec4(*str);
+        }
+        spdlog::warn("Invalid color string node");
+        return errorColor();
     }
 
     if (view.is_array())


### PR DESCRIPTION
## Description

This PR tightens clang-tidy scope so generated code (notably `gladsources`) and non-target platform sources don’t produce diagnostics, and fixes several clang-tidy findings in project code.

## Type of Change

- [x] Build/CI improvement
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have run `clang-format` on my changes
- [x] I have run `clang-tidy` and addressed any warnings
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [ ] I have updated documentation as needed

## Testing

```bash
cmake --preset debug
cmake --build --preset debug
ctest --preset debug
./tools/clang-tidy.sh -v debug
./tools/clang-format.sh -v
```

## Additional Notes

Key changes:
- Narrow `clang-tidy` header diagnostics to `src/` + `tests/`, exclude build/generated trees (including `gladsources`) and exclude the other platform folder.
- Addressed clang-tidy warnings in UI + Linux probe code (optional access guards, safer numeric parsing, designated initializers, deleted special members visibility, and readability parentheses).
