### PR TITLE
perf: cache inode-to-PID map with 3-second TTL in LinuxProcessProbe (#460)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ coverage-output.txt
 test-results.xml
 /sanitizer-logs/
 /sanitizer-reports/
+/*-report/
 clang-tidy-output.txt
 iwyu-output.txt
 

--- a/src/Domain/SamplingConfig.h
+++ b/src/Domain/SamplingConfig.h
@@ -61,6 +61,13 @@ inline constexpr int HISTORY_SECONDS_MAX = 1800; // 30 minutes
 // cache it for 60 seconds to avoid repeated sysfs reads.
 inline constexpr int64_t LINK_SPEED_CACHE_TTL_SECONDS = 60;
 
+// Cache TTL for inode-to-PID mapping (milliseconds) - Linux only
+// buildInodeToPidMap() scans /proc/[pid]/fd/* for all processes to resolve socket
+// inodes to owning PIDs. At 1Hz sampling this scan adds measurable latency on busy
+// systems. A 3-second TTL cuts rebuilds to ~once every 3 calls; short-lived staleness
+// is acceptable for network attribution since the mapping drifts slowly.
+inline constexpr int INODE_PID_CACHE_TTL_MS = 3000;
+
 // -----------------------------------------------------------------------------
 // Instance Enumeration Caches (User-Configurable via TOML)
 // -----------------------------------------------------------------------------

--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -4,6 +4,7 @@
 
 #include "LinuxProcessProbe.h"
 
+#include "Domain/SamplingConfig.h"
 #include "Platform/PlatformConfig.h"
 
 #if TASKSMACK_HAS_NETLINK_SOCKET_STATS
@@ -920,12 +921,18 @@ void LinuxProcessProbe::attributeNetworkToProcesses(std::vector<ProcessCounters>
         return;
     }
 
-    // Build inode-to-PID mapping by scanning /proc/[pid]/fd/*
-    // See https://github.com/mgradwohl/tasksmack/issues/460 for caching this mapping with a
-    //   TTL to reduce /proc scanning overhead on systems with many processes. Current approach
-    //   scans on each enumerate() call (~1Hz) which may add latency on systems with thousands
-    //   of processes.
-    const std::unordered_map<std::uint64_t, std::int32_t> inodeToPid = buildInodeToPidMap();
+    // Rebuild inode-to-PID map at most once per INODE_PID_CACHE_TTL_MS (3 s).
+    // buildInodeToPidMap() scans /proc/[pid]/fd/* for every process — expensive at scale.
+    // Caching reduces that cost by ~67% at the default 1Hz refresh rate with negligible
+    // staleness for network attribution purposes (closes #460).
+    const auto now = std::chrono::steady_clock::now();
+    const auto cacheAgeMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_InodeToPidCacheTime).count();
+    if (m_InodeToPidCache.empty() || cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS)
+    {
+        m_InodeToPidCache = buildInodeToPidMap();
+        m_InodeToPidCacheTime = now;
+    }
+    const auto& inodeToPid = m_InodeToPidCache;
     if (inodeToPid.empty())
     {
         return;

--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -923,26 +923,28 @@ void LinuxProcessProbe::attributeNetworkToProcesses(std::vector<ProcessCounters>
 
     // Rebuild inode-to-PID map at most once per INODE_PID_CACHE_TTL_MS.
     // buildInodeToPidMap() scans /proc/[pid]/fd/* for every process — expensive at scale.
-    // Caching reduces rebuilds; copy under lock to avoid races on the mutable cache members
-    // when enumerate() is called concurrently from multiple threads (see #460).
-    std::unordered_map<std::uint64_t, std::int32_t> inodeToPid;
+    // The map is stored as a shared_ptr so we copy only the pointer under the lock (O(1))
+    // rather than the entire map. Empty results are cached too, so a permission-restricted
+    // /proc environment does not trigger a rescan on every call (see #460).
+    std::shared_ptr<const std::unordered_map<std::uint64_t, std::int32_t>> inodeToPidPtr;
     {
         const std::scoped_lock lock{m_InodePidCacheMutex};
         const auto now = std::chrono::steady_clock::now();
         const auto cacheAgeMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_InodeToPidCacheTime).count();
-        if (m_InodeToPidCache.empty() || cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS)
+        if (cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS)
         {
-            m_InodeToPidCache = buildInodeToPidMap();
+            m_InodeToPidCache = std::make_shared<const std::unordered_map<std::uint64_t, std::int32_t>>(buildInodeToPidMap());
             m_InodeToPidCacheTime = now;
         }
-        inodeToPid = m_InodeToPidCache;
+        inodeToPidPtr = m_InodeToPidCache;
     }
-    if (inodeToPid.empty())
+    if (!inodeToPidPtr || inodeToPidPtr->empty())
     {
         return;
     }
 
     // Aggregate socket bytes by PID
+    const auto& inodeToPid = *inodeToPidPtr;
     const auto pidStats = aggregateByPid(sockets, inodeToPid);
 
     // Apply network stats to processes

--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -921,12 +921,10 @@ void LinuxProcessProbe::attributeNetworkToProcesses(std::vector<ProcessCounters>
         return;
     }
 
-    // Rebuild inode-to-PID map at most once per INODE_PID_CACHE_TTL_MS.
-    // buildInodeToPidMap() scans /proc/[pid]/fd/* for every process — expensive at scale.
-    // Double-checked pattern: decide under the lock whether a rebuild is needed, release
-    // the lock to do the scan (so concurrent threads can still use the previous cache),
-    // then re-lock briefly to publish. Empty results are cached too so a
-    // permission-restricted /proc environment does not rescan every call (see #460).
+    // Refresh inode-to-PID map on a TTL basis to avoid scanning /proc/[pid]/fd/* every
+    // enumerate(). The rebuild slot is claimed by advancing m_InodeToPidCacheTime under
+    // the initial lock, so only one thread rebuilds per TTL window while all others
+    // continue using the previous shared_ptr snapshot (see #460).
     std::shared_ptr<const std::unordered_map<std::uint64_t, std::int32_t>> inodeToPidPtr;
     bool needsRebuild = false;
     {
@@ -934,26 +932,22 @@ void LinuxProcessProbe::attributeNetworkToProcesses(std::vector<ProcessCounters>
         const auto now = std::chrono::steady_clock::now();
         const auto cacheAgeMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_InodeToPidCacheTime).count();
         needsRebuild = (cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS);
-        if (!needsRebuild)
+        if (needsRebuild)
         {
-            inodeToPidPtr = m_InodeToPidCache;
+            // Claim the rebuild slot: advance the timestamp now so any other thread that
+            // checks while we are scanning /proc sees a fresh time and skips rebuilding.
+            m_InodeToPidCacheTime = now;
         }
+        inodeToPidPtr = m_InodeToPidCache; // snapshot current (possibly stale) pointer
     }
     if (needsRebuild)
     {
-        // Build the map outside the lock so concurrent threads keep using the old cache.
+        // Build the map outside the lock; concurrent threads keep using the old snapshot.
         auto rebuilt = std::make_shared<const std::unordered_map<std::uint64_t, std::int32_t>>(buildInodeToPidMap());
-        const auto publishTime = std::chrono::steady_clock::now();
         {
             const std::scoped_lock lock{m_InodePidCacheMutex};
-            // Guard against two threads both deciding to rebuild: only publish if the
-            // cache is still older than the TTL (the other thread may have just refreshed it).
-            const auto cacheAgeMs = std::chrono::duration_cast<std::chrono::milliseconds>(publishTime - m_InodeToPidCacheTime).count();
-            if (cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS)
-            {
-                m_InodeToPidCache = std::move(rebuilt);
-                m_InodeToPidCacheTime = publishTime;
-            }
+            m_InodeToPidCache = std::move(rebuilt);
+            m_InodeToPidCacheTime = std::chrono::steady_clock::now();
             inodeToPidPtr = m_InodeToPidCache;
         }
     }

--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -921,18 +921,22 @@ void LinuxProcessProbe::attributeNetworkToProcesses(std::vector<ProcessCounters>
         return;
     }
 
-    // Rebuild inode-to-PID map at most once per INODE_PID_CACHE_TTL_MS (3 s).
+    // Rebuild inode-to-PID map at most once per INODE_PID_CACHE_TTL_MS.
     // buildInodeToPidMap() scans /proc/[pid]/fd/* for every process — expensive at scale.
-    // Caching reduces that cost by ~67% at the default 1Hz refresh rate with negligible
-    // staleness for network attribution purposes (closes #460).
-    const auto now = std::chrono::steady_clock::now();
-    const auto cacheAgeMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_InodeToPidCacheTime).count();
-    if (m_InodeToPidCache.empty() || cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS)
+    // Caching reduces rebuilds; copy under lock to avoid races on the mutable cache members
+    // when enumerate() is called concurrently from multiple threads (see #460).
+    std::unordered_map<std::uint64_t, std::int32_t> inodeToPid;
     {
-        m_InodeToPidCache = buildInodeToPidMap();
-        m_InodeToPidCacheTime = now;
+        const std::scoped_lock lock{m_InodePidCacheMutex};
+        const auto now = std::chrono::steady_clock::now();
+        const auto cacheAgeMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_InodeToPidCacheTime).count();
+        if (m_InodeToPidCache.empty() || cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS)
+        {
+            m_InodeToPidCache = buildInodeToPidMap();
+            m_InodeToPidCacheTime = now;
+        }
+        inodeToPid = m_InodeToPidCache;
     }
-    const auto& inodeToPid = m_InodeToPidCache;
     if (inodeToPid.empty())
     {
         return;

--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -946,9 +946,22 @@ void LinuxProcessProbe::attributeNetworkToProcesses(std::vector<ProcessCounters>
         auto rebuilt = std::make_shared<const std::unordered_map<std::uint64_t, std::int32_t>>(buildInodeToPidMap());
         {
             const std::scoped_lock lock{m_InodePidCacheMutex};
-            m_InodeToPidCache = std::move(rebuilt);
-            m_InodeToPidCacheTime = std::chrono::steady_clock::now();
-            inodeToPidPtr = m_InodeToPidCache;
+            if (!rebuilt->empty())
+            {
+                m_InodeToPidCache = std::move(rebuilt);
+                m_InodeToPidCacheTime = std::chrono::steady_clock::now();
+                inodeToPidPtr = m_InodeToPidCache;
+            }
+            else
+            {
+                // Preserve the previous snapshot when procfs enumeration transiently
+                // produces no entries; allow a quick retry instead of waiting the full TTL.
+                constexpr auto EMPTY_REBUILD_RETRY_MS = std::chrono::milliseconds{100};
+                const auto ttl = std::chrono::milliseconds{Domain::Sampling::INODE_PID_CACHE_TTL_MS};
+                const auto retryDelay = std::min(EMPTY_REBUILD_RETRY_MS, ttl);
+                m_InodeToPidCacheTime = std::chrono::steady_clock::now() - (ttl - retryDelay);
+                // inodeToPidPtr already holds the previous (possibly non-empty) snapshot
+            }
         }
     }
     if (!inodeToPidPtr || inodeToPidPtr->empty())

--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -923,20 +923,39 @@ void LinuxProcessProbe::attributeNetworkToProcesses(std::vector<ProcessCounters>
 
     // Rebuild inode-to-PID map at most once per INODE_PID_CACHE_TTL_MS.
     // buildInodeToPidMap() scans /proc/[pid]/fd/* for every process — expensive at scale.
-    // The map is stored as a shared_ptr so we copy only the pointer under the lock (O(1))
-    // rather than the entire map. Empty results are cached too, so a permission-restricted
-    // /proc environment does not trigger a rescan on every call (see #460).
+    // Double-checked pattern: decide under the lock whether a rebuild is needed, release
+    // the lock to do the scan (so concurrent threads can still use the previous cache),
+    // then re-lock briefly to publish. Empty results are cached too so a
+    // permission-restricted /proc environment does not rescan every call (see #460).
     std::shared_ptr<const std::unordered_map<std::uint64_t, std::int32_t>> inodeToPidPtr;
+    bool needsRebuild = false;
     {
         const std::scoped_lock lock{m_InodePidCacheMutex};
         const auto now = std::chrono::steady_clock::now();
         const auto cacheAgeMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_InodeToPidCacheTime).count();
-        if (cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS)
+        needsRebuild = (cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS);
+        if (!needsRebuild)
         {
-            m_InodeToPidCache = std::make_shared<const std::unordered_map<std::uint64_t, std::int32_t>>(buildInodeToPidMap());
-            m_InodeToPidCacheTime = now;
+            inodeToPidPtr = m_InodeToPidCache;
         }
-        inodeToPidPtr = m_InodeToPidCache;
+    }
+    if (needsRebuild)
+    {
+        // Build the map outside the lock so concurrent threads keep using the old cache.
+        auto rebuilt = std::make_shared<const std::unordered_map<std::uint64_t, std::int32_t>>(buildInodeToPidMap());
+        const auto publishTime = std::chrono::steady_clock::now();
+        {
+            const std::scoped_lock lock{m_InodePidCacheMutex};
+            // Guard against two threads both deciding to rebuild: only publish if the
+            // cache is still older than the TTL (the other thread may have just refreshed it).
+            const auto cacheAgeMs = std::chrono::duration_cast<std::chrono::milliseconds>(publishTime - m_InodeToPidCacheTime).count();
+            if (cacheAgeMs >= Domain::Sampling::INODE_PID_CACHE_TTL_MS)
+            {
+                m_InodeToPidCache = std::move(rebuilt);
+                m_InodeToPidCacheTime = publishTime;
+            }
+            inodeToPidPtr = m_InodeToPidCache;
+        }
     }
     if (!inodeToPidPtr || inodeToPidPtr->empty())
     {

--- a/src/Platform/Linux/LinuxProcessProbe.h
+++ b/src/Platform/Linux/LinuxProcessProbe.h
@@ -58,12 +58,13 @@ class LinuxProcessProbe : public IProcessProbe
     std::unique_ptr<NetlinkSocketStats> m_SocketStats;
     bool m_HasNetworkCounters = false;
 
-    // Inode-to-PID cache: rebuilt by buildInodeToPidMap() at most once per
-    // INODE_PID_CACHE_TTL_MS to avoid scanning /proc/[pid]/fd/* every enumerate().
-    // The map is stored behind a shared_ptr so callers copy the pointer (O(1)) rather
-    // than the entire map. m_InodePidCacheMutex guards both cache members; the mutex
-    // is necessary because tests (and production callers) may call enumerate()
-    // concurrently from multiple threads.
+    // Inode-to-PID cache: refreshed on a TTL basis to avoid scanning
+    // /proc/[pid]/fd/* every enumerate(). The claim timestamp is set under the
+    // initial lock so only one thread rebuilds per TTL window while others
+    // continue using the previous cache snapshot. The map is stored behind a
+    // shared_ptr so callers copy the pointer O(1) rather than the entire map.
+    // m_InodePidCacheMutex guards publication of both cache members; necessary
+    // because enumerate() may be called concurrently from multiple threads.
     mutable std::mutex m_InodePidCacheMutex;
     mutable std::shared_ptr<const std::unordered_map<std::uint64_t, std::int32_t>> m_InodeToPidCache;
     mutable std::chrono::steady_clock::time_point m_InodeToPidCacheTime;

--- a/src/Platform/Linux/LinuxProcessProbe.h
+++ b/src/Platform/Linux/LinuxProcessProbe.h
@@ -54,6 +54,11 @@ class LinuxProcessProbe : public IProcessProbe
     // Per-process network monitoring via Netlink INET_DIAG
     std::unique_ptr<NetlinkSocketStats> m_SocketStats;
     bool m_HasNetworkCounters = false;
+
+    // Inode-to-PID cache: rebuilt by buildInodeToPidMap() at most once per
+    // INODE_PID_CACHE_TTL_MS to avoid scanning /proc/[pid]/fd/* every enumerate().
+    mutable std::unordered_map<std::uint64_t, std::int32_t> m_InodeToPidCache;
+    mutable std::chrono::steady_clock::time_point m_InodeToPidCacheTime;
 #endif
 
     /// Parse /proc/[pid]/stat for a single process

--- a/src/Platform/Linux/LinuxProcessProbe.h
+++ b/src/Platform/Linux/LinuxProcessProbe.h
@@ -60,9 +60,12 @@ class LinuxProcessProbe : public IProcessProbe
 
     // Inode-to-PID cache: rebuilt by buildInodeToPidMap() at most once per
     // INODE_PID_CACHE_TTL_MS to avoid scanning /proc/[pid]/fd/* every enumerate().
-    // m_InodePidCacheMutex guards both cache members against concurrent enumerate() calls.
+    // The map is stored behind a shared_ptr so callers copy the pointer (O(1)) rather
+    // than the entire map. m_InodePidCacheMutex guards both cache members; the mutex
+    // is necessary because tests (and production callers) may call enumerate()
+    // concurrently from multiple threads.
     mutable std::mutex m_InodePidCacheMutex;
-    mutable std::unordered_map<std::uint64_t, std::int32_t> m_InodeToPidCache;
+    mutable std::shared_ptr<const std::unordered_map<std::uint64_t, std::int32_t>> m_InodeToPidCache;
     mutable std::chrono::steady_clock::time_point m_InodeToPidCacheTime;
 #endif
 

--- a/src/Platform/Linux/LinuxProcessProbe.h
+++ b/src/Platform/Linux/LinuxProcessProbe.h
@@ -5,6 +5,9 @@
 
 #if TASKSMACK_HAS_NETLINK_SOCKET_STATS
 #include "Platform/Linux/NetlinkSocketStats.h"
+
+#include <chrono>
+#include <unordered_map>
 #endif
 
 #include <atomic>
@@ -57,6 +60,8 @@ class LinuxProcessProbe : public IProcessProbe
 
     // Inode-to-PID cache: rebuilt by buildInodeToPidMap() at most once per
     // INODE_PID_CACHE_TTL_MS to avoid scanning /proc/[pid]/fd/* every enumerate().
+    // m_InodePidCacheMutex guards both cache members against concurrent enumerate() calls.
+    mutable std::mutex m_InodePidCacheMutex;
     mutable std::unordered_map<std::uint64_t, std::int32_t> m_InodeToPidCache;
     mutable std::chrono::steady_clock::time_point m_InodeToPidCacheTime;
 #endif


### PR DESCRIPTION
## Description

Closes #460

`buildInodeToPidMap()` scans `/proc/[pid]/fd/*` for every running process on **every** `enumerate()` call (~1 Hz). On systems with many processes this adds measurable latency proportional to process count.

**Fix:** cache the result behind a `shared_ptr<const map>` with a 3-second TTL (`INODE_PID_CACHE_TTL_MS`). A `mutable std::mutex` guards both cache members. The `/proc` scan runs **outside** the lock (double-checked pattern) so concurrent `enumerate()` calls can continue using the previous cache while one thread rebuilds — only the pointer swap and TTL update are done under the lock.

### Changes
| File | Change |
|---|---|
| `src/Domain/SamplingConfig.h` | Add `INODE_PID_CACHE_TTL_MS = 3000` under Platform-Level Optimization Caches |
| `src/Platform/Linux/LinuxProcessProbe.h` | Add `m_InodePidCacheMutex`, `m_InodeToPidCache` (shared_ptr), `m_InodeToPidCacheTime` inside `#if TASKSMACK_HAS_NETLINK_SOCKET_STATS`; explicit `<chrono>` / `<unordered_map>` includes |
| `src/Platform/Linux/LinuxProcessProbe.cpp` | Double-checked cache pattern: check TTL under lock, build outside lock, re-lock to publish |

## PR Size

Small

## Type of Change

- New feature (non-breaking change that adds functionality)

## Checklist

- I have read the CONTRIBUTING guidelines
- My code follows the project coding standards
- I have run clang-tidy and addressed any warnings
- I have run clang-format on my changes
- All new and existing tests pass