### PR TITLE
refactor: modernize smoothing helpers, GPU lookup, and UTF-8 URL handling

### DIFF
--- a/src/App/AboutLayer.cpp
+++ b/src/App/AboutLayer.cpp
@@ -282,7 +282,20 @@ void AboutLayer::loadIcon()
 void AboutLayer::openUrl(const std::string& url)
 {
 #ifdef _WIN32
-    const std::wstring wideUrl(url.begin(), url.end());
+    // MultiByteToWideChar correctly converts UTF-8 to UTF-16;
+    // constructing wstring from url.begin()/url.end() only byte-widens and corrupts non-ASCII chars.
+    const int wlen = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), static_cast<int>(url.size()), nullptr, 0);
+    if (wlen <= 0)
+    {
+        spdlog::warn("Failed to convert URL to wide string: {}", url);
+        return;
+    }
+    std::wstring wideUrl(static_cast<std::size_t>(wlen), L'\0');
+    if (MultiByteToWideChar(CP_UTF8, 0, url.c_str(), static_cast<int>(url.size()), wideUrl.data(), wlen) == 0)
+    {
+        spdlog::warn("Failed to convert URL to wide string: {}", url);
+        return;
+    }
     ShellExecuteW(nullptr, L"open", wideUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 #else
     // NOLINTNEXTLINE(misc-include-cleaner) - pid_t from sys/types.h, include-cleaner false positive

--- a/src/App/Panels/GpuSection.cpp
+++ b/src/App/Panels/GpuSection.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <cstddef>
 #include <format>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -29,14 +30,41 @@ using UI::Widgets::formatAgeSeconds;
 using UI::Widgets::formatAxisPercent;
 using UI::Widgets::HISTORY_PLOT_HEIGHT_DEFAULT;
 using UI::Widgets::hoveredIndexFromPlotX;
+using UI::Widgets::initializeOrSmooth;
 using UI::Widgets::makeTimeAxisConfig;
 using UI::Widgets::NowBar;
 using UI::Widgets::PLOT_FLAGS_DEFAULT;
 using UI::Widgets::plotLineWithFill;
 using UI::Widgets::renderHistoryWithNowBars;
-using UI::Widgets::smoothTowards;
 using UI::Widgets::X_AXIS_FLAGS_DEFAULT;
 using UI::Widgets::Y_AXIS_FLAGS_DEFAULT;
+
+/// Scale each sample to a 0–100 percentage relative to maxVal.
+[[nodiscard]] std::vector<float> normalizeToPercent(std::span<const float> hist, float maxVal)
+{
+    std::vector<float> result(hist.size());
+    std::ranges::transform(hist, result.begin(), [maxVal](float v) { return (v / maxVal) * 100.0F; });
+    return result;
+}
+
+/// Render a "Note: This system does not report GPU X, Y or Z" line in muted text.
+void renderUnavailableMetricsNote(std::span<const std::string> unavailable, ImVec4 textColor)
+{
+    if (unavailable.empty())
+    {
+        return;
+    }
+    std::string noteText = "Note: This system does not report GPU ";
+    for (std::size_t i = 0; i < unavailable.size(); ++i)
+    {
+        if (i > 0)
+        {
+            noteText += (i == unavailable.size() - 1) ? " or " : ", ";
+        }
+        noteText += unavailable[i];
+    }
+    ImGui::TextColored(textColor, "%s", noteText.c_str());
+}
 
 } // namespace
 
@@ -50,20 +78,12 @@ void updateSmoothedGPU(const std::string& gpuId, const Domain::GPUSnapshot& snap
     const double alpha = computeAlpha(ctx.lastDeltaSeconds, ctx.refreshInterval);
 
     auto& smoothed = (*ctx.smoothedGPUs)[gpuId];
-    if (!smoothed.initialized)
-    {
-        smoothed.utilizationPercent = snap.utilizationPercent;
-        smoothed.memoryPercent = snap.memoryUsedPercent;
-        smoothed.temperatureC = static_cast<double>(snap.temperatureC);
-        smoothed.powerWatts = snap.powerDrawWatts;
-        smoothed.initialized = true;
-        return;
-    }
-
-    smoothed.utilizationPercent = smoothTowards(smoothed.utilizationPercent, snap.utilizationPercent, alpha);
-    smoothed.memoryPercent = smoothTowards(smoothed.memoryPercent, snap.memoryUsedPercent, alpha);
-    smoothed.temperatureC = smoothTowards(smoothed.temperatureC, static_cast<double>(snap.temperatureC), alpha);
-    smoothed.powerWatts = smoothTowards(smoothed.powerWatts, snap.powerDrawWatts, alpha);
+    const bool initialized = smoothed.initialized;
+    smoothed.utilizationPercent = initializeOrSmooth(smoothed.utilizationPercent, snap.utilizationPercent, alpha, initialized);
+    smoothed.memoryPercent = initializeOrSmooth(smoothed.memoryPercent, snap.memoryUsedPercent, alpha, initialized);
+    smoothed.temperatureC = initializeOrSmooth(smoothed.temperatureC, static_cast<double>(snap.temperatureC), alpha, initialized);
+    smoothed.powerWatts = initializeOrSmooth(smoothed.powerWatts, snap.powerDrawWatts, alpha, initialized);
+    smoothed.initialized = true;
 }
 
 void renderGpuSection(RenderContext& ctx)
@@ -203,11 +223,7 @@ void renderGpuSection(RenderContext& ctx)
                 // Plot clock as normalized percentage (0-maxClockMHz mapped to 0-100)
                 if (caps.hasClockSpeeds && !clockHist.empty())
                 {
-                    std::vector<float> clockPercent(clockHist.size());
-                    for (size_t i = 0; i < clockHist.size(); ++i)
-                    {
-                        clockPercent[i] = (clockHist[i] / maxClockMHz) * 100.0F;
-                    }
+                    const auto clockPercent = normalizeToPercent(clockHist, maxClockMHz);
                     plotLineWithFill("Clock",
                                      timeData.data(),
                                      clockPercent.data(),
@@ -355,16 +371,7 @@ void renderGpuSection(RenderContext& ctx)
 
             if (!unavailableCoreNotes.empty())
             {
-                std::string noteText = "Note: This system does not report GPU ";
-                for (size_t i = 0; i < unavailableCoreNotes.size(); ++i)
-                {
-                    if (i > 0)
-                    {
-                        noteText += (i == unavailableCoreNotes.size() - 1) ? " or " : ", ";
-                    }
-                    noteText += unavailableCoreNotes[i];
-                }
-                ImGui::TextColored(theme.scheme().textMuted, "%s", noteText.c_str());
+                renderUnavailableMetricsNote(unavailableCoreNotes, theme.scheme().textMuted);
             }
         }
 
@@ -395,11 +402,7 @@ void renderGpuSection(RenderContext& ctx)
                     // Temperature (normalized to 0-100%)
                     if (caps.hasTemperature && !tempHist.empty())
                     {
-                        std::vector<float> tempPercent(tempHist.size());
-                        for (size_t i = 0; i < tempHist.size(); ++i)
-                        {
-                            tempPercent[i] = (tempHist[i] / maxTempC) * 100.0F;
-                        }
+                        const auto tempPercent = normalizeToPercent(tempHist, maxTempC);
                         plotLineWithFill("Temp",
                                          timeData.data(),
                                          tempPercent.data(),
@@ -410,11 +413,7 @@ void renderGpuSection(RenderContext& ctx)
                     // Power (normalized to power limit percentage)
                     if (caps.hasPowerMetrics && !powerHist.empty())
                     {
-                        std::vector<float> powerPercent(powerHist.size());
-                        for (size_t i = 0; i < powerHist.size(); ++i)
-                        {
-                            powerPercent[i] = (powerHist[i] / maxPowerW) * 100.0F;
-                        }
+                        const auto powerPercent = normalizeToPercent(powerHist, maxPowerW);
                         plotLineWithFill("Power",
                                          timeData.data(),
                                          powerPercent.data(),
@@ -490,16 +489,7 @@ void renderGpuSection(RenderContext& ctx)
 
             if (!unavailableNotes.empty())
             {
-                std::string noteText = "Note: This system does not report GPU ";
-                for (size_t i = 0; i < unavailableNotes.size(); ++i)
-                {
-                    if (i > 0)
-                    {
-                        noteText += (i == unavailableNotes.size() - 1) ? " or " : ", ";
-                    }
-                    noteText += unavailableNotes[i];
-                }
-                ImGui::TextColored(theme.scheme().textMuted, "%s", noteText.c_str());
+                renderUnavailableMetricsNote(unavailableNotes, theme.scheme().textMuted);
             }
         }
 

--- a/src/App/Panels/MemorySection.cpp
+++ b/src/App/Panels/MemorySection.cpp
@@ -27,12 +27,12 @@ using UI::Widgets::cropFrontToSize;
 using UI::Widgets::formatAgeSeconds;
 using UI::Widgets::HISTORY_PLOT_HEIGHT_DEFAULT;
 using UI::Widgets::hoveredIndexFromPlotX;
+using UI::Widgets::initializeOrSmooth;
 using UI::Widgets::makeTimeAxisConfig;
 using UI::Widgets::NowBar;
 using UI::Widgets::PLOT_FLAGS_DEFAULT;
 using UI::Widgets::plotLineWithFill;
 using UI::Widgets::renderHistoryWithNowBars;
-using UI::Widgets::smoothTowards;
 using UI::Widgets::X_AXIS_FLAGS_DEFAULT;
 using UI::Widgets::Y_AXIS_FLAGS_DEFAULT;
 
@@ -51,18 +51,11 @@ void updateSmoothedMemory(SmoothedMemory& smoothed,
     const double targetCached = clampPercent(snap.memoryCachedPercent);
     const double targetSwap = clampPercent(snap.swapUsedPercent);
 
-    if (!smoothed.initialized)
-    {
-        smoothed.usedPercent = targetMem;
-        smoothed.cachedPercent = targetCached;
-        smoothed.swapPercent = targetSwap;
-        smoothed.initialized = true;
-        return;
-    }
-
-    smoothed.usedPercent = clampPercent(smoothTowards(smoothed.usedPercent, targetMem, alpha));
-    smoothed.cachedPercent = clampPercent(smoothTowards(smoothed.cachedPercent, targetCached, alpha));
-    smoothed.swapPercent = clampPercent(smoothTowards(smoothed.swapPercent, targetSwap, alpha));
+    const bool initialized = smoothed.initialized;
+    smoothed.usedPercent = clampPercent(initializeOrSmooth(smoothed.usedPercent, targetMem, alpha, initialized));
+    smoothed.cachedPercent = clampPercent(initializeOrSmooth(smoothed.cachedPercent, targetCached, alpha, initialized));
+    smoothed.swapPercent = clampPercent(initializeOrSmooth(smoothed.swapPercent, targetSwap, alpha, initialized));
+    smoothed.initialized = true;
 }
 
 void renderMemorySection(RenderContext& ctx, const std::vector<double>& timestamps, double nowSeconds, int nowBarColumns)

--- a/src/App/Panels/NetworkSection.cpp
+++ b/src/App/Panels/NetworkSection.cpp
@@ -32,11 +32,11 @@ using UI::Widgets::formatAgeSeconds;
 using UI::Widgets::formatAxisBytesPerSec;
 using UI::Widgets::HISTORY_PLOT_HEIGHT_DEFAULT;
 using UI::Widgets::hoveredIndexFromPlotX;
+using UI::Widgets::initializeOrSmooth;
 using UI::Widgets::makeTimeAxisConfig;
 using UI::Widgets::NowBar;
 using UI::Widgets::plotLineWithFill;
 using UI::Widgets::renderHistoryWithNowBars;
-using UI::Widgets::smoothTowards;
 using UI::Widgets::X_AXIS_FLAGS_DEFAULT;
 using UI::Widgets::Y_AXIS_FLAGS_DEFAULT;
 
@@ -50,16 +50,10 @@ void updateSmoothedNetwork(double targetSent, double targetRecv, float deltaTime
 
     const double alpha = computeAlpha(deltaTimeSeconds, ctx.refreshInterval);
 
-    if (!*ctx.smoothedNetInitialized)
-    {
-        *ctx.smoothedNetSentBytesPerSec = targetSent;
-        *ctx.smoothedNetRecvBytesPerSec = targetRecv;
-        *ctx.smoothedNetInitialized = true;
-        return;
-    }
-
-    *ctx.smoothedNetSentBytesPerSec = smoothTowards(*ctx.smoothedNetSentBytesPerSec, targetSent, alpha);
-    *ctx.smoothedNetRecvBytesPerSec = smoothTowards(*ctx.smoothedNetRecvBytesPerSec, targetRecv, alpha);
+    const bool initialized = *ctx.smoothedNetInitialized;
+    *ctx.smoothedNetSentBytesPerSec = initializeOrSmooth(*ctx.smoothedNetSentBytesPerSec, targetSent, alpha, initialized);
+    *ctx.smoothedNetRecvBytesPerSec = initializeOrSmooth(*ctx.smoothedNetRecvBytesPerSec, targetRecv, alpha, initialized);
+    *ctx.smoothedNetInitialized = true;
 }
 
 } // namespace

--- a/src/App/Panels/ProcessDetailsPanel.cpp
+++ b/src/App/Panels/ProcessDetailsPanel.cpp
@@ -43,12 +43,12 @@ using UI::Widgets::formatAxisLocalized;
 using UI::Widgets::formatAxisWatts;
 using UI::Widgets::HISTORY_PLOT_HEIGHT_DEFAULT;
 using UI::Widgets::hoveredIndexFromPlotX;
+using UI::Widgets::initializeOrSmooth;
 using UI::Widgets::makeTimeAxisConfig;
 using UI::Widgets::NowBar;
 using UI::Widgets::plotLineWithFill;
 using UI::Widgets::renderHistoryWithNowBars;
 using UI::Widgets::setupLegendDefault;
-using UI::Widgets::smoothTowards;
 using UI::Widgets::X_AXIS_FLAGS_DEFAULT;
 using UI::Widgets::Y_AXIS_FLAGS_DEFAULT;
 
@@ -422,43 +422,33 @@ void ProcessDetailsPanel::updateSmoothedUsage(const Domain::ProcessSnapshot& sna
     const double targetGpuUtil = UI::Format::clampPercent(snapshot.gpuUtilPercent);
     const double targetGpuMem = Domain::Numeric::toDouble(snapshot.gpuMemoryBytes);
 
-    if (!m_SmoothedUsage.initialized || deltaTimeSeconds <= 0.0F)
-    {
-        m_SmoothedUsage.cpuPercent = targetCpu;
-        m_SmoothedUsage.residentBytes = targetResident;
-        m_SmoothedUsage.virtualBytes = targetVirtual;
-        m_SmoothedUsage.cpuUserPercent = targetCpuUser;
-        m_SmoothedUsage.cpuSystemPercent = targetCpuSystem;
-        m_SmoothedUsage.threadCount = targetThreads;
-        m_SmoothedUsage.handleCount = targetHandles;
-        m_SmoothedUsage.pageFaultsPerSec = targetFaults;
-        m_SmoothedUsage.ioReadBytesPerSec = targetIoRead;
-        m_SmoothedUsage.ioWriteBytesPerSec = targetIoWrite;
-        m_SmoothedUsage.netSentBytesPerSec = targetNetSent;
-        m_SmoothedUsage.netRecvBytesPerSec = targetNetRecv;
-        m_SmoothedUsage.powerWatts = targetPower;
-        m_SmoothedUsage.gpuUtilPercent = targetGpuUtil;
-        m_SmoothedUsage.gpuMemoryBytes = targetGpuMem;
-        m_SmoothedUsage.initialized = true;
-        return;
-    }
+    const bool initialized = m_SmoothedUsage.initialized && (deltaTimeSeconds > 0.0F);
 
-    m_SmoothedUsage.cpuPercent = UI::Format::clampPercent(smoothTowards(m_SmoothedUsage.cpuPercent, targetCpu, alpha));
-    m_SmoothedUsage.residentBytes = std::max(0.0, smoothTowards(m_SmoothedUsage.residentBytes, targetResident, alpha));
-    m_SmoothedUsage.virtualBytes = smoothTowards(m_SmoothedUsage.virtualBytes, targetVirtual, alpha);
+    m_SmoothedUsage.cpuPercent = UI::Format::clampPercent(initializeOrSmooth(m_SmoothedUsage.cpuPercent, targetCpu, alpha, initialized));
+    m_SmoothedUsage.residentBytes = std::max(0.0, initializeOrSmooth(m_SmoothedUsage.residentBytes, targetResident, alpha, initialized));
+    m_SmoothedUsage.virtualBytes = initializeOrSmooth(m_SmoothedUsage.virtualBytes, targetVirtual, alpha, initialized);
     m_SmoothedUsage.virtualBytes = std::max(m_SmoothedUsage.virtualBytes, m_SmoothedUsage.residentBytes);
-    m_SmoothedUsage.cpuUserPercent = UI::Format::clampPercent(smoothTowards(m_SmoothedUsage.cpuUserPercent, targetCpuUser, alpha));
-    m_SmoothedUsage.cpuSystemPercent = UI::Format::clampPercent(smoothTowards(m_SmoothedUsage.cpuSystemPercent, targetCpuSystem, alpha));
-    m_SmoothedUsage.threadCount = std::max(0.0, smoothTowards(m_SmoothedUsage.threadCount, targetThreads, alpha));
-    m_SmoothedUsage.handleCount = std::max(0.0, smoothTowards(m_SmoothedUsage.handleCount, targetHandles, alpha));
-    m_SmoothedUsage.pageFaultsPerSec = std::max(0.0, smoothTowards(m_SmoothedUsage.pageFaultsPerSec, targetFaults, alpha));
-    m_SmoothedUsage.ioReadBytesPerSec = std::max(0.0, smoothTowards(m_SmoothedUsage.ioReadBytesPerSec, targetIoRead, alpha));
-    m_SmoothedUsage.ioWriteBytesPerSec = std::max(0.0, smoothTowards(m_SmoothedUsage.ioWriteBytesPerSec, targetIoWrite, alpha));
-    m_SmoothedUsage.netSentBytesPerSec = std::max(0.0, smoothTowards(m_SmoothedUsage.netSentBytesPerSec, targetNetSent, alpha));
-    m_SmoothedUsage.netRecvBytesPerSec = std::max(0.0, smoothTowards(m_SmoothedUsage.netRecvBytesPerSec, targetNetRecv, alpha));
-    m_SmoothedUsage.powerWatts = std::max(0.0, smoothTowards(m_SmoothedUsage.powerWatts, targetPower, alpha));
-    m_SmoothedUsage.gpuUtilPercent = UI::Format::clampPercent(smoothTowards(m_SmoothedUsage.gpuUtilPercent, targetGpuUtil, alpha));
-    m_SmoothedUsage.gpuMemoryBytes = std::max(0.0, smoothTowards(m_SmoothedUsage.gpuMemoryBytes, targetGpuMem, alpha));
+    m_SmoothedUsage.cpuUserPercent =
+        UI::Format::clampPercent(initializeOrSmooth(m_SmoothedUsage.cpuUserPercent, targetCpuUser, alpha, initialized));
+    m_SmoothedUsage.cpuSystemPercent =
+        UI::Format::clampPercent(initializeOrSmooth(m_SmoothedUsage.cpuSystemPercent, targetCpuSystem, alpha, initialized));
+    m_SmoothedUsage.threadCount = std::max(0.0, initializeOrSmooth(m_SmoothedUsage.threadCount, targetThreads, alpha, initialized));
+    m_SmoothedUsage.handleCount = std::max(0.0, initializeOrSmooth(m_SmoothedUsage.handleCount, targetHandles, alpha, initialized));
+    m_SmoothedUsage.pageFaultsPerSec =
+        std::max(0.0, initializeOrSmooth(m_SmoothedUsage.pageFaultsPerSec, targetFaults, alpha, initialized));
+    m_SmoothedUsage.ioReadBytesPerSec =
+        std::max(0.0, initializeOrSmooth(m_SmoothedUsage.ioReadBytesPerSec, targetIoRead, alpha, initialized));
+    m_SmoothedUsage.ioWriteBytesPerSec =
+        std::max(0.0, initializeOrSmooth(m_SmoothedUsage.ioWriteBytesPerSec, targetIoWrite, alpha, initialized));
+    m_SmoothedUsage.netSentBytesPerSec =
+        std::max(0.0, initializeOrSmooth(m_SmoothedUsage.netSentBytesPerSec, targetNetSent, alpha, initialized));
+    m_SmoothedUsage.netRecvBytesPerSec =
+        std::max(0.0, initializeOrSmooth(m_SmoothedUsage.netRecvBytesPerSec, targetNetRecv, alpha, initialized));
+    m_SmoothedUsage.powerWatts = std::max(0.0, initializeOrSmooth(m_SmoothedUsage.powerWatts, targetPower, alpha, initialized));
+    m_SmoothedUsage.gpuUtilPercent =
+        UI::Format::clampPercent(initializeOrSmooth(m_SmoothedUsage.gpuUtilPercent, targetGpuUtil, alpha, initialized));
+    m_SmoothedUsage.gpuMemoryBytes = std::max(0.0, initializeOrSmooth(m_SmoothedUsage.gpuMemoryBytes, targetGpuMem, alpha, initialized));
+    m_SmoothedUsage.initialized = true;
 }
 
 void ProcessDetailsPanel::renderBasicInfo(const Domain::ProcessSnapshot& proc)

--- a/src/App/Panels/StorageSection.cpp
+++ b/src/App/Panels/StorageSection.cpp
@@ -26,11 +26,11 @@ using UI::Widgets::formatAgeSeconds;
 using UI::Widgets::formatAxisBytesPerSec;
 using UI::Widgets::HISTORY_PLOT_HEIGHT_DEFAULT;
 using UI::Widgets::hoveredIndexFromPlotX;
+using UI::Widgets::initializeOrSmooth;
 using UI::Widgets::makeTimeAxisConfig;
 using UI::Widgets::NowBar;
 using UI::Widgets::plotLineWithFill;
 using UI::Widgets::renderHistoryWithNowBars;
-using UI::Widgets::smoothTowards;
 using UI::Widgets::X_AXIS_FLAGS_DEFAULT;
 using UI::Widgets::Y_AXIS_FLAGS_DEFAULT;
 
@@ -47,16 +47,10 @@ void updateSmoothedDiskIO(double targetRead, double targetWrite, float deltaTime
 
     const double alpha = computeAlpha(deltaTimeSeconds, ctx.refreshInterval);
 
-    if (!*ctx.smoothedInitialized)
-    {
-        *ctx.smoothedReadBytesPerSec = targetRead;
-        *ctx.smoothedWriteBytesPerSec = targetWrite;
-        *ctx.smoothedInitialized = true;
-        return;
-    }
-
-    *ctx.smoothedReadBytesPerSec = smoothTowards(*ctx.smoothedReadBytesPerSec, targetRead, alpha);
-    *ctx.smoothedWriteBytesPerSec = smoothTowards(*ctx.smoothedWriteBytesPerSec, targetWrite, alpha);
+    const bool initialized = *ctx.smoothedInitialized;
+    *ctx.smoothedReadBytesPerSec = initializeOrSmooth(*ctx.smoothedReadBytesPerSec, targetRead, alpha, initialized);
+    *ctx.smoothedWriteBytesPerSec = initializeOrSmooth(*ctx.smoothedWriteBytesPerSec, targetWrite, alpha, initialized);
+    *ctx.smoothedInitialized = true;
 }
 
 void renderStorageSection(RenderContext& ctx)

--- a/src/Domain/GPUModel.cpp
+++ b/src/Domain/GPUModel.cpp
@@ -70,7 +70,7 @@ void GPUModel::refresh()
         const double timeDeltaSeconds = static_cast<double>(timeDelta.count()) / 1000.0;
 
         // Compute snapshots
-        std::unordered_map<std::string, GPUSnapshot> newSnapshots;
+        SnapshotMap newSnapshots;
         for (const auto& current : currentCounters)
         {
             // Look for previous counters
@@ -139,7 +139,7 @@ std::vector<GPUSnapshot> GPUModel::snapshots() const
     return result;
 }
 
-std::vector<GPUSnapshot> GPUModel::history(const std::string& gpuId) const
+std::vector<GPUSnapshot> GPUModel::history(std::string_view gpuId) const
 {
     const std::shared_lock lock(m_Mutex);
     auto it = m_Histories.find(gpuId);
@@ -151,10 +151,9 @@ std::vector<GPUSnapshot> GPUModel::history(const std::string& gpuId) const
     // Copy history data to vector for thread-safe return
     std::vector<GPUSnapshot> result;
     result.reserve(it->second.size());
-    for (size_t i = 0; i < it->second.size(); ++i)
-    {
-        result.push_back(it->second[i]);
-    }
+    result.resize(it->second.size());
+    const std::size_t copied = it->second.copyTo(result.data(), result.size());
+    result.resize(copied);
     return result;
 }
 
@@ -247,7 +246,7 @@ GPUModel::computeSnapshot(const Platform::GPUCounters& current, const Platform::
 }
 
 // Template helper for extracting history fields - reduces code duplication
-template<typename FieldPtr> std::vector<float> GPUModel::getHistoryField(const std::string& gpuId, FieldPtr field) const
+template<typename FieldPtr> std::vector<float> GPUModel::getHistoryField(std::string_view gpuId, FieldPtr field) const
 {
     const std::shared_lock lock(m_Mutex);
     auto it = m_Histories.find(gpuId);
@@ -265,42 +264,42 @@ template<typename FieldPtr> std::vector<float> GPUModel::getHistoryField(const s
     return result;
 }
 
-std::vector<float> GPUModel::utilizationHistory(const std::string& gpuId) const
+std::vector<float> GPUModel::utilizationHistory(std::string_view gpuId) const
 {
     return getHistoryField(gpuId, &GPUSnapshot::utilizationPercent);
 }
 
-std::vector<float> GPUModel::memoryPercentHistory(const std::string& gpuId) const
+std::vector<float> GPUModel::memoryPercentHistory(std::string_view gpuId) const
 {
     return getHistoryField(gpuId, &GPUSnapshot::memoryUsedPercent);
 }
 
-std::vector<float> GPUModel::gpuClockHistory(const std::string& gpuId) const
+std::vector<float> GPUModel::gpuClockHistory(std::string_view gpuId) const
 {
     return getHistoryField(gpuId, &GPUSnapshot::gpuClockMHz);
 }
 
-std::vector<float> GPUModel::encoderHistory(const std::string& gpuId) const
+std::vector<float> GPUModel::encoderHistory(std::string_view gpuId) const
 {
     return getHistoryField(gpuId, &GPUSnapshot::encoderUtilPercent);
 }
 
-std::vector<float> GPUModel::decoderHistory(const std::string& gpuId) const
+std::vector<float> GPUModel::decoderHistory(std::string_view gpuId) const
 {
     return getHistoryField(gpuId, &GPUSnapshot::decoderUtilPercent);
 }
 
-std::vector<float> GPUModel::temperatureHistory(const std::string& gpuId) const
+std::vector<float> GPUModel::temperatureHistory(std::string_view gpuId) const
 {
     return getHistoryField(gpuId, &GPUSnapshot::temperatureC);
 }
 
-std::vector<float> GPUModel::powerHistory(const std::string& gpuId) const
+std::vector<float> GPUModel::powerHistory(std::string_view gpuId) const
 {
     return getHistoryField(gpuId, &GPUSnapshot::powerDrawWatts);
 }
 
-std::vector<float> GPUModel::fanSpeedHistory(const std::string& gpuId) const
+std::vector<float> GPUModel::fanSpeedHistory(std::string_view gpuId) const
 {
     return getHistoryField(gpuId, &GPUSnapshot::fanSpeedRPMPercent);
 }

--- a/src/Domain/GPUModel.h
+++ b/src/Domain/GPUModel.h
@@ -6,6 +6,7 @@
 #include "Platform/IGPUProbe.h"
 
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <shared_mutex>
 #include <string_view>

--- a/src/Domain/GPUModel.h
+++ b/src/Domain/GPUModel.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <memory>
 #include <shared_mutex>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -16,6 +17,28 @@ namespace Domain
 
 // GPU history capacity: 5 minutes at 1 second intervals = 300 samples
 inline constexpr size_t GPU_HISTORY_CAPACITY = 300;
+
+struct TransparentStringHash
+{
+    // NOLINTNEXTLINE(readability-identifier-naming) - STL transparent hashing requires this exact alias name.
+    using is_transparent = void;
+
+    [[nodiscard]] std::size_t operator()(std::string_view value) const noexcept
+    {
+        return std::hash<std::string_view>{}(value);
+    }
+};
+
+struct TransparentStringEqual
+{
+    // NOLINTNEXTLINE(readability-identifier-naming) - STL transparent equality requires this exact alias name.
+    using is_transparent = void;
+
+    [[nodiscard]] bool operator()(std::string_view lhs, std::string_view rhs) const noexcept
+    {
+        return lhs == rhs;
+    }
+};
 
 class GPUModel
 {
@@ -35,17 +58,17 @@ class GPUModel
     [[nodiscard]] std::vector<GPUSnapshot> snapshots() const;
 
     // Get history for specific GPU (returns copy for thread safety)
-    [[nodiscard]] std::vector<GPUSnapshot> history(const std::string& gpuId) const;
+    [[nodiscard]] std::vector<GPUSnapshot> history(std::string_view gpuId) const;
 
     // Get flattened history arrays for specific GPU (for chart plotting)
-    [[nodiscard]] std::vector<float> utilizationHistory(const std::string& gpuId) const;
-    [[nodiscard]] std::vector<float> memoryPercentHistory(const std::string& gpuId) const;
-    [[nodiscard]] std::vector<float> gpuClockHistory(const std::string& gpuId) const;
-    [[nodiscard]] std::vector<float> encoderHistory(const std::string& gpuId) const;
-    [[nodiscard]] std::vector<float> decoderHistory(const std::string& gpuId) const;
-    [[nodiscard]] std::vector<float> temperatureHistory(const std::string& gpuId) const;
-    [[nodiscard]] std::vector<float> powerHistory(const std::string& gpuId) const;
-    [[nodiscard]] std::vector<float> fanSpeedHistory(const std::string& gpuId) const;
+    [[nodiscard]] std::vector<float> utilizationHistory(std::string_view gpuId) const;
+    [[nodiscard]] std::vector<float> memoryPercentHistory(std::string_view gpuId) const;
+    [[nodiscard]] std::vector<float> gpuClockHistory(std::string_view gpuId) const;
+    [[nodiscard]] std::vector<float> encoderHistory(std::string_view gpuId) const;
+    [[nodiscard]] std::vector<float> decoderHistory(std::string_view gpuId) const;
+    [[nodiscard]] std::vector<float> temperatureHistory(std::string_view gpuId) const;
+    [[nodiscard]] std::vector<float> powerHistory(std::string_view gpuId) const;
+    [[nodiscard]] std::vector<float> fanSpeedHistory(std::string_view gpuId) const;
 
     // Get timestamps for GPU history
     [[nodiscard]] std::vector<double> historyTimestamps() const;
@@ -67,16 +90,21 @@ class GPUModel
     std::vector<Platform::GPUInfo> m_GPUInfo;
 
     // Current snapshots per GPU
-    std::unordered_map<std::string, GPUSnapshot> m_Snapshots;
+    using SnapshotMap = std::unordered_map<std::string, GPUSnapshot, TransparentStringHash, TransparentStringEqual>;
+    using HistoryMap =
+        std::unordered_map<std::string, History<GPUSnapshot, GPU_HISTORY_CAPACITY>, TransparentStringHash, TransparentStringEqual>;
+    using CounterMap = std::unordered_map<std::string, Platform::GPUCounters, TransparentStringHash, TransparentStringEqual>;
+
+    SnapshotMap m_Snapshots;
 
     // History buffers per GPU
-    std::unordered_map<std::string, History<GPUSnapshot, GPU_HISTORY_CAPACITY>> m_Histories;
+    HistoryMap m_Histories;
 
     // Timestamps for history data
     std::vector<double> m_HistoryTimestamps;
 
     // Previous counters for rate calculation
-    std::unordered_map<std::string, Platform::GPUCounters> m_PrevCounters;
+    CounterMap m_PrevCounters;
     std::chrono::steady_clock::time_point m_PrevSampleTime;
 
     // Thread safety
@@ -87,7 +115,7 @@ class GPUModel
     computeSnapshot(const Platform::GPUCounters& current, const Platform::GPUCounters* previous, double timeDeltaSeconds) const;
 
     // Helper template: extract a field from GPU history and return as float vector
-    template<typename FieldPtr> [[nodiscard]] std::vector<float> getHistoryField(const std::string& gpuId, FieldPtr field) const;
+    template<typename FieldPtr> [[nodiscard]] std::vector<float> getHistoryField(std::string_view gpuId, FieldPtr field) const;
 };
 
 } // namespace Domain

--- a/src/Platform/Windows/WindowsGPUProbe.cpp
+++ b/src/Platform/Windows/WindowsGPUProbe.cpp
@@ -3,12 +3,19 @@
 #include "DXGIGPUProbe.h"
 #include "NVMLGPUProbe.h"
 #include "PDHGPUProbe.h"
+#include "Platform/GPUTypes.h"
 
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace Platform
 {

--- a/src/UI/ChartWidgets.h
+++ b/src/UI/ChartWidgets.h
@@ -17,6 +17,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -80,6 +81,16 @@ inline double computeAlpha(float deltaTimeSeconds, std::chrono::milliseconds ref
 inline double smoothTowards(double current, double target, double alpha)
 {
     return current + (alpha * (target - current));
+}
+
+template<typename T> inline T initializeOrSmooth(T current, T target, double alpha, bool initialized)
+{
+    static_assert(std::is_arithmetic_v<T>, "initializeOrSmooth requires arithmetic types");
+    if (!initialized)
+    {
+        return target;
+    }
+    return static_cast<T>(smoothTowards(static_cast<double>(current), static_cast<double>(target), alpha));
 }
 
 inline std::string formatAgeSeconds(double relativeSeconds)

--- a/src/UI/Theme.cpp
+++ b/src/UI/Theme.cpp
@@ -2,6 +2,7 @@
 
 #include "ThemeLoader.h"
 
+#include <imgui.h>
 #include <implot.h>
 #include <spdlog/spdlog.h>
 

--- a/src/UI/Theme.cpp
+++ b/src/UI/Theme.cpp
@@ -261,7 +261,7 @@ auto Theme::applyPendingTheme() -> bool
     return true;
 }
 
-void Theme::setThemeById(const std::string& id)
+void Theme::setThemeById(std::string_view id)
 {
     for (std::size_t i = 0; i < m_DiscoveredThemes.size(); ++i)
     {

--- a/src/UI/Theme.h
+++ b/src/UI/Theme.h
@@ -223,7 +223,7 @@ class Theme
     void setTheme(std::size_t index);
 
     /// Set current theme by ID (deferred to next frame)
-    void setThemeById(const std::string& id);
+    void setThemeById(std::string_view id);
 
     /// Apply current theme colors to ImGui style
     void applyImGuiStyle() const;

--- a/tools/iwyu.ps1
+++ b/tools/iwyu.ps1
@@ -1,0 +1,75 @@
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('debug', 'relwithdebinfo')]
+    [string]$BuildType = 'debug',
+
+    [Parameter()]
+    [switch]$VerboseOutput,
+
+    [Parameter()]
+    [Nullable[int]]$Jobs,
+
+    [Parameter()]
+    [switch]$Fix,
+
+    [Parameter()]
+    [switch]$Report,
+
+    [Parameter(Position = 1, ValueFromRemainingArguments = $true)]
+    [string[]]$Files
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$scriptPath = Join-Path $scriptDir 'iwyu.sh'
+
+if (-not (Test-Path $scriptPath)) {
+    Write-Error "Missing script: $scriptPath"
+    exit 1
+}
+
+$gitBashPath = 'C:/Program Files/Git/bin/bash.exe'
+if (Test-Path $gitBashPath) {
+    $bashPath = $gitBashPath
+    $useGitBash = $true
+}
+else {
+    $bash = Get-Command bash -ErrorAction SilentlyContinue
+    if (-not $bash) {
+        Write-Error 'bash was not found in PATH. Install Git Bash/WSL and ensure bash is available.'
+        exit 1
+    }
+    $bashPath = $bash.Source
+    $useGitBash = $false
+}
+
+$scriptPathForBash = $scriptPath -replace '\\', '/'
+$args = @()
+if ($VerboseOutput) { $args += '-v' }
+if ($null -ne $Jobs -and $Jobs -gt 0) {
+    $args += '-j'
+    $args += "$Jobs"
+}
+if ($Fix) { $args += '-f' }
+if ($Report) { $args += '-r' }
+$args += $BuildType
+if ($Files) { $args += $Files }
+
+if ($useGitBash) {
+    & $bashPath $scriptPathForBash @args
+    exit $LASTEXITCODE
+}
+
+$projectRootForBash = ($projectRoot -replace '\\', '/')
+if ($projectRootForBash -match '^([A-Za-z]):/(.*)$') {
+    $projectRootForBash = "/mnt/$($Matches[1].ToLower())/$($Matches[2])"
+}
+
+$commandLine = "cd '$projectRootForBash' && ./tools/iwyu.sh"
+foreach ($arg in $args) {
+    $commandLine += " $arg"
+}
+
+& $bashPath -lc $commandLine
+exit $LASTEXITCODE

--- a/tools/iwyu.ps1
+++ b/tools/iwyu.ps1
@@ -23,6 +23,7 @@ $ErrorActionPreference = 'Stop'
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $scriptPath = Join-Path $scriptDir 'iwyu.sh'
+$projectRoot = Split-Path -Parent $scriptDir
 
 if (-not (Test-Path $scriptPath)) {
     Write-Error "Missing script: $scriptPath"
@@ -68,7 +69,9 @@ if ($projectRootForBash -match '^([A-Za-z]):/(.*)$') {
 
 $commandLine = "cd '$projectRootForBash' && ./tools/iwyu.sh"
 foreach ($arg in $args) {
-    $commandLine += " $arg"
+    # Single-quote each arg to prevent word-splitting and shell metacharacter expansion.
+    $escaped = $arg -replace "'", "'\"'\"'"
+    $commandLine += " '$escaped'"
 }
 
 & $bashPath -lc $commandLine


### PR DESCRIPTION
## Summary

Code quality modernization pass covering several independent improvements found during a codebase audit.

### Changes

**Bug fix**
- `AboutLayer::openUrl`: replaced `std::wstring(url.begin(), url.end())` (byte-widening, breaks non-ASCII URLs) with `MultiByteToWideChar(CP_UTF8, ...)` for correct UTF-8 → UTF-16 conversion

**API modernization**
- `Theme::setThemeById`: parameter changed from `const std::string&` to `std::string_view`
- `GPUModel` public methods: parameters changed from `const std::string&` to `std::string_view`
- `GPUModel` internal maps: added `TransparentStringHash` / `TransparentStringEqual` for heterogeneous lookup (avoids temporary `std::string` allocations on every lookup)

**Duplicate code elimination**
- `GpuSection`: extracted `normalizeToPercent()` and `renderUnavailableMetricsNote()` anonymous-namespace helpers, replacing 3 identical normalize loops and 2 identical note-building blocks
- `ChartWidgets.h`: added `initializeOrSmooth()` helper centralizing the init-or-smooth branch pattern used identically in every panel section

**Smoothing refactor** (uses new `initializeOrSmooth` helper)
- `MemorySection`, `NetworkSection`, `StorageSection`, `ProcessDetailsPanel`, `GpuSection` — consolidated per-field smooth calls

**Include hygiene**
- `Theme.cpp`: added direct `#include <imgui.h>` for ImGui symbols used in `applyImGuiStyle()`
- `WindowsGPUProbe.cpp`: added direct includes for types used from headers

**Tooling**
- `tools/iwyu.ps1`: new Windows wrapper script for `include-what-you-use` (delegates to `iwyu.sh` via Git Bash; requires IWYU binary installed separately)
