### PR TITLE
fix: resolve 11 clang-tidy warnings in DRMGPUProbe, PathService, AboutLayer

### DIFF
--- a/src/App/AboutLayer.cpp
+++ b/src/App/AboutLayer.cpp
@@ -203,7 +203,7 @@ void AboutLayer::loadIcon()
 
     constexpr std::array<const char*, 2> sizes = {"tasksmack-256.png", "tasksmack-128.png"};
 
-    for (const auto file : sizes)
+    for (const auto* const file : sizes)
     {
         const auto iconPath = iconsDir / file;
 

--- a/src/Core/PathService.cpp
+++ b/src/Core/PathService.cpp
@@ -4,6 +4,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include <filesystem>
 #include <string>
 #include <system_error>
 
@@ -30,7 +31,7 @@ namespace
 std::filesystem::path toAbsolute(const std::filesystem::path& raw)
 {
     std::error_code ec;
-    std::filesystem::path abs = std::filesystem::absolute(raw, ec);
+    const std::filesystem::path abs = std::filesystem::absolute(raw, ec);
     if (!ec)
     {
         return abs.lexically_normal();
@@ -40,7 +41,7 @@ std::filesystem::path toAbsolute(const std::filesystem::path& raw)
     if (raw.is_relative())
     {
         std::error_code cwdEc;
-        std::filesystem::path cwd = std::filesystem::current_path(cwdEc);
+        const std::filesystem::path cwd = std::filesystem::current_path(cwdEc);
         if (!cwdEc)
         {
             return (cwd / raw).lexically_normal();
@@ -66,7 +67,7 @@ std::filesystem::path toAbsolute(const std::filesystem::path& raw)
                          "Returning lexically-normalized raw path.",
                          rawStr);
         }
-        catch (...)
+        catch (...) // NOLINT(bugprone-empty-catch)
         {}
     }
     catch (...)
@@ -77,7 +78,7 @@ std::filesystem::path toAbsolute(const std::filesystem::path& raw)
                          "non-representable characters); both absolute() and current_path() failed. "
                          "Returning lexically-normalized raw path.");
         }
-        catch (...)
+        catch (...) // NOLINT(bugprone-empty-catch)
         {}
     }
     return raw.lexically_normal();

--- a/src/Platform/Linux/DRMGPUProbe.cpp
+++ b/src/Platform/Linux/DRMGPUProbe.cpp
@@ -8,6 +8,8 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <system_error>
+#include <utility>
 #include <vector>
 
 namespace Platform
@@ -86,7 +88,7 @@ std::vector<DRMGPUProbe::DRMCard> DRMGPUProbe::discoverDRMCards() const
     };
 
     // Iterate over DRM card entries
-    Fs::directory_iterator dirIter(m_DrmBasePath, fsErr);
+    const Fs::directory_iterator dirIter(m_DrmBasePath, fsErr);
     if (fsErr)
     {
         spdlog::debug("DRMGPUProbe: failed to open {} for iteration: {}", m_DrmBasePath, fsErr.message());


### PR DESCRIPTION
## Summary

Fixes 11 clang-tidy warnings found in the latest CI static-analysis run.

### Changes

**`src/Platform/Linux/DRMGPUProbe.cpp`**
- Add `<system_error>` and `<utility>` includes (`misc-include-cleaner`)
- Declare `dirIter` as `const` (`misc-const-correctness`)

**`src/Core/PathService.cpp`**
- Add `<filesystem>` include directly (`misc-include-cleaner`)
- Declare `abs` and `cwd` as `const` (`misc-const-correctness`)
- Suppress `bugprone-empty-catch` on both intentionally-empty fallback logging catch blocks (these are best-effort — swallowing exceptions is deliberate and documented)

**`src/App/AboutLayer.cpp`**
- Change loop variable to `const auto* const file` (`readability-qualified-auto`)

### Verification
- Local `clang-tidy completed successfully.` with 0 warnings
- Build: clean (659 files)