### PR TITLE
fix: distinct read/write colors on I/O chart tab (#367)

### DIFF
--- a/assets/themes/arctic-fire-light.toml
+++ b/assets/themes/arctic-fire-light.toml
@@ -68,10 +68,12 @@ idle = "#B0B0B0"       # Gray - idle kernel thread (I)
 [charts]
 cpu = "#1976D2"       # Blue - CPU usage line
 memory = "#388E3C"    # Green - memory usage line
-io = "#D32F2F"        # Red - I/O usage line
+io = "#D32F2F"        # Red - I/O read usage line
+io_write = "#7C64C8"        # Aurora Purple - I/O write usage line
 cpu_fill = "#1976D24D"       # Blue with 30% alpha - CPU fill
 memory_fill = "#388E3C4D"    # Green with 30% alpha - memory fill
-io_fill = "#D32F2F4D"        # Red with 30% alpha - I/O fill
+io_fill = "#D32F2F4D"        # Red with 30% alpha - I/O read fill
+io_write_fill = "#7C64C84D"   # Aurora Purple with 30% alpha - I/O write fill
 peak_line = "#F57C00B3"      # Orange with 70% alpha - peak reference line
 
 # =============================================================================

--- a/assets/themes/arctic-fire.toml
+++ b/assets/themes/arctic-fire.toml
@@ -70,10 +70,12 @@ idle = "#808080"       # Gray - idle kernel thread (I)
 [charts]
 cpu = "#42A5F5"       # Blue - CPU usage line
 memory = "#00E676"    # Emerald - memory usage line
-io = "#FF7043"        # Orange - I/O usage line
+io = "#FF7043"        # Orange - I/O read usage line
+io_write = "#AB47BC"        # Purple - I/O write usage line
 cpu_fill = "#42A5F54D"       # Blue with 30% alpha - CPU fill
 memory_fill = "#00E6764D"    # Emerald with 30% alpha - memory fill
-io_fill = "#FF70434D"        # Orange with 30% alpha - I/O fill
+io_fill = "#FF70434D"        # Orange with 30% alpha - I/O read fill
+io_write_fill = "#AB47BC4D"   # Purple with 30% alpha - I/O write fill
 peak_line = "#FFD54FB3"      # Gold with 70% alpha - peak reference line
 
 # =============================================================================

--- a/assets/themes/cyberpunk-light.toml
+++ b/assets/themes/cyberpunk-light.toml
@@ -68,10 +68,12 @@ idle = "#999999"       # Light gray - idle kernel thread (I)
 [charts]
 cpu = "#1976D2"       # Blue - CPU usage line
 memory = "#388E3C"    # Green - memory usage line
-io = "#D32F2F"        # Red - I/O usage line
+io = "#D32F2F"        # Red - I/O read usage line
+io_write = "#815CFF"        # Vivid Violet - I/O write usage line
 cpu_fill = "#1976D24D"       # Blue with 30% alpha - CPU fill
 memory_fill = "#388E3C4D"    # Green with 30% alpha - memory fill
-io_fill = "#D32F2F4D"        # Red with 30% alpha - I/O fill
+io_fill = "#D32F2F4D"        # Red with 30% alpha - I/O read fill
+io_write_fill = "#815CFF4D"   # Vivid Violet with 30% alpha - I/O write fill
 peak_line = "#F57C00B3"      # Orange with 70% alpha - peak reference line
 
 # =============================================================================

--- a/assets/themes/cyberpunk.toml
+++ b/assets/themes/cyberpunk.toml
@@ -70,10 +70,12 @@ idle = "#666680"       # Muted purple-gray - idle kernel thread (I)
 [charts]
 cpu = "#00E5FF"       # Electric Blue - CPU usage line
 memory = "#76FF03"    # Neon Green - memory usage line
-io = "#FF4081"        # Neon Pink - I/O usage line
+io = "#FF4081"        # Neon Pink - I/O read usage line
+io_write = "#7C4DFF"        # Violet - I/O write usage line
 cpu_fill = "#00E5FF4D"       # Electric Blue with 30% alpha - CPU fill
 memory_fill = "#76FF034D"    # Neon Green with 30% alpha - memory fill
-io_fill = "#FF40814D"        # Neon Pink with 30% alpha - I/O fill
+io_fill = "#FF40814D"        # Neon Pink with 30% alpha - I/O read fill
+io_write_fill = "#7C4DFF4D"   # Violet with 30% alpha - I/O write fill
 peak_line = "#FFD600B3"      # Gold with 70% alpha - peak reference line
 
 # =============================================================================

--- a/assets/themes/monochrome-light.toml
+++ b/assets/themes/monochrome-light.toml
@@ -69,10 +69,12 @@ idle = "#A5D6A7"       # I - Very light green - idle kernel thread
 [charts]
 cpu = "#2E7D32"       # Dark green - CPU usage line
 memory = "#4CAF50"    # Medium green - memory usage line
-io = "#388E3C"        # Medium-dark green - I/O usage line
+io = "#388E3C"        # Medium-dark green - I/O read usage line
+io_write = "#8BD88B"        # Very light green - I/O write usage line
 cpu_fill = "#2E7D324D"       # Dark green with 30% alpha - CPU fill
 memory_fill = "#4CAF504D"    # Medium green with 30% alpha - memory fill
-io_fill = "#388E3C4D"        # Medium-dark green with 30% alpha - I/O fill
+io_fill = "#388E3C4D"        # Medium-dark green with 30% alpha - I/O read fill
+io_write_fill = "#8BD88B4D"   # Very light green with 30% alpha - I/O write fill
 peak_line = "#4CAF50B3"      # Medium green with 70% alpha - peak reference line
 
 # =============================================================================

--- a/assets/themes/monochrome.toml
+++ b/assets/themes/monochrome.toml
@@ -69,10 +69,12 @@ idle = "#1B5E20"       # I - Very dim green - idle kernel thread
 [charts]
 cpu = "#81C784"       # Bright green - CPU usage line
 memory = "#4CAF50"    # Medium green - memory usage line
-io = "#66BB6A"        # Light green - I/O usage line
+io = "#66BB6A"        # Light green - I/O read usage line
+io_write = "#1B5E20"        # Very dark green - I/O write usage line
 cpu_fill = "#81C7844D"       # Bright green with 30% alpha - CPU fill
 memory_fill = "#4CAF504D"    # Medium green with 30% alpha - memory fill
-io_fill = "#66BB6A4D"        # Light green with 30% alpha - I/O fill
+io_fill = "#66BB6A4D"        # Light green with 30% alpha - I/O read fill
+io_write_fill = "#1B5E204D"   # Very dark green with 30% alpha - I/O write fill
 peak_line = "#9CCC65B3"      # Yellow-green with 70% alpha - peak reference line
 
 # =============================================================================

--- a/assets/themes/ubuntu-dark.toml
+++ b/assets/themes/ubuntu-dark.toml
@@ -69,10 +69,12 @@ idle = "#808080"       # Gray - idle kernel thread (I)
 [charts]
 cpu = "#3584E4"       # Blue - CPU usage line
 memory = "#33D17A"    # Light Green - memory usage line
-io = "#ED333B"        # Light Red - I/O usage line
+io = "#ED333B"        # Light Red - I/O read usage line
+io_write = "#FFBE00"        # Yellow - I/O write usage line
 cpu_fill = "#3584E44D"       # Blue with 30% alpha - CPU fill
 memory_fill = "#33D17A4D"    # Light Green with 30% alpha - memory fill
-io_fill = "#ED333B4D"        # Light Red with 30% alpha - I/O fill
+io_fill = "#ED333B4D"        # Light Red with 30% alpha - I/O read fill
+io_write_fill = "#FFBE004D"   # Yellow with 30% alpha - I/O write fill
 peak_line = "#F5C211B3"      # Gold with 70% alpha - peak reference line
 
 # =============================================================================

--- a/assets/themes/ubuntu-light.toml
+++ b/assets/themes/ubuntu-light.toml
@@ -69,10 +69,12 @@ idle = "#A0A0A0"       # Gray - idle kernel thread (I)
 [charts]
 cpu = "#3584E4"       # Blue - CPU usage line
 memory = "#26A269"    # Green - memory usage line
-io = "#C01C28"        # Red - I/O usage line
+io = "#C01C28"        # Red - I/O read usage line
+io_write = "#FFC533"        # Yellow - I/O write usage line
 cpu_fill = "#3584E44D"       # Blue with 30% alpha - CPU fill
 memory_fill = "#26A2694D"    # Green with 30% alpha - memory fill
-io_fill = "#C01C284D"        # Red with 30% alpha - I/O fill
+io_fill = "#C01C284D"        # Red with 30% alpha - I/O read fill
+io_write_fill = "#FFC5334D"   # Yellow with 30% alpha - I/O write fill
 peak_line = "#E5A50AB3"      # Gold with 70% alpha - peak reference line
 
 # =============================================================================

--- a/assets/themes/windows-dark.toml
+++ b/assets/themes/windows-dark.toml
@@ -69,10 +69,12 @@ idle = "#808080"       # Gray - idle kernel thread (I)
 [charts]
 cpu = "#0078D4"       # Windows Blue - CPU usage line
 memory = "#10893E"    # Green - memory usage line
-io = "#E74856"        # Red - I/O usage line
+io = "#E74856"        # Red - I/O read usage line
+io_write = "#F7630C"        # Orange - I/O write usage line
 cpu_fill = "#0078D44D"       # Windows Blue with 30% alpha - CPU fill
 memory_fill = "#10893E4D"    # Green with 30% alpha - memory fill
-io_fill = "#E748564D"        # Red with 30% alpha - I/O fill
+io_fill = "#E748564D"        # Red with 30% alpha - I/O read fill
+io_write_fill = "#F7630C4D"   # Orange with 30% alpha - I/O write fill
 peak_line = "#FFB900B3"      # Gold with 70% alpha - peak reference line
 
 # =============================================================================

--- a/assets/themes/windows-light.toml
+++ b/assets/themes/windows-light.toml
@@ -69,10 +69,12 @@ idle = "#A0A0A0"       # Gray - idle kernel thread (I)
 [charts]
 cpu = "#0078D4"       # Windows Blue - CPU usage line
 memory = "#107C10"    # Green - memory usage line
-io = "#E74856"        # Red - I/O usage line
+io = "#E74856"        # Red - I/O read usage line
+io_write = "#FA7A1C"        # Orange - I/O write usage line
 cpu_fill = "#0078D44D"       # Windows Blue with 30% alpha - CPU fill
 memory_fill = "#107C104D"    # Green with 30% alpha - memory fill
-io_fill = "#E748564D"        # Red with 30% alpha - I/O fill
+io_fill = "#E748564D"        # Red with 30% alpha - I/O read fill
+io_write_fill = "#FA7A1C4D"   # Orange with 30% alpha - I/O write fill
 peak_line = "#F7630CB3"      # Orange with 70% alpha - peak reference line
 
 # =============================================================================

--- a/src/App/Panels/ProcessDetailsPanel.cpp
+++ b/src/App/Panels/ProcessDetailsPanel.cpp
@@ -1031,7 +1031,7 @@ void ProcessDetailsPanel::renderIoStats(const Domain::ProcessSnapshot& proc)
     const NowBar writeBar{.valueText = UI::Format::formatBytesPerSecWithUnit(m_SmoothedUsage.ioWriteBytesPerSec, writeUnit),
                           .label = "Disk Write",
                           .value01 = (writeMax > 0.0) ? std::clamp(m_SmoothedUsage.ioWriteBytesPerSec / writeMax, 0.0, 1.0) : 0.0,
-                          .color = theme.accentColor(1)};
+                          .color = theme.scheme().chartIoWrite};
 
     auto plot = [&]()
     {
@@ -1046,7 +1046,8 @@ void ProcessDetailsPanel::renderIoStats(const Domain::ProcessSnapshot& proc)
             const int plotCount = UI::Format::checkedCount(alignedCount);
             plotLineWithFill("Read", timeData.data(), readData.data(), plotCount, theme.scheme().chartIo, theme.scheme().chartIoFill);
 
-            plotLineWithFill("Write", timeData.data(), writeData.data(), plotCount, theme.accentColor(1));
+            plotLineWithFill(
+                "Write", timeData.data(), writeData.data(), plotCount, theme.scheme().chartIoWrite, theme.scheme().chartIoWriteFill);
 
             if (ImPlot::IsPlotHovered())
             {
@@ -1059,7 +1060,8 @@ void ProcessDetailsPanel::renderIoStats(const Domain::ProcessSnapshot& proc)
                         const auto ageText = formatAgeSeconds(timeData[*idxVal]);
                         ImGui::TextUnformatted(ageText.c_str());
                         ImGui::TextColored(theme.scheme().chartIo, "Read: %s", UI::Format::formatBytesPerSec(readData[*idxVal]).c_str());
-                        ImGui::TextColored(theme.accentColor(1), "Write: %s", UI::Format::formatBytesPerSec(writeData[*idxVal]).c_str());
+                        ImGui::TextColored(
+                            theme.scheme().chartIoWrite, "Write: %s", UI::Format::formatBytesPerSec(writeData[*idxVal]).c_str());
                         ImGui::EndTooltip();
                     }
                 }

--- a/src/UI/Theme.cpp
+++ b/src/UI/Theme.cpp
@@ -73,11 +73,13 @@ void Theme::loadDefaultFallbackTheme()
     fallback.chartCpu = blue;
     fallback.chartMemory = green;
     fallback.chartIo = orange;
+    fallback.chartIoWrite = red;
 
     // Chart fill colors (semi-transparent versions)
     fallback.chartCpuFill = ImVec4(0.26F, 0.59F, 0.98F, 0.3F);
     fallback.chartMemoryFill = ImVec4(0.0F, 1.0F, 0.0F, 0.3F);
     fallback.chartIoFill = ImVec4(1.0F, 0.5F, 0.0F, 0.3F);
+    fallback.chartIoWriteFill = ImVec4(1.0F, 0.0F, 0.0F, 0.3F);
 
     fallback.cpuUser = blue;
     fallback.cpuSystem = orange;

--- a/src/UI/Theme.h
+++ b/src/UI/Theme.h
@@ -69,14 +69,16 @@ struct ColorScheme
     ImVec4 statusIdle{};      // I - Idle kernel thread (gray)
 
     // Chart line colors (for specific metrics)
-    ImVec4 chartCpu{};    // CPU usage line
-    ImVec4 chartMemory{}; // Memory usage line
-    ImVec4 chartIo{};     // I/O usage line
+    ImVec4 chartCpu{};     // CPU usage line
+    ImVec4 chartMemory{};  // Memory usage line
+    ImVec4 chartIo{};      // I/O read usage line
+    ImVec4 chartIoWrite{}; // I/O write usage line (distinct from read)
 
     // Chart fill colors (semi-transparent versions for shaded plots)
-    ImVec4 chartCpuFill{};    // CPU usage fill
-    ImVec4 chartMemoryFill{}; // Memory usage fill
-    ImVec4 chartIoFill{};     // I/O usage fill
+    ImVec4 chartCpuFill{};     // CPU usage fill
+    ImVec4 chartMemoryFill{};  // Memory usage fill
+    ImVec4 chartIoFill{};      // I/O read usage fill
+    ImVec4 chartIoWriteFill{}; // I/O write usage fill
 
     // CPU breakdown colors
     ImVec4 cpuUser{};   // User CPU time

--- a/src/UI/ThemeLoader.cpp
+++ b/src/UI/ThemeLoader.cpp
@@ -289,11 +289,13 @@ auto ThemeLoader::loadTheme(const std::filesystem::path& path) -> std::optional<
         scheme.chartCpu = getColor(tbl, "charts.cpu");
         scheme.chartMemory = getColor(tbl, "charts.memory");
         scheme.chartIo = getColor(tbl, "charts.io");
+        scheme.chartIoWrite = getColor(tbl, "charts.io_write", scheme.chartMemory);
 
         // Chart fill colors (with fallback to line colors for backward compatibility)
         scheme.chartCpuFill = getColor(tbl, "charts.cpu_fill", scheme.chartCpu);
         scheme.chartMemoryFill = getColor(tbl, "charts.memory_fill", scheme.chartMemory);
         scheme.chartIoFill = getColor(tbl, "charts.io_fill", scheme.chartIo);
+        scheme.chartIoWriteFill = getColor(tbl, "charts.io_write_fill", scheme.chartIoWrite);
 
         // CPU breakdown
         scheme.cpuUser = getColor(tbl, "cpu_breakdown.user");

--- a/tests/UI/test_ThemeLoader.cpp
+++ b/tests/UI/test_ThemeLoader.cpp
@@ -401,6 +401,7 @@ idle = "#808080"
 cpu = "#0078D4"
 memory = "#10893E"
 io = "#E74856"
+io_write = "#F7630C"
 
 [cpu_breakdown]
 user = "#0078D4"
@@ -520,6 +521,16 @@ modal_window_dim_background = "#0000004D"
     expectColorNear(theme->progressLow, ImVec4(0.0F, 1.0F, 0.0F, 1.0F));    // #00FF00
     expectColorNear(theme->progressMedium, ImVec4(1.0F, 1.0F, 0.0F, 1.0F)); // #FFFF00
     expectColorNear(theme->progressHigh, ImVec4(1.0F, 0.0F, 0.0F, 1.0F));   // #FF0000
+
+    // Check I/O chart colors (read vs write must be distinct)
+    // #E74856 = (231/255, 72/255, 86/255, 1.0)
+    expectColorNear(theme->chartIo, ImVec4(0xE7 / 255.0F, 0x48 / 255.0F, 0x56 / 255.0F, 1.0F));
+    // #F7630C = (247/255, 99/255, 12/255, 1.0)
+    expectColorNear(theme->chartIoWrite, ImVec4(0xF7 / 255.0F, 0x63 / 255.0F, 0x0C / 255.0F, 1.0F));
+    // Read and write must not be the same color
+    EXPECT_FALSE(theme->chartIo.x == theme->chartIoWrite.x && theme->chartIo.y == theme->chartIoWrite.y &&
+                 theme->chartIo.z == theme->chartIoWrite.z)
+        << "I/O read and write chart colors must be visually distinct";
 }
 
 TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_NonExistentFile)
@@ -689,6 +700,160 @@ modal_window_dim_background = "#0000004D"
 
     // Verify accent colors from the array
     expectColorNear(theme->accents[0], ImVec4(0x00 / 255.0F, 0x78 / 255.0F, 0xD4 / 255.0F, 1.0F)); // Windows Blue
+}
+
+// ========== I/O Write Color Tests ==========
+
+TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_IoWriteColor_FallsBackToMemoryWhenAbsent)
+{
+    // When io_write is not specified, chartIoWrite should fall back to chartMemory
+    createThemeFile("no-io-write.toml", R"(
+[meta]
+name = "No IO Write"
+
+[accents]
+colors = ["#0078D4", "#E74856", "#10893E", "#8E8CD8", "#F7630C", "#00B7C3", "#FFB900", "#E3008C"]
+
+[progress]
+low = "#10893E"
+medium = "#FFB900"
+high = "#E74856"
+
+[semantic]
+text_primary = "#FFFFFF"
+text_disabled = "#808080"
+text_muted = "#CCCCCC"
+text_error = "#FF0000"
+text_warning = "#FFA500"
+text_success = "#00FF00"
+text_info = "#00FFFF"
+
+[status]
+running = "#00FF00"
+sleeping = "#0000FF"
+disk_sleep = "#FFA500"
+zombie = "#FF0000"
+stopped = "#FF00FF"
+idle = "#808080"
+
+[charts]
+cpu = "#0078D4"
+memory = "#10893E"
+io = "#E74856"
+# io_write intentionally absent — should fall back to chartMemory
+
+[cpu_breakdown]
+user = "#0078D4"
+system = "#E74856"
+iowait = "#FFB900"
+idle = "#808080"
+
+[charts.gpu]
+utilization = "#0078D4"
+memory = "#10893E"
+temperature = "#E74856"
+power = "#FFB900"
+encoder = "#00B7C3"
+decoder = "#8E8CD8"
+clock = "#E3008C"
+fan = "#808080"
+
+[buttons.success]
+normal = "#10893E"
+hovered = "#2AA84E"
+active = "#0A6B2E"
+
+[ui.window]
+background = "#1E1E1E"
+child_background = "#252526"
+popup_background = "#2D2D30"
+border = "#3F3F46"
+
+[ui.frame]
+background = "#333337"
+background_hovered = "#3E3E42"
+background_active = "#0078D4"
+
+[ui.title]
+background = "#2D2D30"
+background_active = "#0078D4"
+background_collapsed = "#3F3F46"
+
+[ui.bars]
+menu = "#2D2D30"
+status = "#2D2D30"
+
+[ui.scrollbar]
+background = "#1E1E1E"
+grab = "#5A5A5A"
+grab_hovered = "#808080"
+grab_active = "#0078D4"
+
+[ui.controls]
+check_mark = "#FFFFFF"
+slider_grab = "#5A5A5A"
+slider_grab_active = "#0078D4"
+
+[ui.button]
+normal = "#333337"
+hovered = "#3E3E42"
+active = "#0078D4"
+
+[ui.header]
+normal = "#333337"
+hovered = "#3E3E42"
+active = "#0078D4"
+
+[ui.separator]
+normal = "#3F3F46"
+hovered = "#5A5A5A"
+active = "#0078D4"
+
+[ui.resize_grip]
+normal = "#3F3F46"
+hovered = "#5A5A5A"
+active = "#0078D4"
+
+[ui.tab]
+normal = "#2D2D30"
+hovered = "#3E3E42"
+active = "#0078D4"
+active_overline = "#FFFFFF"
+unfocused = "#252526"
+unfocused_active = "#3F3F46"
+unfocused_active_overline = "#808080"
+
+[ui.docking]
+preview = "#0078D480"
+empty_background = "#1E1E1E"
+
+[ui.plot]
+lines = "#0078D4"
+lines_hovered = "#60CDFF"
+histogram = "#10893E"
+histogram_hovered = "#6CCB5F"
+
+[ui.table]
+header_background = "#333337"
+border_strong = "#3F3F46"
+border_light = "#2D2D30"
+row_background = "#00000000"
+row_background_alt = "#FFFFFF0D"
+
+[ui.misc]
+text_selected_background = "#0078D480"
+drag_drop_target = "#FFB900"
+nav_highlight = "#0078D4"
+nav_windowing_highlight = "#FFFFFFB3"
+nav_windowing_dim_background = "#0000004D"
+modal_window_dim_background = "#0000004D"
+)");
+
+    auto theme = ThemeLoader::loadTheme(m_TempDir / "no-io-write.toml");
+    ASSERT_TRUE(theme.has_value());
+
+    // chartIoWrite falls back to chartMemory (#10893E) when io_write is absent
+    expectColorNear(theme->chartIoWrite, theme->chartMemory);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Fixes #367.

The I/O tab's read and write series used the same color in **arctic-fire** (both `#FF7043`) and **windows** themes (both `#E74856`) because write was using `accentColor(1)`, which happens to equal `chartIo` in those themes. Write also had no fill color (inconsistent with read).

## Changes

| File | Change |
|------|--------|
| `src/UI/Theme.h` | Add `chartIoWrite` / `chartIoWriteFill` to `ColorScheme` |
| `src/UI/ThemeLoader.cpp` | Load `charts.io_write` / `charts.io_write_fill` with backward-compatible fallback to `chartMemory` |
| All 10 theme TOMLs | Add `io_write` and `io_write_fill` entries — perceptually distinct from `io` read color |
| `src/App/Panels/ProcessDetailsPanel.cpp` | Use `chartIoWrite` / `chartIoWriteFill` for write NowBar, chart line, fill, and tooltip |
| `tests/UI/test_ThemeLoader.cpp` | Assert `chartIoWrite` loads correctly and is distinct from `chartIo`; assert fallback to `chartMemory` when key absent |

## Test Coverage

- `LoadTheme_ValidFile`: asserts explicit `io_write` color parses to correct value and differs from `io` read color
- `LoadTheme_IoWriteColor_FallsBackToMemoryWhenAbsent`: asserts backward-compatible fallback when `io_write` key is absent
- Full suite: 772/772 passing