### PR TITLE
feat(windows): Upgrade to GetIfTable2 for 64-bit network counters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,13 +690,15 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if(WIN32)
-    # Windows SDK version - required for GetIfTable2 and MIB_IF_TABLE2 (Vista+)
-    # _WIN32_WINNT=0x0A00 targets Windows 10+
+    # Windows SDK version: GetIfTable2 and MIB_IF_TABLE2 are available on Vista+,
+    # but we intentionally target Windows 10+ via _WIN32_WINNT=0x0A00 / WINVER=0x0A00.
+    # NTDDI_VERSION is required for iphlpapi.h to include netioapi.h (GetIfTable2 APIs).
     target_compile_definitions(TaskSmack PRIVATE
         NOMINMAX
         WIN32_LEAN_AND_MEAN
         _WIN32_WINNT=0x0A00
         WINVER=0x0A00
+        NTDDI_VERSION=0x0A000000
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,7 +690,14 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if(WIN32)
-    target_compile_definitions(TaskSmack PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
+    # Windows SDK version - required for GetIfTable2 and MIB_IF_TABLE2 (Vista+)
+    # _WIN32_WINNT=0x0A00 targets Windows 10+
+    target_compile_definitions(TaskSmack PRIVATE
+        NOMINMAX
+        WIN32_LEAN_AND_MEAN
+        _WIN32_WINNT=0x0A00
+        WINVER=0x0A00
+    )
 endif()
 
 target_include_directories(TaskSmack PRIVATE

--- a/src/Platform/Windows/WindowsSystemProbe.cpp
+++ b/src/Platform/Windows/WindowsSystemProbe.cpp
@@ -431,8 +431,8 @@ void WindowsSystemProbe::readNetworkCounters(SystemCounters& counters)
         // 64-bit link speeds in bits/sec - convert to Mbps
         // Use transmit speed (receive speed may differ on asymmetric links)
         // Windows uses 0 or ULONG64_MAX to indicate unknown speed
-        constexpr uint64_t UNKNOWN_SPEED_MAX = std::numeric_limits<uint64_t>::max();
-        if (row.TransmitLinkSpeed == 0 || row.TransmitLinkSpeed == UNKNOWN_SPEED_MAX)
+        constexpr uint64_t WINDOWS_UNKNOWN_LINK_SPEED = std::numeric_limits<uint64_t>::max();
+        if (row.TransmitLinkSpeed == 0 || row.TransmitLinkSpeed == WINDOWS_UNKNOWN_LINK_SPEED)
         {
             ifaceCounters.linkSpeedMbps = 0;
         }

--- a/src/Platform/Windows/WindowsSystemProbe.cpp
+++ b/src/Platform/Windows/WindowsSystemProbe.cpp
@@ -381,8 +381,8 @@ void WindowsSystemProbe::readNetworkCounters(SystemCounters& counters)
         // IF_TYPE_TUNNEL (131) - VPN tunnels
         // IF_TYPE_PPP (23) - PPP connections
         // IF_TYPE_PROP_VIRTUAL (53) - Virtual adapters (Hyper-V, Docker, etc.)
-        const bool isNetworkInterface = ((row.Type == IF_TYPE_ETHERNET_CSMACD) || (row.Type == IF_TYPE_IEEE80211) ||
-                                         (row.Type == IF_TYPE_TUNNEL) || (row.Type == IF_TYPE_PPP) || (row.Type == IF_TYPE_PROP_VIRTUAL));
+        const bool isNetworkInterface = (row.Type == IF_TYPE_ETHERNET_CSMACD || row.Type == IF_TYPE_IEEE80211 ||
+                                         row.Type == IF_TYPE_TUNNEL || row.Type == IF_TYPE_PPP || row.Type == IF_TYPE_PROP_VIRTUAL);
 
         if (!isNetworkInterface)
         {

--- a/src/Platform/Windows/WindowsSystemProbe.cpp
+++ b/src/Platform/Windows/WindowsSystemProbe.cpp
@@ -3,6 +3,13 @@
 #include <spdlog/spdlog.h>
 
 // clang-format off
+// Windows SDK version - required for GetIfTable2 and MIB_IF_TABLE2 (Vista+)
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00 // NOLINT(cppcoreguidelines-macro-usage) - Windows platform requirement
+#endif
+#ifndef WINVER
+#define WINVER _WIN32_WINNT
+#endif
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -334,7 +341,7 @@ SystemCapabilities WindowsSystemProbe::capabilities() const
         .hasSteal = false,          // Windows doesn't expose steal time
         .hasLoadAvg = false,        // Windows doesn't have load average
         .hasCpuFreq = true,         // From registry ~MHz
-        .hasNetworkCounters = true, // Via GetIfTable
+        .hasNetworkCounters = true, // Via GetIfTable2 (64-bit counters, Unicode names)
     };
 }
 
@@ -346,38 +353,29 @@ long WindowsSystemProbe::ticksPerSecond() const
 
 void WindowsSystemProbe::readNetworkCounters(SystemCounters& counters)
 {
-    // Use GetIfTable to enumerate network interfaces and read byte counters.
-    // This is the older API that works across all Windows versions.
-    // First call with null buffer to get required size.
-    DWORD tableSize = 0;
-    if (GetIfTable(nullptr, &tableSize, FALSE) != ERROR_INSUFFICIENT_BUFFER)
+    // Use GetIfTable2 for 64-bit counters and proper Unicode interface names.
+    // GetIfTable2 allocates the buffer internally; we must free it with FreeMibTable.
+    // Available since Windows Vista/Server 2008.
+    MIB_IF_TABLE2* table = nullptr;
+    const DWORD status = GetIfTable2(&table);
+    if (status != NO_ERROR || table == nullptr)
     {
-        spdlog::warn("GetIfTable size query failed");
-        return;
-    }
-
-    // Allocate buffer for the interface table
-    std::vector<std::byte> buffer(tableSize);
-    auto* table = reinterpret_cast<MIB_IFTABLE*>(buffer.data());
-
-    if (GetIfTable(table, &tableSize, FALSE) != NO_ERROR)
-    {
-        spdlog::warn("GetIfTable failed");
+        spdlog::warn("GetIfTable2 failed: {}", status);
         return;
     }
 
     uint64_t totalRxBytes = 0;
     uint64_t totalTxBytes = 0;
 
-    for (DWORD i = 0; i < table->dwNumEntries; ++i)
+    for (ULONG i = 0; i < table->NumEntries; ++i)
     {
-        const MIB_IFROW& row = table->table[i];
+        const MIB_IF_ROW2& row = table->Table[i];
 
         // Filter interfaces:
         // - Skip loopback (internal traffic)
         // - Skip non-network interface types (Bluetooth, etc.)
         // - Include Ethernet, Wi-Fi, and virtual adapters (VPN, Docker, etc.)
-        if (row.dwType == IF_TYPE_SOFTWARE_LOOPBACK)
+        if (row.Type == IF_TYPE_SOFTWARE_LOOPBACK)
         {
             continue;
         }
@@ -388,36 +386,52 @@ void WindowsSystemProbe::readNetworkCounters(SystemCounters& counters)
         // IF_TYPE_TUNNEL (131) - VPN tunnels
         // IF_TYPE_PPP (23) - PPP connections
         // IF_TYPE_PROP_VIRTUAL (53) - Virtual adapters (Hyper-V, Docker, etc.)
-        const bool isNetworkInterface = (row.dwType == IF_TYPE_ETHERNET_CSMACD || row.dwType == IF_TYPE_IEEE80211 ||
-                                         row.dwType == IF_TYPE_TUNNEL || row.dwType == IF_TYPE_PPP || row.dwType == IF_TYPE_PROP_VIRTUAL);
+        const bool isNetworkInterface = ((row.Type == IF_TYPE_ETHERNET_CSMACD) || (row.Type == IF_TYPE_IEEE80211) ||
+                                         (row.Type == IF_TYPE_TUNNEL) || (row.Type == IF_TYPE_PPP) || (row.Type == IF_TYPE_PROP_VIRTUAL));
 
         if (!isNetworkInterface)
         {
             continue;
         }
 
-        const uint64_t rxBytes = row.dwInOctets;
-        const uint64_t txBytes = row.dwOutOctets;
+        // 64-bit byte counters - no more 32-bit overflow issues
+        const uint64_t rxBytes = row.InOctets;
+        const uint64_t txBytes = row.OutOctets;
 
         totalRxBytes += rxBytes;
         totalTxBytes += txBytes;
 
         // Store per-interface data
         SystemCounters::InterfaceCounters ifaceCounters;
-        // MIB_IFROW uses narrow strings for description (ANSI)
-        // bDescr is a fixed-size char array, null-terminated
-        ifaceCounters.name = std::string(reinterpret_cast<const char*>(row.bDescr), row.dwDescrLen);
-        // Remove any trailing null characters using std::erase
-        std::erase(ifaceCounters.name, '\0');
-        ifaceCounters.displayName = ifaceCounters.name; // Use same name for display
+
+        // MIB_IF_ROW2 provides proper Unicode strings:
+        // - Alias: friendly name (e.g., "Wi-Fi", "Ethernet")
+        // - Description: full adapter description (e.g., "Intel(R) Wi-Fi 6 AX201 160MHz")
+        // Use Alias for name (shorter, user-friendly) and Description for display
+        ifaceCounters.name = WinString::wideToUtf8(row.Alias);
+        ifaceCounters.displayName = WinString::wideToUtf8(row.Description);
+
+        // Fall back to alias if description is empty
+        if (ifaceCounters.displayName.empty())
+        {
+            ifaceCounters.displayName = ifaceCounters.name;
+        }
+
         ifaceCounters.rxBytes = rxBytes;
         ifaceCounters.txBytes = txBytes;
-        // dwOperStatus: MIB_IF_OPER_STATUS enum - IF_OPER_STATUS_OPERATIONAL (1) means up
-        ifaceCounters.isUp = (row.dwOperStatus == IF_OPER_STATUS_OPERATIONAL);
-        // dwSpeed is in bits per second, convert to Mbps
-        ifaceCounters.linkSpeedMbps = row.dwSpeed / 1'000'000ULL;
+
+        // IF_OPER_STATUS enum - IfOperStatusUp (1) means interface is operational
+        ifaceCounters.isUp = (row.OperStatus == IfOperStatusUp);
+
+        // 64-bit link speeds in bits/sec - convert to Mbps
+        // Use transmit speed (receive speed may differ on asymmetric links)
+        ifaceCounters.linkSpeedMbps = row.TransmitLinkSpeed / 1'000'000ULL;
+
         counters.networkInterfaces.push_back(std::move(ifaceCounters));
     }
+
+    // Free the table allocated by GetIfTable2
+    FreeMibTable(table);
 
     counters.netRxBytes = totalRxBytes;
     counters.netTxBytes = totalTxBytes;

--- a/src/Platform/Windows/WindowsSystemProbe.cpp
+++ b/src/Platform/Windows/WindowsSystemProbe.cpp
@@ -3,13 +3,7 @@
 #include <spdlog/spdlog.h>
 
 // clang-format off
-// Windows SDK version - required for GetIfTable2 and MIB_IF_TABLE2 (Vista+)
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0A00 // NOLINT(cppcoreguidelines-macro-usage) - Windows platform requirement
-#endif
-#ifndef WINVER
-#define WINVER _WIN32_WINNT
-#endif
+// Windows headers - _WIN32_WINNT is set via CMake compile definitions
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -156,12 +156,15 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(WIN32)
-    # Windows SDK version - required for GetIfTable2 and MIB_IF_TABLE2 (Vista+)
+    # Windows SDK version: GetIfTable2 and MIB_IF_TABLE2 are available on Vista+,
+    # but we intentionally target Windows 10+ via _WIN32_WINNT=0x0A00 / WINVER=0x0A00.
+    # NTDDI_VERSION is required for iphlpapi.h to include netioapi.h (GetIfTable2 APIs).
     target_compile_definitions(TaskSmackTests PRIVATE
         NOMINMAX
         WIN32_LEAN_AND_MEAN
         _WIN32_WINNT=0x0A00
         WINVER=0x0A00
+        NTDDI_VERSION=0x0A000000
     )
     # Windows needs additional system libraries
     target_link_libraries(TaskSmackTests PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -156,6 +156,13 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(WIN32)
+    # Windows SDK version - required for GetIfTable2 and MIB_IF_TABLE2 (Vista+)
+    target_compile_definitions(TaskSmackTests PRIVATE
+        NOMINMAX
+        WIN32_LEAN_AND_MEAN
+        _WIN32_WINNT=0x0A00
+        WINVER=0x0A00
+    )
     # Windows needs additional system libraries
     target_link_libraries(TaskSmackTests PRIVATE
         pdh


### PR DESCRIPTION
## Summary

Upgrades the Windows network interface enumeration from `GetIfTable` to `GetIfTable2` API for improved accuracy and Unicode support.

## Changes

### API Migration: GetIfTable → GetIfTable2

| Field | Old (GetIfTable) | New (GetIfTable2) |
|-------|------------------|-------------------|
| Byte counters | 32-bit (`dwInOctets`/`dwOutOctets`) | 64-bit (`InOctets`/`OutOctets`) |
| Link speed | 32-bit (`dwSpeed`) ~4 Gbps max | 64-bit (`TransmitLinkSpeed`) |
| Interface name | ANSI (`bDescr`) | Unicode (`Alias`/`Description`) |
| Oper status | `IF_OPER_STATUS_OPERATIONAL` | `IfOperStatusUp` |
| Memory mgmt | Manual buffer allocation | Automatic with `FreeMibTable` |

### Benefits

1. **64-bit byte counters** - No more overflow on high-traffic interfaces
2. **64-bit link speeds** - Correctly reports 10/25/100 Gbps connections
3. **Unicode names** - Proper display of non-ASCII interface names
4. **Cleaner code** - No manual buffer sizing, API allocates internally

### Compatibility

`GetIfTable2` is available since Windows Vista/Server 2008. The code now targets `_WIN32_WINNT = 0x0A00` (Windows 10) which is the same as `WindowsProcessProbe`.

## Testing

- Linux build unaffected (code is Windows-only)
- CI will verify Windows build compiles correctly
- Network counters should work identically with improved accuracy

## Related

Closes #349

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have run `clang-format` on my changes
- [ ] Windows CI build passes (to be verified)
- [ ] Manual testing on Windows (if available)