### PR TITLE
feat: add system-wide Handles/FDs history to Overview tab

### DIFF
--- a/src/App/Panels/SystemMetricsPanel.cpp
+++ b/src/App/Panels/SystemMetricsPanel.cpp
@@ -924,7 +924,8 @@ void SystemMetricsPanel::renderOverview()
         const auto procTimestamps = m_ProcessModel->historyTimestamps();
         const auto pageFaultHist = m_ProcessModel->systemPageFaultsHistory();
         const auto threadHist = m_ProcessModel->systemThreadCountHistory();
-        const size_t alignedCount = std::min({procTimestamps.size(), pageFaultHist.size(), threadHist.size()});
+        const auto handleHist = m_ProcessModel->systemHandleCountHistory();
+        const size_t alignedCount = std::min({procTimestamps.size(), pageFaultHist.size(), threadHist.size(), handleHist.size()});
 
         // Always use default axis config even with no data
         const auto axis = alignedCount > 0 ? makeTimeAxisConfig(procTimestamps, m_MaxHistorySeconds, m_HistoryScrollSeconds)
@@ -933,17 +934,20 @@ void SystemMetricsPanel::renderOverview()
         std::vector<float> timeData;
         std::vector<float> faultData;
         std::vector<float> threadData;
+        std::vector<float> handleData;
 
         if (alignedCount > 0)
         {
             timeData = buildTimeAxis(procTimestamps, alignedCount, nowSeconds);
             faultData.assign(pageFaultHist.end() - static_cast<std::ptrdiff_t>(alignedCount), pageFaultHist.end());
             threadData.assign(threadHist.end() - static_cast<std::ptrdiff_t>(alignedCount), threadHist.end());
+            handleData.assign(handleHist.end() - static_cast<std::ptrdiff_t>(alignedCount), handleHist.end());
 
             // Update smoothed values
             const double targetThreads = static_cast<double>(threadData.back());
             const double targetFaults = static_cast<double>(faultData.back());
-            updateSmoothedThreadsFaults(targetThreads, targetFaults, m_LastDeltaSeconds);
+            const double targetHandles = static_cast<double>(handleData.back());
+            updateSmoothedThreadsFaults(targetThreads, targetFaults, targetHandles, m_LastDeltaSeconds);
         }
 
         const double threadMax = threadData.empty()
@@ -952,6 +956,15 @@ void SystemMetricsPanel::renderOverview()
         const double faultMax = faultData.empty()
                                   ? 1.0
                                   : std::max(m_SmoothedThreadsFaults.pageFaults, static_cast<double>(*std::ranges::max_element(faultData)));
+        const double handleMax = handleData.empty()
+                                   ? 1.0
+                                   : std::max(m_SmoothedThreadsFaults.handles, static_cast<double>(*std::ranges::max_element(handleData)));
+
+#ifdef _WIN32
+        constexpr const char* handleLabel = "Handles";
+#else
+        constexpr const char* handleLabel = "FDs";
+#endif
 
         const NowBar threadsBar{.valueText = UI::Format::formatCountWithLabel(std::llround(m_SmoothedThreadsFaults.threads), "threads"),
                                 .label = "Threads",
@@ -961,6 +974,10 @@ void SystemMetricsPanel::renderOverview()
                                .label = "Page Faults",
                                .value01 = (faultMax > 0.0) ? std::clamp(m_SmoothedThreadsFaults.pageFaults / faultMax, 0.0, 1.0) : 0.0,
                                .color = theme.accentColor(3)};
+        const NowBar handlesBar{.valueText = UI::Format::formatCountWithLabel(std::llround(m_SmoothedThreadsFaults.handles), handleLabel),
+                                .label = handleLabel,
+                                .value01 = (handleMax > 0.0) ? std::clamp(m_SmoothedThreadsFaults.handles / handleMax, 0.0, 1.0) : 0.0,
+                                .color = theme.scheme().chartMemory};
 
         auto plot = [&]()
         {
@@ -975,6 +992,7 @@ void SystemMetricsPanel::renderOverview()
                 const int count = UI::Format::checkedCount(alignedCount);
                 plotLineWithFill("Threads", timeData.data(), threadData.data(), count, theme.scheme().chartCpu);
                 plotLineWithFill("Page Faults/s", timeData.data(), faultData.data(), count, theme.accentColor(3));
+                plotLineWithFill(handleLabel, timeData.data(), handleData.data(), count, theme.scheme().chartMemory);
 
                 if (ImPlot::IsPlotHovered())
                 {
@@ -993,6 +1011,10 @@ void SystemMetricsPanel::renderOverview()
                             ImGui::TextColored(theme.accentColor(3),
                                                "Page Faults: %s",
                                                UI::Format::formatCountPerSecond(static_cast<double>(faultData[*idxVal])).c_str());
+                            ImGui::TextColored(theme.scheme().chartMemory,
+                                               "%s: %s",
+                                               handleLabel,
+                                               UI::Format::formatIntLocalized(std::llround(handleData[*idxVal])).c_str());
                             ImGui::EndTooltip();
                         }
                     }
@@ -1003,8 +1025,12 @@ void SystemMetricsPanel::renderOverview()
         };
 
         ImGui::TextColored(theme.scheme().textPrimary, ICON_FA_GEARS "  Threads & Page Faults (%zu samples)", alignedCount);
-        renderHistoryWithNowBars(
-            "ThreadsFaultsHistoryLayout", HISTORY_PLOT_HEIGHT_DEFAULT, plot, {threadsBar, faultsBar}, false, OVERVIEW_NOW_BAR_COLUMNS);
+        renderHistoryWithNowBars("ThreadsFaultsHistoryLayout",
+                                 HISTORY_PLOT_HEIGHT_DEFAULT,
+                                 plot,
+                                 {threadsBar, faultsBar, handlesBar},
+                                 false,
+                                 OVERVIEW_NOW_BAR_COLUMNS);
         ImGui::Spacing();
     }
 }
@@ -1225,7 +1251,10 @@ void SystemMetricsPanel::updateSmoothedPower(float targetWatts, float targetBatt
     m_SmoothedPower.batteryChargePercent = smoothTowards(m_SmoothedPower.batteryChargePercent, targetB, alpha);
 }
 
-void SystemMetricsPanel::updateSmoothedThreadsFaults(double targetThreads, double targetFaults, float deltaTimeSeconds)
+void SystemMetricsPanel::updateSmoothedThreadsFaults(double targetThreads,
+                                                     double targetFaults,
+                                                     double targetHandles,
+                                                     float deltaTimeSeconds)
 {
     const double alpha = computeAlpha(deltaTimeSeconds, m_RefreshInterval);
 
@@ -1233,12 +1262,14 @@ void SystemMetricsPanel::updateSmoothedThreadsFaults(double targetThreads, doubl
     {
         m_SmoothedThreadsFaults.threads = targetThreads;
         m_SmoothedThreadsFaults.pageFaults = targetFaults;
+        m_SmoothedThreadsFaults.handles = targetHandles;
         m_SmoothedThreadsFaults.initialized = true;
         return;
     }
 
     m_SmoothedThreadsFaults.threads = smoothTowards(m_SmoothedThreadsFaults.threads, targetThreads, alpha);
     m_SmoothedThreadsFaults.pageFaults = smoothTowards(m_SmoothedThreadsFaults.pageFaults, targetFaults, alpha);
+    m_SmoothedThreadsFaults.handles = smoothTowards(m_SmoothedThreadsFaults.handles, targetHandles, alpha);
 }
 
 } // namespace App

--- a/src/App/Panels/SystemMetricsPanel.cpp
+++ b/src/App/Panels/SystemMetricsPanel.cpp
@@ -918,7 +918,7 @@ void SystemMetricsPanel::renderOverview()
         }
     }
 
-    // Threads & Page Faults combined (aggregated from processes)
+    // Threads, Page Faults, and Handles/FDs combined (aggregated from processes)
     if (m_ProcessModel != nullptr)
     {
         const auto procTimestamps = m_ProcessModel->historyTimestamps();
@@ -947,18 +947,15 @@ void SystemMetricsPanel::renderOverview()
             const double targetThreads = static_cast<double>(threadData.back());
             const double targetFaults = static_cast<double>(faultData.back());
             const double targetHandles = static_cast<double>(handleData.back());
-            updateSmoothedThreadsFaults(targetThreads, targetFaults, targetHandles, m_LastDeltaSeconds);
+            updateSmoothedResources(targetThreads, targetFaults, targetHandles, m_LastDeltaSeconds);
         }
 
-        const double threadMax = threadData.empty()
-                                   ? 1.0
-                                   : std::max(m_SmoothedThreadsFaults.threads, static_cast<double>(*std::ranges::max_element(threadData)));
-        const double faultMax = faultData.empty()
-                                  ? 1.0
-                                  : std::max(m_SmoothedThreadsFaults.pageFaults, static_cast<double>(*std::ranges::max_element(faultData)));
-        const double handleMax = handleData.empty()
-                                   ? 1.0
-                                   : std::max(m_SmoothedThreadsFaults.handles, static_cast<double>(*std::ranges::max_element(handleData)));
+        const double threadMax =
+            threadData.empty() ? 1.0 : std::max(m_SmoothedResources.threads, static_cast<double>(*std::ranges::max_element(threadData)));
+        const double faultMax =
+            faultData.empty() ? 1.0 : std::max(m_SmoothedResources.pageFaults, static_cast<double>(*std::ranges::max_element(faultData)));
+        const double handleMax =
+            handleData.empty() ? 1.0 : std::max(m_SmoothedResources.handles, static_cast<double>(*std::ranges::max_element(handleData)));
 
 #ifdef _WIN32
         constexpr const char* handleLabel = "Handles";
@@ -966,23 +963,23 @@ void SystemMetricsPanel::renderOverview()
         constexpr const char* handleLabel = "FDs";
 #endif
 
-        const NowBar threadsBar{.valueText = UI::Format::formatCountWithLabel(std::llround(m_SmoothedThreadsFaults.threads), "threads"),
+        const NowBar threadsBar{.valueText = UI::Format::formatCountWithLabel(std::llround(m_SmoothedResources.threads), "threads"),
                                 .label = "Threads",
-                                .value01 = (threadMax > 0.0) ? std::clamp(m_SmoothedThreadsFaults.threads / threadMax, 0.0, 1.0) : 0.0,
+                                .value01 = (threadMax > 0.0) ? std::clamp(m_SmoothedResources.threads / threadMax, 0.0, 1.0) : 0.0,
                                 .color = theme.scheme().chartCpu};
-        const NowBar faultsBar{.valueText = UI::Format::formatCountPerSecond(m_SmoothedThreadsFaults.pageFaults),
+        const NowBar faultsBar{.valueText = UI::Format::formatCountPerSecond(m_SmoothedResources.pageFaults),
                                .label = "Page Faults",
-                               .value01 = (faultMax > 0.0) ? std::clamp(m_SmoothedThreadsFaults.pageFaults / faultMax, 0.0, 1.0) : 0.0,
+                               .value01 = (faultMax > 0.0) ? std::clamp(m_SmoothedResources.pageFaults / faultMax, 0.0, 1.0) : 0.0,
                                .color = theme.accentColor(3)};
-        const NowBar handlesBar{.valueText = UI::Format::formatCountWithLabel(std::llround(m_SmoothedThreadsFaults.handles), handleLabel),
+        const NowBar handlesBar{.valueText = UI::Format::formatCountWithLabel(std::llround(m_SmoothedResources.handles), handleLabel),
                                 .label = handleLabel,
-                                .value01 = (handleMax > 0.0) ? std::clamp(m_SmoothedThreadsFaults.handles / handleMax, 0.0, 1.0) : 0.0,
+                                .value01 = (handleMax > 0.0) ? std::clamp(m_SmoothedResources.handles / handleMax, 0.0, 1.0) : 0.0,
                                 .color = theme.scheme().chartMemory};
 
         auto plot = [&]()
         {
             const UI::Widgets::PlotFontGuard fontGuard;
-            if (ImPlot::BeginPlot("##ThreadsFaultsHistory", ImVec2(-1, HISTORY_PLOT_HEIGHT_DEFAULT), PLOT_FLAGS_DEFAULT))
+            if (ImPlot::BeginPlot("##ResourcesHistory", ImVec2(-1, HISTORY_PLOT_HEIGHT_DEFAULT), PLOT_FLAGS_DEFAULT))
             {
                 UI::Widgets::setupLegendDefault();
                 ImPlot::SetupAxes("Time (s)", nullptr, X_AXIS_FLAGS_DEFAULT, ImPlotAxisFlags_AutoFit | Y_AXIS_FLAGS_DEFAULT);
@@ -1024,8 +1021,9 @@ void SystemMetricsPanel::renderOverview()
             }
         };
 
-        ImGui::TextColored(theme.scheme().textPrimary, ICON_FA_GEARS "  Threads & Page Faults (%zu samples)", alignedCount);
-        renderHistoryWithNowBars("ThreadsFaultsHistoryLayout",
+        ImGui::TextColored(
+            theme.scheme().textPrimary, ICON_FA_GEARS "  Threads, Page Faults & %s (%zu samples)", handleLabel, alignedCount);
+        renderHistoryWithNowBars("ResourcesHistoryLayout",
                                  HISTORY_PLOT_HEIGHT_DEFAULT,
                                  plot,
                                  {threadsBar, faultsBar, handlesBar},
@@ -1251,25 +1249,22 @@ void SystemMetricsPanel::updateSmoothedPower(float targetWatts, float targetBatt
     m_SmoothedPower.batteryChargePercent = smoothTowards(m_SmoothedPower.batteryChargePercent, targetB, alpha);
 }
 
-void SystemMetricsPanel::updateSmoothedThreadsFaults(double targetThreads,
-                                                     double targetFaults,
-                                                     double targetHandles,
-                                                     float deltaTimeSeconds)
+void SystemMetricsPanel::updateSmoothedResources(double targetThreads, double targetFaults, double targetHandles, float deltaTimeSeconds)
 {
     const double alpha = computeAlpha(deltaTimeSeconds, m_RefreshInterval);
 
-    if (!m_SmoothedThreadsFaults.initialized)
+    if (!m_SmoothedResources.initialized)
     {
-        m_SmoothedThreadsFaults.threads = targetThreads;
-        m_SmoothedThreadsFaults.pageFaults = targetFaults;
-        m_SmoothedThreadsFaults.handles = targetHandles;
-        m_SmoothedThreadsFaults.initialized = true;
+        m_SmoothedResources.threads = targetThreads;
+        m_SmoothedResources.pageFaults = targetFaults;
+        m_SmoothedResources.handles = targetHandles;
+        m_SmoothedResources.initialized = true;
         return;
     }
 
-    m_SmoothedThreadsFaults.threads = smoothTowards(m_SmoothedThreadsFaults.threads, targetThreads, alpha);
-    m_SmoothedThreadsFaults.pageFaults = smoothTowards(m_SmoothedThreadsFaults.pageFaults, targetFaults, alpha);
-    m_SmoothedThreadsFaults.handles = smoothTowards(m_SmoothedThreadsFaults.handles, targetHandles, alpha);
+    m_SmoothedResources.threads = smoothTowards(m_SmoothedResources.threads, targetThreads, alpha);
+    m_SmoothedResources.pageFaults = smoothTowards(m_SmoothedResources.pageFaults, targetFaults, alpha);
+    m_SmoothedResources.handles = smoothTowards(m_SmoothedResources.handles, targetHandles, alpha);
 }
 
 } // namespace App

--- a/src/App/Panels/SystemMetricsPanel.h
+++ b/src/App/Panels/SystemMetricsPanel.h
@@ -124,13 +124,13 @@ class SystemMetricsPanel : public Panel
         bool initialized = false;
     } m_SmoothedPower;
 
-    struct SmoothedThreadsFaults
+    struct SmoothedResources
     {
         double threads = 0.0;
         double pageFaults = 0.0;
         double handles = 0.0;
         bool initialized = false;
-    } m_SmoothedThreadsFaults;
+    } m_SmoothedResources;
 
     struct SmoothedSystemIO
     {
@@ -169,7 +169,7 @@ class SystemMetricsPanel : public Panel
     void updateSmoothedMemory(const Domain::SystemSnapshot& snap, float deltaTimeSeconds);
     void updateSmoothedDiskIO(const Domain::StorageSnapshot& snap, float deltaTimeSeconds);
     void updateSmoothedPower(float targetWatts, float targetBatteryPercent, float deltaTimeSeconds);
-    void updateSmoothedThreadsFaults(double targetThreads, double targetFaults, double targetHandles, float deltaTimeSeconds);
+    void updateSmoothedResources(double targetThreads, double targetFaults, double targetHandles, float deltaTimeSeconds);
 };
 
 } // namespace App

--- a/src/App/Panels/SystemMetricsPanel.h
+++ b/src/App/Panels/SystemMetricsPanel.h
@@ -128,6 +128,7 @@ class SystemMetricsPanel : public Panel
     {
         double threads = 0.0;
         double pageFaults = 0.0;
+        double handles = 0.0;
         bool initialized = false;
     } m_SmoothedThreadsFaults;
 
@@ -168,7 +169,7 @@ class SystemMetricsPanel : public Panel
     void updateSmoothedMemory(const Domain::SystemSnapshot& snap, float deltaTimeSeconds);
     void updateSmoothedDiskIO(const Domain::StorageSnapshot& snap, float deltaTimeSeconds);
     void updateSmoothedPower(float targetWatts, float targetBatteryPercent, float deltaTimeSeconds);
-    void updateSmoothedThreadsFaults(double targetThreads, double targetFaults, float deltaTimeSeconds);
+    void updateSmoothedThreadsFaults(double targetThreads, double targetFaults, double targetHandles, float deltaTimeSeconds);
 };
 
 } // namespace App

--- a/src/Domain/ProcessModel.cpp
+++ b/src/Domain/ProcessModel.cpp
@@ -114,6 +114,7 @@ void ProcessModel::computeSnapshots(const std::vector<Platform::ProcessCounters>
     double aggNetRecv = 0.0;
     double aggPageFaults = 0.0;
     double aggThreads = 0.0;
+    double aggHandles = 0.0;
     double aggPower = 0.0;
 
     for (const auto& current : counters)
@@ -213,6 +214,7 @@ void ProcessModel::computeSnapshots(const std::vector<Platform::ProcessCounters>
         aggNetRecv += snapRef.netReceivedBytesPerSec;
         aggPageFaults += snapRef.pageFaultsPerSec;
         aggThreads += static_cast<double>(snapRef.threadCount);
+        aggHandles += static_cast<double>(snapRef.handleCount);
         aggPower += snapRef.powerWatts;
 
         m_PrevCounters[key] = current;
@@ -242,6 +244,7 @@ void ProcessModel::computeSnapshots(const std::vector<Platform::ProcessCounters>
         m_SystemNetRecvHistory.push_back(aggNetRecv);
         m_SystemPageFaultsHistory.push_back(aggPageFaults);
         m_SystemThreadCountHistory.push_back(aggThreads);
+        m_SystemHandleCountHistory.push_back(aggHandles);
         m_SystemPowerHistory.push_back(aggPower);
         trimHistory();
     }
@@ -275,6 +278,12 @@ std::vector<double> ProcessModel::systemThreadCountHistory() const
 {
     std::shared_lock lock(m_Mutex); // NOLINT(misc-const-correctness) - lock guard pattern
     return {m_SystemThreadCountHistory.begin(), m_SystemThreadCountHistory.end()};
+}
+
+std::vector<double> ProcessModel::systemHandleCountHistory() const
+{
+    std::shared_lock lock(m_Mutex); // NOLINT(misc-const-correctness) - lock guard pattern
+    return {m_SystemHandleCountHistory.begin(), m_SystemHandleCountHistory.end()};
 }
 
 std::vector<double> ProcessModel::systemPowerHistory() const
@@ -590,6 +599,7 @@ void ProcessModel::trimHistory()
     trimFront(m_SystemNetRecvHistory);
     trimFront(m_SystemPageFaultsHistory);
     trimFront(m_SystemThreadCountHistory);
+    trimFront(m_SystemHandleCountHistory);
     trimFront(m_SystemPowerHistory);
 }
 

--- a/src/Domain/ProcessModel.h
+++ b/src/Domain/ProcessModel.h
@@ -49,6 +49,7 @@ class ProcessModel
     [[nodiscard]] std::vector<double> systemNetRecvHistory() const;
     [[nodiscard]] std::vector<double> systemPageFaultsHistory() const;
     [[nodiscard]] std::vector<double> systemThreadCountHistory() const;
+    [[nodiscard]] std::vector<double> systemHandleCountHistory() const;
     [[nodiscard]] std::vector<double> systemPowerHistory() const;
     [[nodiscard]] std::vector<double> historyTimestamps() const;
 
@@ -132,6 +133,7 @@ class ProcessModel
     std::deque<double> m_SystemNetRecvHistory;
     std::deque<double> m_SystemPageFaultsHistory;
     std::deque<double> m_SystemThreadCountHistory;
+    std::deque<double> m_SystemHandleCountHistory;
     std::deque<double> m_SystemPowerHistory;
     std::deque<double> m_Timestamps;
     double m_MaxHistorySeconds = 300.0; // Align with Storage/System defaults

--- a/tests/Domain/test_ProcessModel.cpp
+++ b/tests/Domain/test_ProcessModel.cpp
@@ -1340,6 +1340,68 @@ TEST(ProcessModelTest, SystemThreadCountHistoryIsEmptyInitially)
     EXPECT_TRUE(history.empty());
 }
 
+TEST(ProcessModelTest, SystemHandleCountHistoryIsEmptyInitially)
+{
+    auto probe = std::make_unique<MockProcessProbe>();
+    Domain::ProcessModel model(std::move(probe));
+
+    auto history = model.systemHandleCountHistory();
+    EXPECT_TRUE(history.empty());
+}
+
+TEST(ProcessModelTest, SystemHandleCountHistoryAggregatesAcrossProcesses)
+{
+    auto probe = std::make_unique<MockProcessProbe>();
+    probe->setTotalCpuTime(100000);
+
+    auto* rawProbe = probe.get();
+    Domain::ProcessModel model{std::move(probe)};
+
+    // First sample — no history entry yet (needs two samples for a delta)
+    auto c1 = makeCounter(100, "proc_a", 'R', 1000, 500);
+    c1.handleCount = 10;
+    auto c2 = makeCounter(200, "proc_b", 'R', 2000, 1000);
+    c2.handleCount = 25;
+    rawProbe->setCounters({c1, c2});
+    model.refresh();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    c1.userTime += 100;
+    c2.userTime += 100;
+    rawProbe->setCounters({c1, c2});
+    model.refresh();
+
+    const auto history = model.systemHandleCountHistory();
+    ASSERT_FALSE(history.empty());
+    // Aggregated handle count should be the sum: 10 + 25 = 35
+    EXPECT_DOUBLE_EQ(history.back(), 35.0);
+}
+
+TEST(ProcessModelTest, SystemHandleCountHistoryAlignedWithTimestamps)
+{
+    auto probe = std::make_unique<MockProcessProbe>();
+    probe->setTotalCpuTime(100000);
+
+    auto* rawProbe = probe.get();
+    Domain::ProcessModel model{std::move(probe)};
+
+    auto counter = makeCounter(100, "proc_a", 'R', 1000, 500);
+    counter.handleCount = 5;
+    rawProbe->setCounters({counter});
+    model.refresh();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    counter.userTime += 100;
+    rawProbe->setCounters({counter});
+    model.refresh();
+
+    const auto timestamps = model.historyTimestamps();
+    const auto handleHistory = model.systemHandleCountHistory();
+    EXPECT_EQ(timestamps.size(), handleHistory.size());
+}
+
 TEST(ProcessModelTest, SystemPowerHistoryIsEmptyInitially)
 {
     auto probe = std::make_unique<MockProcessProbe>();


### PR DESCRIPTION
Closes #365

## Summary

Adds a system-wide Handles/FDs line to the existing **Threads & Page Faults** chart in the System Metrics Panel Overview tab.

## Changes

### Domain (`ProcessModel`)
- Added `m_SystemHandleCountHistory` deque alongside the existing thread/page-fault/power deques
- Accumulates `aggHandles` (sum of `snapRef.handleCount` across all processes) each sample
- Pushes to the deque and trims it in `trimHistory()` — strictly aligned with `historyTimestamps()`
- Added thread-safe `systemHandleCountHistory()` accessor

### UI (`SystemMetricsPanel`)
- Fetches `systemHandleCountHistory()` and aligns it with `procTimestamps`, `pageFaultHist`, `threadHist`
- Adds a third `plotLineWithFill` line using `theme.scheme().chartMemory` (consistent with ProcessDetailsPanel per-process handles chart)
- Adds a `handlesBar` NowBar entry with smoothed value
- Label is **"Handles"** on Windows, **"FDs"** on Linux (matching ProcessDetailsPanel)
- Hover tooltip shows handle count at the hovered timestamp
- Updated `SmoothedThreadsFaults` struct and `updateSmoothedThreadsFaults()` to track handles

### Tests
- `SystemHandleCountHistoryIsEmptyInitially` — baseline empty state
- `SystemHandleCountHistoryAggregatesAcrossProcesses` — two processes with 10 + 25 handles → 35 in history
- `SystemHandleCountHistoryAlignedWithTimestamps` — history size equals timestamp size

**782/782 tests pass.**