### PR TITLE
ci: upgrade Node.js 20 actions to Node.js 24 (#440)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/setup-llvm
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: linux-${{ matrix.build_type }}
           max-size: 500M
@@ -97,7 +97,7 @@ jobs:
         run: choco install llvm ninja ccache -y
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: windows-${{ matrix.build_type }}
           max-size: 500M
@@ -155,7 +155,7 @@ jobs:
           install-clang-tidy: 'true'
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: linux-tidy
           max-size: 500M
@@ -194,7 +194,7 @@ jobs:
           sudo apt-get install -y iwyu
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: linux-iwyu
           max-size: 500M
@@ -316,7 +316,7 @@ jobs:
           install-coverage-tools: 'true'
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: linux-coverage
           max-size: 500M
@@ -401,7 +401,7 @@ jobs:
         uses: ./.github/actions/setup-llvm
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: linux-${{ matrix.preset }}
           max-size: 500M

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/setup-llvm
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: linux-release-package
           max-size: 500M
@@ -72,7 +72,7 @@ jobs:
         run: choco install llvm ninja ccache -y
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: windows-release-package
           max-size: 500M


### PR DESCRIPTION
## Summary

Closes #440.

Two actions were generating Node.js 20 deprecation warnings across every CI job. Node.js 20 reaches EOL in April 2026, runners switch to Node.js 24 as the default on **June 2, 2026**, and Node.js 20 is fully removed on **September 16, 2026**.

## Changes

| Action | Before | After | Node.js |
|--------|--------|-------|---------|
| `actions/labeler` | `v5` | `v6.0.1` | 20 → 24 |
| `hendrikmuhs/ccache-action` | `v1.2` (floating) | `v1.2.23` | 20 → 24 |

### `actions/labeler@v5` → `v6.0.1`
- `v6.0.0` (Sep 3, 2025) upgrades the runtime to Node.js 24
- All inputs (`repo-token`, `configuration-path`, `sync-labels`) are unchanged — no `labeler.yml` changes required
- The "config file not found locally, fetching via API" log is expected: `pull_request_target` runs without a checkout, so the action falls back to the GitHub API to read the config. This was always the behavior.

### `hendrikmuhs/ccache-action@v1.2` → `v1.2.23`
- `v1.2.21` (Mar 16, 2026) was the first release to upgrade to Node.js 24
- Pinned to `v1.2.23` (latest, Apr 23, 2026) rather than keeping the `v1.2` floating tag, since the floating tag demonstrably lagged behind — it never pointed to v1.2.21+ despite it being available
- Updated in all 6 job steps in `ci.yml` and both steps in `release.yml` (8 total)