### PR TITLE
tooling: CMake 3.29, UserConfig path validation tests, PR auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,77 @@
+# PR auto-labeler configuration for actions/labeler
+# Maps file path globs to labels. Labels are applied when any matching file is changed.
+# See: https://github.com/actions/labeler
+
+# ── Platform ──────────────────────────────────────────────────────────────────
+
+"linux":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/Platform/Linux/**"
+      - "tests/Platform/Linux/**"
+
+"windows":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/Platform/Windows/**"
+      - "tests/Platform/Windows/**"
+
+"Platform":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/Platform/**"
+      - "tests/Platform/**"
+
+# ── Layers ────────────────────────────────────────────────────────────────────
+
+"testing":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "tests/**"
+      - "**/test_*.cpp"
+      - "benchmarks/**"
+
+"documentation":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/*.md"
+      - "docs/**"
+      - "assets/themes/README.md"
+
+"ci":
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/codeql/**"
+      - ".github/labeler.yml"
+      - "CMakePresets.json"
+
+"tooling":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "tools/**"
+      - ".clang-format"
+      - ".clang-tidy"
+      - ".pre-commit-config.yaml"
+      - "CMakeLists.txt"
+      - "cmake/**"
+
+"dependencies":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "CMakeLists.txt"
+      - ".github/dependabot.yml"
+
+"security":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "SECURITY.md"
+      - ".github/codeql/**"
+
+"release":
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".github/workflows/release.yml"
+      - "assets/app.manifest.in"
+      - "assets/tasksmack.rc.in"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,20 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 3.28)
+# Minimum CMake version rationale:
+#   3.25: FetchContent_Declare(SYSTEM) keyword (suppresses warnings from third-party headers)
+#   3.25: CMakePresets.json schema version 6 (workflowPresets, include directives)
+#   3.24: FETCHCONTENT_TRY_FIND_PACKAGE_MODE variable
+#   3.29: Declared as minimum in CMakePresets.json (cmakeMinimumRequired field)
+cmake_minimum_required(VERSION 3.29)
 
 # Enable IPO policy explicitly (avoids third-party warnings when targets set IPO properties)
 if(POLICY CMP0069)

--- a/src/App/UserConfig.cpp
+++ b/src/App/UserConfig.cpp
@@ -86,8 +86,7 @@ constexpr int WINDOW_POS_ABS_MAX = 100'000;
 [[nodiscard]] auto sanitizeConfigDir(const std::filesystem::path& candidate, const std::filesystem::path& fallback) -> std::filesystem::path
 {
     auto normalized = candidate.lexically_normal();
-    const bool hasTraversal = std::ranges::any_of(normalized, [](const auto& part) { return part == ".."; });
-    if (!normalized.is_absolute() || hasTraversal)
+    if (!UserConfigHelpers::isValidConfigDir(normalized))
     {
         spdlog::warn("Ignoring unsafe config directory {}; using {}", normalized.string(), fallback.string());
         return fallback;

--- a/src/App/UserConfigHelpers.h
+++ b/src/App/UserConfigHelpers.h
@@ -3,6 +3,7 @@
 #include "Domain/Numeric.h"
 
 #include <algorithm>
+#include <filesystem>
 #include <functional>
 
 #include <toml++/toml.hpp>
@@ -66,6 +67,24 @@ inline void loadAndNarrowIntWithClamp(
         const int narrowed = Domain::Numeric::narrowOr<int>(*val, defaultValue);
         destination = std::clamp(narrowed, minVal, maxVal);
     }
+}
+
+/// Validates a candidate config directory path derived from user/environment input.
+/// Returns true if the path is safe to use as a config directory:
+///   - must be absolute after lexical normalization
+///   - must not contain any ".." traversal components after normalization
+///
+/// This is a purely lexical check (no filesystem access). Callers that need
+/// symlink-safe validation should resolve the path with weakly_canonical() first
+/// and then call this function on the result.
+[[nodiscard]] inline auto isValidConfigDir(const std::filesystem::path& candidate) -> bool
+{
+    const auto normalized = candidate.lexically_normal();
+    if (!normalized.is_absolute())
+    {
+        return false;
+    }
+    return !std::ranges::any_of(normalized, [](const auto& part) { return part == ".."; });
 }
 
 } // namespace App::UserConfigHelpers

--- a/tests/App/test_UserConfigHelpers.cpp
+++ b/tests/App/test_UserConfigHelpers.cpp
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
+
 #include <toml++/toml.hpp>
 
 namespace App
@@ -83,12 +85,15 @@ TEST(UserConfigHelpersTest, LoadAndNarrowIntWithClampUsesDefaultWhenMissing)
 
 TEST(UserConfigHelpersTest, IsValidConfigDirAcceptsAbsolutePath)
 {
-    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("/home/user/.config/tasksmack")));
+    // Build a platform-native absolute path: C:\home\user\... on Windows, /home/user/... on POSIX.
+    const auto absPath = std::filesystem::current_path().root_path() / "home" / "user" / ".config" / "tasksmack";
+    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(absPath));
 }
 
 TEST(UserConfigHelpersTest, IsValidConfigDirAcceptsAbsolutePathWithoutTraversal)
 {
-    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("/tmp/tasksmack")));
+    const auto absPath = std::filesystem::current_path().root_path() / "tmp" / "tasksmack";
+    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(absPath));
 }
 
 TEST(UserConfigHelpersTest, IsValidConfigDirRejectsRelativePath)
@@ -104,11 +109,13 @@ TEST(UserConfigHelpersTest, IsValidConfigDirRejectsDotDotTraversal)
 
 TEST(UserConfigHelpersTest, IsValidConfigDirNormalizesAbsoluteTraversal)
 {
-    // An absolute path with ".." is lexically normalized (e.g. /home/user/../../etc/passwd → /etc/passwd).
-    // The normalized form is still an absolute path with no ".." components, so it is accepted.
-    // Restricting WHICH absolute paths are allowed is a caller responsibility (e.g. checking the path
-    // is under the expected config root).
-    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("/home/user/../../etc/passwd")));
+    // An absolute path with ".." that normalizes away all traversal components is accepted.
+    // e.g. on POSIX: root/"home"/"user"/".."/../"etc" → /etc (absolute, no "..").
+    // Restricting WHICH absolute paths are allowed is a caller responsibility (e.g. checking
+    // the resolved path is under the expected config root).
+    const auto root = std::filesystem::current_path().root_path();
+    const auto pathWithTraversal = root / "home" / "user" / ".." / ".." / "etc";
+    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(pathWithTraversal));
 }
 
 TEST(UserConfigHelpersTest, IsValidConfigDirRejectsBareTraversal)
@@ -118,7 +125,8 @@ TEST(UserConfigHelpersTest, IsValidConfigDirRejectsBareTraversal)
 
 TEST(UserConfigHelpersTest, IsValidConfigDirAcceptsRootPath)
 {
-    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("/")));
+    // root_path() returns "/" on POSIX and e.g. "C:\" on Windows — always absolute.
+    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::current_path().root_path()));
 }
 
 TEST(UserConfigHelpersTest, IsValidConfigDirRejectsEmptyPath)

--- a/tests/App/test_UserConfigHelpers.cpp
+++ b/tests/App/test_UserConfigHelpers.cpp
@@ -79,6 +79,54 @@ TEST(UserConfigHelpersTest, LoadAndNarrowIntWithClampUsesDefaultWhenMissing)
     EXPECT_EQ(dst, 999);
 }
 
+// ========== isValidConfigDir ==========
+
+TEST(UserConfigHelpersTest, IsValidConfigDirAcceptsAbsolutePath)
+{
+    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("/home/user/.config/tasksmack")));
+}
+
+TEST(UserConfigHelpersTest, IsValidConfigDirAcceptsAbsolutePathWithoutTraversal)
+{
+    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("/tmp/tasksmack")));
+}
+
+TEST(UserConfigHelpersTest, IsValidConfigDirRejectsRelativePath)
+{
+    EXPECT_FALSE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("relative/path")));
+}
+
+TEST(UserConfigHelpersTest, IsValidConfigDirRejectsDotDotTraversal)
+{
+    // A relative path with traversal components is rejected because it is not absolute.
+    EXPECT_FALSE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("../../etc/passwd")));
+}
+
+TEST(UserConfigHelpersTest, IsValidConfigDirNormalizesAbsoluteTraversal)
+{
+    // An absolute path with ".." is lexically normalized (e.g. /home/user/../../etc/passwd → /etc/passwd).
+    // The normalized form is still an absolute path with no ".." components, so it is accepted.
+    // Restricting WHICH absolute paths are allowed is a caller responsibility (e.g. checking the path
+    // is under the expected config root).
+    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("/home/user/../../etc/passwd")));
+}
+
+TEST(UserConfigHelpersTest, IsValidConfigDirRejectsBareTraversal)
+{
+    EXPECT_FALSE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("../../etc/shadow")));
+}
+
+TEST(UserConfigHelpersTest, IsValidConfigDirAcceptsRootPath)
+{
+    EXPECT_TRUE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("/")));
+}
+
+TEST(UserConfigHelpersTest, IsValidConfigDirRejectsEmptyPath)
+{
+    // Empty path is not absolute.
+    EXPECT_FALSE(App::UserConfigHelpers::isValidConfigDir(std::filesystem::path("")));
+}
+
 } // namespace
 } // namespace App
 


### PR DESCRIPTION
Closes #108, #399, #90

## Changes

### #108 — Document CMake 3.29 minimum version requirement
- Bumped `cmake_minimum_required` from 3.28 → 3.29 to align with the `cmakeMinimumRequired` field already declared in `CMakePresets.json`
- Added inline comment documenting which features drive each version requirement

### #399 — Harden `UserConfig` path validation (CodeQL cpp/path-injection)
- Extracted `isValidConfigDir()` from the anonymous-namespace `sanitizeConfigDir()` in `UserConfig.cpp` into the testable `UserConfigHelpers.h` header
- `sanitizeConfigDir()` now delegates to `isValidConfigDir()` — no behavioural change, validation logic is now unit-testable
- Added 7 unit tests covering: accepted absolute paths, rejected relative paths, rejected bare traversal (`../../etc`), and the lexical-normalization behaviour of absolute paths containing `...`

### #90 — PR auto-labeling
- Added `.github/labeler.yml` mapping file-path globs to existing repo labels (`linux`, `windows`, `Platform`, `testing`, `documentation`, `ci`, `tooling`, `dependencies`, `security`, `release`)
- Added `.github/workflows/pr-labeler.yml` using `actions/labeler@v5` on `pull_request_target` with minimal permissions (`contents: read`, `pull-requests: write`)