### PR TITLE
feat: per-disk I/O charts in StorageSection (#366)

### DIFF
--- a/src/App/Panels/StorageSection.cpp
+++ b/src/App/Panels/StorageSection.cpp
@@ -1,5 +1,6 @@
 #include "StorageSection.h"
 
+#include "Domain/StorageModel.h"
 #include "UI/ChartWidgets.h"
 #include "UI/Format.h"
 #include "UI/IconsFontAwesome6.h"
@@ -9,9 +10,12 @@
 #include <implot.h>
 
 #include <algorithm>
+#include <cfloat>
 #include <chrono>
 #include <cstddef>
+#include <format>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace App::StorageSection
@@ -35,6 +39,76 @@ using UI::Widgets::X_AXIS_FLAGS_DEFAULT;
 using UI::Widgets::Y_AXIS_FLAGS_DEFAULT;
 
 constexpr size_t STORAGE_NOW_BAR_COLUMNS = 2; // Read, Write
+
+/// Render a single disk cell (label + read/write NowBars + chart).
+void renderDiskCell(std::string_view deviceName,
+                    const std::vector<float>& timeData,
+                    const std::vector<float>& readData,
+                    const std::vector<float>& writeData,
+                    double smoothedRead,
+                    double smoothedWrite,
+                    const UI::Widgets::TimeAxisConfig& axisConfig,
+                    const UI::Theme& theme)
+{
+    const double readMax = std::max({readData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(readData)), smoothedRead, 1.0});
+    const double writeMax =
+        std::max({writeData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(writeData)), smoothedWrite, 1.0});
+
+    const NowBar readBar{.valueText = UI::Format::formatBytesPerSec(smoothedRead),
+                         .label = "Read",
+                         .value01 = std::clamp(smoothedRead / readMax, 0.0, 1.0),
+                         .color = theme.scheme().chartIo};
+    const NowBar writeBar{.valueText = UI::Format::formatBytesPerSec(smoothedWrite),
+                          .label = "Write",
+                          .value01 = std::clamp(smoothedWrite / writeMax, 0.0, 1.0),
+                          .color = theme.scheme().chartIoWrite};
+
+    const std::string plotId = std::format("##DiskPlot_{}", deviceName);
+    const std::string layoutId = std::format("DiskLayout_{}", deviceName);
+
+    auto diskPlotFn = [&]()
+    {
+        const UI::Widgets::PlotFontGuard fontGuard;
+        if (ImPlot::BeginPlot(plotId.c_str(), ImVec2(-1, HISTORY_PLOT_HEIGHT_DEFAULT), ImPlotFlags_NoMenus))
+        {
+            UI::Widgets::setupLegendDefault();
+            ImPlot::SetupAxes("Time (s)", nullptr, X_AXIS_FLAGS_DEFAULT, ImPlotAxisFlags_AutoFit | Y_AXIS_FLAGS_DEFAULT);
+            ImPlot::SetupAxisFormat(ImAxis_Y1, formatAxisBytesPerSec);
+            ImPlot::SetupAxisLimits(ImAxis_X1, axisConfig.xMin, axisConfig.xMax, ImPlotCond_Always);
+
+            const int count = UI::Format::checkedCount(timeData.size());
+            plotLineWithFill("Read", timeData.data(), readData.data(), count, theme.scheme().chartIo, theme.scheme().chartIoFill);
+            plotLineWithFill(
+                "Write", timeData.data(), writeData.data(), count, theme.scheme().chartIoWrite, theme.scheme().chartIoWriteFill);
+
+            if (ImPlot::IsPlotHovered() && !timeData.empty())
+            {
+                const ImPlotPoint mouse = ImPlot::GetPlotMousePos();
+                if (const auto idxVal = hoveredIndexFromPlotX(timeData, mouse.x))
+                {
+                    if (*idxVal < timeData.size())
+                    {
+                        ImGui::BeginTooltip();
+                        ImGui::TextUnformatted(formatAgeSeconds(static_cast<double>(timeData[*idxVal])).c_str());
+                        ImGui::Separator();
+                        ImGui::TextColored(theme.scheme().chartIo,
+                                           "Read: %s",
+                                           UI::Format::formatBytesPerSec(static_cast<double>(readData[*idxVal])).c_str());
+                        ImGui::TextColored(theme.scheme().chartIoWrite,
+                                           "Write: %s",
+                                           UI::Format::formatBytesPerSec(static_cast<double>(writeData[*idxVal])).c_str());
+                        ImGui::EndTooltip();
+                    }
+                }
+            }
+            ImPlot::EndPlot();
+        }
+    };
+
+    ImGui::TextColored(theme.scheme().textPrimary, "%.*s", static_cast<int>(deviceName.size()), deviceName.data());
+    renderHistoryWithNowBars(
+        layoutId.c_str(), HISTORY_PLOT_HEIGHT_DEFAULT, diskPlotFn, {readBar, writeBar}, false, STORAGE_NOW_BAR_COLUMNS);
+}
 
 } // namespace
 
@@ -66,95 +140,192 @@ void renderStorageSection(RenderContext& ctx)
 
     const auto& diskSnap = ctx.storageModel->latestSnapshot();
     const auto diskTimestamps = ctx.storageModel->historyTimestamps();
-    const auto diskReadHist = ctx.storageModel->totalReadHistory();
-    const auto diskWriteHist = ctx.storageModel->totalWriteHistory();
-    const size_t alignedDisk = std::min({diskTimestamps.size(), diskReadHist.size(), diskWriteHist.size()});
+    const size_t historySize = diskTimestamps.size();
 
-    const auto diskAxis = alignedDisk > 0 ? makeTimeAxisConfig(diskTimestamps, ctx.maxHistorySeconds, ctx.historyScrollSeconds)
+    const auto diskAxis = historySize > 0 ? makeTimeAxisConfig(diskTimestamps, ctx.maxHistorySeconds, ctx.historyScrollSeconds)
                                           : makeTimeAxisConfig({}, ctx.maxHistorySeconds, ctx.historyScrollSeconds);
 
+    // Build shared time axis (float, relative)
     std::vector<float> diskTimes;
-    std::vector<float> readData;
-    std::vector<float> writeData;
-
-    if (alignedDisk > 0)
+    if (historySize > 0)
     {
-        diskTimes = buildTimeAxis(diskTimestamps, alignedDisk, nowSeconds);
-        readData.reserve(alignedDisk);
-        writeData.reserve(alignedDisk);
-        // Copy from double to float
-        for (size_t i = diskReadHist.size() - alignedDisk; i < diskReadHist.size(); ++i)
-        {
-            readData.push_back(static_cast<float>(diskReadHist[i]));
-            writeData.push_back(static_cast<float>(diskWriteHist[i]));
-        }
+        diskTimes = buildTimeAxis(diskTimestamps, historySize, nowSeconds);
     }
 
-    // Update smoothed I/O values
+    // Update aggregate smoothed values
     updateSmoothedDiskIO(diskSnap.totalReadBytesPerSec, diskSnap.totalWriteBytesPerSec, ctx.lastDeltaSeconds, ctx);
 
     const double smoothedRead = ctx.smoothedReadBytesPerSec != nullptr ? *ctx.smoothedReadBytesPerSec : diskSnap.totalReadBytesPerSec;
     const double smoothedWrite = ctx.smoothedWriteBytesPerSec != nullptr ? *ctx.smoothedWriteBytesPerSec : diskSnap.totalWriteBytesPerSec;
 
-    // Calculate max across all data for consistent Y axis
-    const double diskMax = std::max({readData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(readData)),
-                                     writeData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(writeData)),
-                                     smoothedRead,
-                                     smoothedWrite,
-                                     1.0});
+    const auto perDisk = ctx.storageModel->perDiskHistory();
+    const size_t diskCount = perDisk.size();
 
-    const NowBar readBar{.valueText = UI::Format::formatBytesPerSec(smoothedRead),
-                         .label = "Disk Read",
-                         .value01 = std::clamp(smoothedRead / diskMax, 0.0, 1.0),
-                         .color = theme.scheme().chartCpu};
-    const NowBar writeBar{.valueText = UI::Format::formatBytesPerSec(smoothedWrite),
-                          .label = "Disk Write",
-                          .value01 = std::clamp(smoothedWrite / diskMax, 0.0, 1.0),
-                          .color = theme.accentColor(2)};
-
-    auto diskPlot = [&]()
+    if (diskCount > 1)
     {
-        const UI::Widgets::PlotFontGuard fontGuard;
-        if (ImPlot::BeginPlot("##SystemDiskHistory", ImVec2(-1, HISTORY_PLOT_HEIGHT_DEFAULT), ImPlotFlags_NoMenus))
+        // ── Multi-disk: one chart cell per disk in a 2-column grid ──────────────
+        ImGui::TextColored(
+            theme.scheme().textPrimary, ICON_FA_HARD_DRIVE "  Disk I/O by Device (%zu disks, %zu samples)", diskCount, historySize);
+
+        const float gridWidth = ImGui::GetContentRegionAvail().x;
+        constexpr float MIN_CELL_WIDTH = 320.0F;
+        const size_t gridCols = std::max<size_t>(1, static_cast<size_t>(gridWidth / MIN_CELL_WIDTH));
+        const int gridColsInt = UI::Format::checkedCount(gridCols);
+        const size_t gridRows = (diskCount + gridCols - 1) / gridCols;
+
+        if (ImGui::BeginTable("PerDiskGrid", gridColsInt, ImGuiTableFlags_SizingStretchSame))
         {
-            UI::Widgets::setupLegendDefault();
-            ImPlot::SetupAxes("Time (s)", nullptr, X_AXIS_FLAGS_DEFAULT, ImPlotAxisFlags_AutoFit | Y_AXIS_FLAGS_DEFAULT);
-            ImPlot::SetupAxisFormat(ImAxis_Y1, formatAxisBytesPerSec);
-            ImPlot::SetupAxisLimits(ImAxis_X1, diskAxis.xMin, diskAxis.xMax, ImPlotCond_Always);
-
-            const int count = UI::Format::checkedCount(alignedDisk);
-            plotLineWithFill("Read", diskTimes.data(), readData.data(), count, theme.scheme().chartCpu);
-            plotLineWithFill("Write", diskTimes.data(), writeData.data(), count, theme.accentColor(2));
-
-            if (ImPlot::IsPlotHovered())
+            for (size_t row = 0; row < gridRows; ++row)
             {
-                const ImPlotPoint mouse = ImPlot::GetPlotMousePos();
-                if (const auto idxVal = hoveredIndexFromPlotX(diskTimes, mouse.x))
+                ImGui::TableNextRow();
+                for (size_t col = 0; col < gridCols; ++col)
                 {
-                    if (*idxVal < alignedDisk)
+                    const size_t diskIdx = (row * gridCols) + col;
+                    ImGui::TableNextColumn();
+                    if (diskIdx >= diskCount)
                     {
-                        ImGui::BeginTooltip();
-                        const auto ageText = formatAgeSeconds(static_cast<double>(diskTimes[*idxVal]));
-                        ImGui::TextUnformatted(ageText.c_str());
-                        ImGui::Separator();
-                        ImGui::TextColored(theme.scheme().chartCpu,
-                                           "Read: %s",
-                                           UI::Format::formatBytesPerSec(static_cast<double>(readData[*idxVal])).c_str());
-                        ImGui::TextColored(theme.accentColor(2),
-                                           "Write: %s",
-                                           UI::Format::formatBytesPerSec(static_cast<double>(writeData[*idxVal])).c_str());
-                        ImGui::EndTooltip();
+                        continue;
                     }
+
+                    const auto& disk = perDisk[diskIdx];
+                    const size_t alignedCount = std::min({diskTimes.size(), disk.readBytesPerSec.size(), disk.writeBytesPerSec.size()});
+
+                    // Build float read/write data for this disk
+                    std::vector<float> readData;
+                    std::vector<float> writeData;
+                    readData.reserve(alignedCount);
+                    writeData.reserve(alignedCount);
+                    const size_t readOffset = disk.readBytesPerSec.size() - alignedCount;
+                    const size_t writeOffset = disk.writeBytesPerSec.size() - alignedCount;
+                    for (size_t i = 0; i < alignedCount; ++i)
+                    {
+                        readData.push_back(static_cast<float>(disk.readBytesPerSec[readOffset + i]));
+                        writeData.push_back(static_cast<float>(disk.writeBytesPerSec[writeOffset + i]));
+                    }
+
+                    // Per-disk snapshot values for NowBars (no smoothing per-disk for simplicity)
+                    double diskRead = 0.0;
+                    double diskWrite = 0.0;
+                    for (const auto& d : diskSnap.disks)
+                    {
+                        if (d.deviceName == disk.deviceName)
+                        {
+                            diskRead = d.readBytesPerSec;
+                            diskWrite = d.writeBytesPerSec;
+                            break;
+                        }
+                    }
+
+                    const std::string childId = std::format("DiskCell_{}", disk.deviceName);
+                    ImGui::PushStyleColor(ImGuiCol_ChildBg, theme.scheme().childBg);
+                    ImGui::PushStyleColor(ImGuiCol_Border, theme.scheme().separator);
+
+                    const float labelHeight = ImGui::GetTextLineHeight();
+                    const float spacingY = ImGui::GetStyle().ItemSpacing.y;
+                    constexpr float BAR_HEIGHT = 20.0F; // approximate NowBar row height
+                    const float childHeight = labelHeight + spacingY + HISTORY_PLOT_HEIGHT_DEFAULT + BAR_HEIGHT + (spacingY * 2.0F);
+
+                    if (ImGui::BeginChild(childId.c_str(), ImVec2(-FLT_MIN, childHeight), ImGuiChildFlags_Borders))
+                    {
+                        if (alignedCount == 0)
+                        {
+                            ImGui::TextColored(theme.scheme().textMuted, "%s\nCollecting data...", disk.deviceName.c_str());
+                        }
+                        else
+                        {
+                            const std::vector<float> cellTimes(diskTimes.end() - static_cast<std::ptrdiff_t>(alignedCount),
+                                                               diskTimes.end());
+                            renderDiskCell(disk.deviceName, cellTimes, readData, writeData, diskRead, diskWrite, diskAxis, theme);
+                        }
+                    }
+                    ImGui::EndChild();
+                    ImGui::PopStyleColor(2);
                 }
             }
-
-            ImPlot::EndPlot();
+            ImGui::EndTable();
         }
-    };
+    }
+    else
+    {
+        // ── Single disk (or no data yet): aggregate chart ─────────────────────
+        const auto diskReadHist = ctx.storageModel->totalReadHistory();
+        const auto diskWriteHist = ctx.storageModel->totalWriteHistory();
+        const size_t alignedDisk = std::min({historySize, diskReadHist.size(), diskWriteHist.size()});
 
-    ImGui::TextColored(theme.scheme().textPrimary, ICON_FA_HARD_DRIVE "  Disk I/O History (%zu samples)", alignedDisk);
-    renderHistoryWithNowBars(
-        "SystemDiskHistoryLayout", HISTORY_PLOT_HEIGHT_DEFAULT, diskPlot, {readBar, writeBar}, false, STORAGE_NOW_BAR_COLUMNS);
+        std::vector<float> readData;
+        std::vector<float> writeData;
+        if (alignedDisk > 0)
+        {
+            readData.reserve(alignedDisk);
+            writeData.reserve(alignedDisk);
+            for (size_t i = diskReadHist.size() - alignedDisk; i < diskReadHist.size(); ++i)
+            {
+                readData.push_back(static_cast<float>(diskReadHist[i]));
+                writeData.push_back(static_cast<float>(diskWriteHist[i]));
+            }
+        }
+
+        // Calculate max across all data for consistent Y axis
+        const double diskMax = std::max({readData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(readData)),
+                                         writeData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(writeData)),
+                                         smoothedRead,
+                                         smoothedWrite,
+                                         1.0});
+
+        const NowBar readBar{.valueText = UI::Format::formatBytesPerSec(smoothedRead),
+                             .label = "Disk Read",
+                             .value01 = std::clamp(smoothedRead / diskMax, 0.0, 1.0),
+                             .color = theme.scheme().chartIo};
+        const NowBar writeBar{.valueText = UI::Format::formatBytesPerSec(smoothedWrite),
+                              .label = "Disk Write",
+                              .value01 = std::clamp(smoothedWrite / diskMax, 0.0, 1.0),
+                              .color = theme.scheme().chartIoWrite};
+
+        auto diskPlot = [&]()
+        {
+            const UI::Widgets::PlotFontGuard fontGuard;
+            if (ImPlot::BeginPlot("##SystemDiskHistory", ImVec2(-1, HISTORY_PLOT_HEIGHT_DEFAULT), ImPlotFlags_NoMenus))
+            {
+                UI::Widgets::setupLegendDefault();
+                ImPlot::SetupAxes("Time (s)", nullptr, X_AXIS_FLAGS_DEFAULT, ImPlotAxisFlags_AutoFit | Y_AXIS_FLAGS_DEFAULT);
+                ImPlot::SetupAxisFormat(ImAxis_Y1, formatAxisBytesPerSec);
+                ImPlot::SetupAxisLimits(ImAxis_X1, diskAxis.xMin, diskAxis.xMax, ImPlotCond_Always);
+
+                const int count = UI::Format::checkedCount(alignedDisk);
+                plotLineWithFill("Read", diskTimes.data(), readData.data(), count, theme.scheme().chartIo, theme.scheme().chartIoFill);
+                plotLineWithFill(
+                    "Write", diskTimes.data(), writeData.data(), count, theme.scheme().chartIoWrite, theme.scheme().chartIoWriteFill);
+
+                if (ImPlot::IsPlotHovered())
+                {
+                    const ImPlotPoint mouse = ImPlot::GetPlotMousePos();
+                    if (const auto idxVal = hoveredIndexFromPlotX(diskTimes, mouse.x))
+                    {
+                        if (*idxVal < alignedDisk)
+                        {
+                            ImGui::BeginTooltip();
+                            const auto ageText = formatAgeSeconds(static_cast<double>(diskTimes[*idxVal]));
+                            ImGui::TextUnformatted(ageText.c_str());
+                            ImGui::Separator();
+                            ImGui::TextColored(theme.scheme().chartIo,
+                                               "Read: %s",
+                                               UI::Format::formatBytesPerSec(static_cast<double>(readData[*idxVal])).c_str());
+                            ImGui::TextColored(theme.scheme().chartIoWrite,
+                                               "Write: %s",
+                                               UI::Format::formatBytesPerSec(static_cast<double>(writeData[*idxVal])).c_str());
+                            ImGui::EndTooltip();
+                        }
+                    }
+                }
+
+                ImPlot::EndPlot();
+            }
+        };
+
+        ImGui::TextColored(theme.scheme().textPrimary, ICON_FA_HARD_DRIVE "  Disk I/O History (%zu samples)", alignedDisk);
+        renderHistoryWithNowBars(
+            "SystemDiskHistoryLayout", HISTORY_PLOT_HEIGHT_DEFAULT, diskPlot, {readBar, writeBar}, false, STORAGE_NOW_BAR_COLUMNS);
+    }
 }
 
 } // namespace App::StorageSection

--- a/src/App/Panels/StorageSection.cpp
+++ b/src/App/Panels/StorageSection.cpp
@@ -16,6 +16,7 @@
 #include <format>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace App::StorageSection
@@ -45,22 +46,22 @@ void renderDiskCell(std::string_view deviceName,
                     const std::vector<float>& timeData,
                     const std::vector<float>& readData,
                     const std::vector<float>& writeData,
-                    double smoothedRead,
-                    double smoothedWrite,
+                    double currentRead,
+                    double currentWrite,
                     const UI::Widgets::TimeAxisConfig& axisConfig,
                     const UI::Theme& theme)
 {
-    const double readMax = std::max({readData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(readData)), smoothedRead, 1.0});
+    const double readMax = std::max({readData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(readData)), currentRead, 1.0});
     const double writeMax =
-        std::max({writeData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(writeData)), smoothedWrite, 1.0});
+        std::max({writeData.empty() ? 1.0 : static_cast<double>(*std::ranges::max_element(writeData)), currentWrite, 1.0});
 
-    const NowBar readBar{.valueText = UI::Format::formatBytesPerSec(smoothedRead),
+    const NowBar readBar{.valueText = UI::Format::formatBytesPerSec(currentRead),
                          .label = "Read",
-                         .value01 = std::clamp(smoothedRead / readMax, 0.0, 1.0),
+                         .value01 = std::clamp(currentRead / readMax, 0.0, 1.0),
                          .color = theme.scheme().chartIo};
-    const NowBar writeBar{.valueText = UI::Format::formatBytesPerSec(smoothedWrite),
+    const NowBar writeBar{.valueText = UI::Format::formatBytesPerSec(currentWrite),
                           .label = "Write",
-                          .value01 = std::clamp(smoothedWrite / writeMax, 0.0, 1.0),
+                          .value01 = std::clamp(currentWrite / writeMax, 0.0, 1.0),
                           .color = theme.scheme().chartIoWrite};
 
     const std::string plotId = std::format("##DiskPlot_{}", deviceName);
@@ -173,6 +174,14 @@ void renderStorageSection(RenderContext& ctx)
         const int gridColsInt = UI::Format::checkedCount(gridCols);
         const size_t gridRows = (diskCount + gridCols - 1) / gridCols;
 
+        // Pre-build device name → snapshot lookup to avoid O(n²) linear scans in the cell loop.
+        std::unordered_map<std::string, const Domain::DiskSnapshot*> diskLookup;
+        diskLookup.reserve(diskSnap.disks.size());
+        for (const auto& d : diskSnap.disks)
+        {
+            diskLookup.emplace(d.deviceName, &d);
+        }
+
         if (ImGui::BeginTable("PerDiskGrid", gridColsInt, ImGuiTableFlags_SizingStretchSame))
         {
             for (size_t row = 0; row < gridRows; ++row)
@@ -203,17 +212,13 @@ void renderStorageSection(RenderContext& ctx)
                         writeData.push_back(static_cast<float>(disk.writeBytesPerSec[writeOffset + i]));
                     }
 
-                    // Per-disk snapshot values for NowBars (no smoothing per-disk for simplicity)
+                    // Per-disk snapshot values for NowBars (O(1) lookup via pre-built map).
                     double diskRead = 0.0;
                     double diskWrite = 0.0;
-                    for (const auto& d : diskSnap.disks)
+                    if (const auto it = diskLookup.find(disk.deviceName); it != diskLookup.end())
                     {
-                        if (d.deviceName == disk.deviceName)
-                        {
-                            diskRead = d.readBytesPerSec;
-                            diskWrite = d.writeBytesPerSec;
-                            break;
-                        }
+                        diskRead = it->second->readBytesPerSec;
+                        diskWrite = it->second->writeBytesPerSec;
                     }
 
                     const std::string childId = std::format("DiskCell_{}", disk.deviceName);

--- a/src/Domain/StorageModel.cpp
+++ b/src/Domain/StorageModel.cpp
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -80,16 +81,37 @@ void StorageModel::sample()
         m_History.push_back(snapshot);
         m_Timestamps.push_back(nowSeconds);
 
-        // Maintain per-disk I/O histories aligned to m_Timestamps
-        for (const auto& diskSnap : snapshot.disks)
+        // Maintain per-disk I/O histories aligned to m_Timestamps.
+        // Track which disks are present in this sample; known-but-absent disks
+        // get a zero placeholder so every deque stays index-aligned with m_Timestamps.
+        std::unordered_set<std::string> presentDisks;
+        presentDisks.reserve(snapshot.disks.size());
+        for (const auto& disk : snapshot.disks)
         {
-            const auto& name = diskSnap.deviceName;
+            const auto& name = disk.deviceName;
+            presentDisks.insert(name);
             if (!m_DiskReadHistory.contains(name))
             {
+                // New disk: backfill zeros for all prior timestamps before this sample.
                 m_DiskOrder.push_back(name);
+                const size_t backfillCount = m_Timestamps.size() - 1; // current ts already pushed
+                for (size_t i = 0; i < backfillCount; ++i)
+                {
+                    m_DiskReadHistory[name].push_back(0.0);
+                    m_DiskWriteHistory[name].push_back(0.0);
+                }
             }
-            m_DiskReadHistory[name].push_back(diskSnap.readBytesPerSec);
-            m_DiskWriteHistory[name].push_back(diskSnap.writeBytesPerSec);
+            m_DiskReadHistory[name].push_back(disk.readBytesPerSec);
+            m_DiskWriteHistory[name].push_back(disk.writeBytesPerSec);
+        }
+        // Append a zero placeholder for known disks absent from this sample.
+        for (const auto& name : m_DiskOrder)
+        {
+            if (!presentDisks.contains(name))
+            {
+                m_DiskReadHistory[name].push_back(0.0);
+                m_DiskWriteHistory[name].push_back(0.0);
+            }
         }
 
         trimHistory(nowSeconds);
@@ -183,19 +205,37 @@ void StorageModel::trimHistory(double nowSeconds)
         m_History.pop_front();
     }
 
-    // Align per-disk deques to current timestamp count to prevent drift
+    // Align per-disk deques to the timestamp count so each disk series remains
+    // index-aligned with m_Timestamps even when a disk is introduced later or
+    // missing from some samples.
+    // Use .find() rather than operator[] to avoid unintentionally inserting
+    // empty deques for names that do not yet have map entries.
     const size_t targetSize = m_Timestamps.size();
     for (const auto& name : m_DiskOrder)
     {
-        auto& readHist = m_DiskReadHistory[name];
-        auto& writeHist = m_DiskWriteHistory[name];
-        while (readHist.size() > targetSize)
+        if (auto readIt = m_DiskReadHistory.find(name); readIt != m_DiskReadHistory.end())
         {
-            readHist.pop_front();
+            auto& readHist = readIt->second;
+            while (readHist.size() > targetSize)
+            {
+                readHist.pop_front();
+            }
+            while (readHist.size() < targetSize)
+            {
+                readHist.push_front({});
+            }
         }
-        while (writeHist.size() > targetSize)
+        if (auto writeIt = m_DiskWriteHistory.find(name); writeIt != m_DiskWriteHistory.end())
         {
-            writeHist.pop_front();
+            auto& writeHist = writeIt->second;
+            while (writeHist.size() > targetSize)
+            {
+                writeHist.pop_front();
+            }
+            while (writeHist.size() < targetSize)
+            {
+                writeHist.push_front({});
+            }
         }
     }
 }

--- a/src/Domain/StorageModel.cpp
+++ b/src/Domain/StorageModel.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -78,6 +79,19 @@ void StorageModel::sample()
         m_LatestSnapshot = snapshot;
         m_History.push_back(snapshot);
         m_Timestamps.push_back(nowSeconds);
+
+        // Maintain per-disk I/O histories aligned to m_Timestamps
+        for (const auto& diskSnap : snapshot.disks)
+        {
+            const auto& name = diskSnap.deviceName;
+            if (!m_DiskReadHistory.contains(name))
+            {
+                m_DiskOrder.push_back(name);
+            }
+            m_DiskReadHistory[name].push_back(diskSnap.readBytesPerSec);
+            m_DiskWriteHistory[name].push_back(diskSnap.writeBytesPerSec);
+        }
+
         trimHistory(nowSeconds);
         m_HasPrevSample = true;
         m_PrevSampleTime = now;
@@ -168,6 +182,22 @@ void StorageModel::trimHistory(double nowSeconds)
         m_Timestamps.pop_front();
         m_History.pop_front();
     }
+
+    // Align per-disk deques to current timestamp count to prevent drift
+    const size_t targetSize = m_Timestamps.size();
+    for (const auto& name : m_DiskOrder)
+    {
+        auto& readHist = m_DiskReadHistory[name];
+        auto& writeHist = m_DiskWriteHistory[name];
+        while (readHist.size() > targetSize)
+        {
+            readHist.pop_front();
+        }
+        while (writeHist.size() > targetSize)
+        {
+            writeHist.pop_front();
+        }
+    }
 }
 
 StorageSnapshot StorageModel::latestSnapshot() const
@@ -204,6 +234,30 @@ std::vector<double> StorageModel::totalWriteHistory() const
         out.push_back(snap.totalWriteBytesPerSec);
     }
     return out;
+}
+
+std::vector<PerDiskHistory> StorageModel::perDiskHistory() const
+{
+    std::shared_lock lock(m_Mutex); // NOLINT(misc-const-correctness) - lock guard pattern
+    std::vector<PerDiskHistory> result;
+    result.reserve(m_DiskOrder.size());
+    for (const auto& name : m_DiskOrder)
+    {
+        PerDiskHistory entry;
+        entry.deviceName = name;
+        const auto readIt = m_DiskReadHistory.find(name);
+        const auto writeIt = m_DiskWriteHistory.find(name);
+        if (readIt != m_DiskReadHistory.end())
+        {
+            entry.readBytesPerSec = {readIt->second.begin(), readIt->second.end()};
+        }
+        if (writeIt != m_DiskWriteHistory.end())
+        {
+            entry.writeBytesPerSec = {writeIt->second.begin(), writeIt->second.end()};
+        }
+        result.push_back(std::move(entry));
+    }
+    return result;
 }
 
 std::vector<double> StorageModel::historyTimestamps() const

--- a/src/Domain/StorageModel.h
+++ b/src/Domain/StorageModel.h
@@ -51,7 +51,9 @@ class StorageModel
     [[nodiscard]] std::vector<double> historyTimestamps() const;
 
     /// Per-device I/O history for charting individual disks.
-    /// Each entry is aligned to historyTimestamps().
+    /// Each entry is strictly aligned to historyTimestamps(): every per-disk
+    /// vector has the same length as historyTimestamps(). Samples where a disk
+    /// was absent (disappeared or not yet seen) are represented as 0.0.
     [[nodiscard]] std::vector<PerDiskHistory> perDiskHistory() const;
 
     /// Configure history retention.

--- a/src/Domain/StorageModel.h
+++ b/src/Domain/StorageModel.h
@@ -14,6 +14,14 @@
 namespace Domain
 {
 
+/// Per-device I/O history for charting.
+struct PerDiskHistory
+{
+    std::string deviceName;
+    std::vector<double> readBytesPerSec;  ///< Aligned to StorageModel::historyTimestamps()
+    std::vector<double> writeBytesPerSec; ///< Aligned to StorageModel::historyTimestamps()
+};
+
 /// Manages disk/storage metrics: samples probe, computes rates, maintains history.
 /// Thread-safe (allows background sampling + UI reads).
 class StorageModel
@@ -41,6 +49,10 @@ class StorageModel
     [[nodiscard]] std::vector<double> totalReadHistory() const;
     [[nodiscard]] std::vector<double> totalWriteHistory() const;
     [[nodiscard]] std::vector<double> historyTimestamps() const;
+
+    /// Per-device I/O history for charting individual disks.
+    /// Each entry is aligned to historyTimestamps().
+    [[nodiscard]] std::vector<PerDiskHistory> perDiskHistory() const;
 
     /// Configure history retention.
     void setMaxHistorySeconds(double seconds);
@@ -72,6 +84,11 @@ class StorageModel
     std::chrono::steady_clock::time_point m_PrevSampleTime;
     std::chrono::steady_clock::time_point m_StartTime;
     bool m_HasPrevSample = false;
+
+    // Per-device I/O history for per-disk charting (deques aligned to m_Timestamps)
+    std::unordered_map<std::string, std::deque<double>> m_DiskReadHistory;
+    std::unordered_map<std::string, std::deque<double>> m_DiskWriteHistory;
+    std::vector<std::string> m_DiskOrder; ///< Insertion-order disk names for consistent display
 
     double m_MaxHistorySeconds = 300.0; // 5 minutes default
 };

--- a/tests/Domain/test_StorageModel.cpp
+++ b/tests/Domain/test_StorageModel.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
 #include <thread>
 
@@ -568,6 +569,111 @@ TEST(StorageModelTest, PerDiskHistoryPreservesInsertionOrder)
     // Order must match probe insertion order
     EXPECT_EQ(history[0].deviceName, "sdb");
     EXPECT_EQ(history[1].deviceName, "sda");
+}
+
+TEST(StorageModelTest, PerDiskHistoryDiskDisappearsPreservesAlignment)
+{
+    auto mockProbeOwned = std::make_unique<Mocks::MockDiskProbe>();
+    Mocks::MockDiskProbe* mockProbe = mockProbeOwned.get();
+
+    // Sample 1: two disks
+    Platform::SystemDiskCounters counters;
+    Platform::DiskCounters sda;
+    sda.deviceName = "sda";
+    sda.sectorSize = 512;
+    sda.readsCompleted = 100;
+    sda.readSectors = 1000;
+    counters.disks.push_back(sda);
+    Platform::DiskCounters sdb;
+    sdb.deviceName = "sdb";
+    sdb.sectorSize = 512;
+    sdb.readsCompleted = 50;
+    sdb.readSectors = 500;
+    counters.disks.push_back(sdb);
+    mockProbe->setNextCounters(counters);
+
+    StorageModel model(std::move(mockProbeOwned));
+    model.sample();
+
+    // Sample 2: sdb disappears
+    counters.disks.clear();
+    sda.readsCompleted = 200;
+    sda.readSectors = 2000;
+    counters.disks.push_back(sda);
+    mockProbe->setNextCounters(counters);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    model.sample();
+
+    const auto timestamps = model.historyTimestamps();
+    const auto history = model.perDiskHistory();
+
+    ASSERT_EQ(history.size(), 2U);
+    for (const auto& entry : history)
+    {
+        EXPECT_EQ(entry.readBytesPerSec.size(), timestamps.size())
+            << "Per-disk read history for " << entry.deviceName << " must be aligned to timestamps";
+        EXPECT_EQ(entry.writeBytesPerSec.size(), timestamps.size())
+            << "Per-disk write history for " << entry.deviceName << " must be aligned to timestamps";
+    }
+
+    // sdb was absent in sample 2: its last entry must be the 0.0 placeholder
+    const auto it = std::ranges::find_if(history, [](const PerDiskHistory& e) { return e.deviceName == "sdb"; });
+    ASSERT_NE(it, history.end());
+    EXPECT_DOUBLE_EQ(it->readBytesPerSec.back(), 0.0);
+    EXPECT_DOUBLE_EQ(it->writeBytesPerSec.back(), 0.0);
+}
+
+TEST(StorageModelTest, PerDiskHistoryNewDiskAppearsBackfillsPlaceholders)
+{
+    auto mockProbeOwned = std::make_unique<Mocks::MockDiskProbe>();
+    Mocks::MockDiskProbe* mockProbe = mockProbeOwned.get();
+
+    // Sample 1: only sda
+    Platform::SystemDiskCounters counters;
+    Platform::DiskCounters sda;
+    sda.deviceName = "sda";
+    sda.sectorSize = 512;
+    sda.readsCompleted = 100;
+    sda.readSectors = 1000;
+    counters.disks.push_back(sda);
+    mockProbe->setNextCounters(counters);
+
+    StorageModel model(std::move(mockProbeOwned));
+    model.sample();
+
+    // Sample 2: sda + new disk nvme0n1
+    sda.readsCompleted = 200;
+    sda.readSectors = 2000;
+    Platform::DiskCounters nvme;
+    nvme.deviceName = "nvme0n1";
+    nvme.sectorSize = 512;
+    nvme.readsCompleted = 100;
+    nvme.readSectors = 1000;
+    counters.disks.clear();
+    counters.disks.push_back(sda);
+    counters.disks.push_back(nvme);
+    mockProbe->setNextCounters(counters);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    model.sample();
+
+    const auto timestamps = model.historyTimestamps();
+    const auto history = model.perDiskHistory();
+
+    ASSERT_EQ(history.size(), 2U);
+    for (const auto& entry : history)
+    {
+        EXPECT_EQ(entry.readBytesPerSec.size(), timestamps.size())
+            << "Per-disk read history for " << entry.deviceName << " must be aligned to timestamps";
+        EXPECT_EQ(entry.writeBytesPerSec.size(), timestamps.size())
+            << "Per-disk write history for " << entry.deviceName << " must be aligned to timestamps";
+    }
+
+    // nvme0n1 appeared in sample 2: its oldest (backfilled) entry must be 0.0
+    const auto it = std::ranges::find_if(history, [](const PerDiskHistory& e) { return e.deviceName == "nvme0n1"; });
+    ASSERT_NE(it, history.end());
+    ASSERT_GE(it->readBytesPerSec.size(), 1U);
+    EXPECT_DOUBLE_EQ(it->readBytesPerSec.front(), 0.0);
+    EXPECT_DOUBLE_EQ(it->writeBytesPerSec.front(), 0.0);
 }
 
 } // namespace

--- a/tests/Domain/test_StorageModel.cpp
+++ b/tests/Domain/test_StorageModel.cpp
@@ -406,5 +406,169 @@ TEST(StorageModelTest, SnapshotReflectsProbeCapabilities)
     EXPECT_TRUE(snap.hasIoTime);
 }
 
+// =============================================================================
+// Per-Disk History
+// =============================================================================
+
+TEST(StorageModelTest, PerDiskHistoryEmptyBeforeSample)
+{
+    auto mockProbe = std::make_unique<Mocks::MockDiskProbe>();
+    StorageModel model(std::move(mockProbe));
+
+    EXPECT_TRUE(model.perDiskHistory().empty());
+}
+
+TEST(StorageModelTest, PerDiskHistoryTracksAllDisks)
+{
+    auto mockProbe = std::make_unique<Mocks::MockDiskProbe>();
+
+    Platform::SystemDiskCounters counters;
+    Platform::DiskCounters sda;
+    sda.deviceName = "sda";
+    sda.sectorSize = 512;
+    sda.readsCompleted = 100;
+    sda.readSectors = 1000;
+    counters.disks.push_back(sda);
+
+    Platform::DiskCounters nvme;
+    nvme.deviceName = "nvme0n1";
+    nvme.sectorSize = 512;
+    nvme.readsCompleted = 200;
+    nvme.readSectors = 2000;
+    counters.disks.push_back(nvme);
+
+    mockProbe->setNextCounters(counters);
+
+    StorageModel model(std::move(mockProbe));
+    model.sample();
+
+    const auto history = model.perDiskHistory();
+    ASSERT_EQ(history.size(), 2U);
+    EXPECT_EQ(history[0].deviceName, "sda");
+    EXPECT_EQ(history[1].deviceName, "nvme0n1");
+}
+
+TEST(StorageModelTest, PerDiskHistoryAlignedToTimestamps)
+{
+    auto mockProbeOwned = std::make_unique<Mocks::MockDiskProbe>();
+    Mocks::MockDiskProbe* mockProbe = mockProbeOwned.get();
+
+    Platform::SystemDiskCounters counters;
+    Platform::DiskCounters sda;
+    sda.deviceName = "sda";
+    sda.sectorSize = 512;
+    sda.readsCompleted = 100;
+    sda.readSectors = 1000;
+    counters.disks.push_back(sda);
+
+    Platform::DiskCounters nvme;
+    nvme.deviceName = "nvme0n1";
+    nvme.sectorSize = 512;
+    nvme.readsCompleted = 200;
+    nvme.readSectors = 2000;
+    counters.disks.push_back(nvme);
+
+    mockProbe->setNextCounters(counters);
+
+    StorageModel model(std::move(mockProbeOwned));
+    model.sample();
+
+    // Second sample with updated sector counts to produce non-zero rates
+    sda.readsCompleted = 200;
+    sda.readSectors = 2000;
+    sda.writesCompleted = 50;
+    sda.writeSectors = 500;
+    nvme.readsCompleted = 400;
+    nvme.readSectors = 4000;
+    nvme.writesCompleted = 100;
+    nvme.writeSectors = 1000;
+    counters.disks.clear();
+    counters.disks.push_back(sda);
+    counters.disks.push_back(nvme);
+    mockProbe->setNextCounters(counters);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    model.sample();
+
+    const auto timestamps = model.historyTimestamps();
+    const auto history = model.perDiskHistory();
+
+    ASSERT_EQ(history.size(), 2U);
+    for (const auto& entry : history)
+    {
+        EXPECT_EQ(entry.readBytesPerSec.size(), timestamps.size());
+        EXPECT_EQ(entry.writeBytesPerSec.size(), timestamps.size());
+    }
+}
+
+TEST(StorageModelTest, PerDiskHistoryRatesNonNegative)
+{
+    auto mockProbeOwned = std::make_unique<Mocks::MockDiskProbe>();
+    Mocks::MockDiskProbe* mockProbe = mockProbeOwned.get();
+
+    Platform::SystemDiskCounters counters;
+    Platform::DiskCounters sda;
+    sda.deviceName = "sda";
+    sda.sectorSize = 512;
+    sda.readsCompleted = 100;
+    sda.readSectors = 1000;
+    sda.writesCompleted = 50;
+    sda.writeSectors = 500;
+    counters.disks.push_back(sda);
+    mockProbe->setNextCounters(counters);
+
+    StorageModel model(std::move(mockProbeOwned));
+    model.sample();
+
+    sda.readsCompleted = 200;
+    sda.readSectors = 2000;
+    sda.writesCompleted = 100;
+    sda.writeSectors = 1000;
+    counters.disks.clear();
+    counters.disks.push_back(sda);
+    mockProbe->setNextCounters(counters);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    model.sample();
+
+    const auto history = model.perDiskHistory();
+    ASSERT_EQ(history.size(), 1U);
+    for (const double rate : history[0].readBytesPerSec)
+    {
+        EXPECT_GE(rate, 0.0);
+    }
+    for (const double rate : history[0].writeBytesPerSec)
+    {
+        EXPECT_GE(rate, 0.0);
+    }
+}
+
+TEST(StorageModelTest, PerDiskHistoryPreservesInsertionOrder)
+{
+    auto mockProbe = std::make_unique<Mocks::MockDiskProbe>();
+
+    Platform::SystemDiskCounters counters;
+    Platform::DiskCounters diskA;
+    diskA.deviceName = "sdb";
+    diskA.sectorSize = 512;
+    counters.disks.push_back(diskA);
+
+    Platform::DiskCounters diskB;
+    diskB.deviceName = "sda";
+    diskB.sectorSize = 512;
+    counters.disks.push_back(diskB);
+
+    mockProbe->setNextCounters(counters);
+
+    StorageModel model(std::move(mockProbe));
+    model.sample();
+
+    const auto history = model.perDiskHistory();
+    ASSERT_EQ(history.size(), 2U);
+    // Order must match probe insertion order
+    EXPECT_EQ(history[0].deviceName, "sdb");
+    EXPECT_EQ(history[1].deviceName, "sda");
+}
+
 } // namespace
 } // namespace Domain


### PR DESCRIPTION
## Summary

Closes #366.

When the system has more than one disk, `StorageSection` now renders a per-device grid (2 columns, mirroring `CpuCoresSection`) instead of a single aggregate chart. Each cell shows the device name, Read/Write NowBars, and a read+write history plot. The single-disk fallback path is unchanged.

## Changes

### Domain (`StorageModel`)
- Added `PerDiskHistory` struct (`deviceName`, `readBytesPerSec`, `writeBytesPerSec` vectors aligned to `historyTimestamps()`).
- Added `perDiskHistory()` method returning per-device history in insertion order.
- `sample()` populates `m_DiskReadHistory` / `m_DiskWriteHistory` per device.
- `trimHistory()` trims per-disk deques to stay aligned with the main timestamp deque.
- `m_DiskOrder` preserves insertion order for stable display ordering.

### UI (`StorageSection`)
- `renderDiskCell()` helper renders one device: label + Read/Write `NowBar`s + `plotLineWithFill` chart.
- Multi-disk path: `BeginTable` 2-column grid, one `BeginChild` cell per device.
- Single-disk path: original aggregate chart unchanged.
- Uses `chartIo`/`chartIoFill` (read) and `chartIoWrite`/`chartIoWriteFill` (write) from the theme — available now that #367 has landed.

### Tests (5 new)
- `PerDiskHistoryEmptyBeforeSample`
- `PerDiskHistoryTracksAllDisks`
- `PerDiskHistoryAlignedToTimestamps`
- `PerDiskHistoryRatesNonNegative`
- `PerDiskHistoryPreservesInsertionOrder`

## Test Results
All 777 tests pass (772 original + 5 new).

## Checklist
- [x] clang-format applied
- [x] clang-tidy clean (no warnings in modified files)
- [x] All tests pass (777/777)
- [x] Rebased on main (includes merged #367 / PR #439)