### PR TITLE
fix: load assets from bin layout and align debug launch targets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/build/debug/TaskSmack",
             "windows": {
-                "program": "${workspaceFolder}/build/win-debug/TaskSmack.exe"
+                "program": "${workspaceFolder}/build/win-debug/bin/TaskSmack.exe"
             },
             "args": [],
             "cwd": "${workspaceFolder}",
@@ -24,7 +24,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/build/relwithdebinfo/TaskSmack",
             "windows": {
-                "program": "${workspaceFolder}/build/win-relwithdebinfo/TaskSmack.exe"
+                "program": "${workspaceFolder}/build/win-relwithdebinfo/bin/TaskSmack.exe"
             },
             "args": [],
             "cwd": "${workspaceFolder}",
@@ -41,7 +41,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/build/release/TaskSmack",
             "windows": {
-                "program": "${workspaceFolder}/build/win-release/TaskSmack.exe"
+                "program": "${workspaceFolder}/build/win-release/bin/TaskSmack.exe"
             },
             "args": [],
             "cwd": "${workspaceFolder}",
@@ -59,7 +59,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/build/optimized/TaskSmack",
             "windows": {
-                "program": "${workspaceFolder}/build/win-optimized/TaskSmack.exe"
+                "program": "${workspaceFolder}/build/win-optimized/bin/TaskSmack.exe"
             },
             "args": [],
             "cwd": "${workspaceFolder}",

--- a/src/UI/AssetPath.cpp
+++ b/src/UI/AssetPath.cpp
@@ -44,7 +44,9 @@ std::filesystem::path selectAssetsDir(const std::filesystem::path& exeDir,
 
     // lexically_normal() resolves ".." without requiring the path to exist;
     // existence is validated below via probeExists.
-    const std::array<std::filesystem::path, 3> candidates = {
+    // For debug/developer workflows, prefer <exeDir>/bin/assets when present.
+    const std::array<std::filesystem::path, 4> candidates = {
+        exeDir / "bin" / "assets",
         exeDir / "assets",
         exeDir / dataDir / appName / "assets",
         (exeDir / ".." / dataDir / appName / "assets").lexically_normal(),
@@ -59,13 +61,14 @@ std::filesystem::path selectAssetsDir(const std::filesystem::path& exeDir,
         }
     }
 
-    spdlog::warn("Assets directory not found in any expected location; defaulting to {}", candidates[0].string());
-    return candidates[0];
+    const std::filesystem::path fallback = exeDir / "assets";
+    spdlog::warn("Assets directory not found in any expected location; defaulting to {}", fallback.string());
+    return fallback;
 }
 
 std::filesystem::path findAssetsDir()
 {
-    // Cache the resolved directory: filesystem probing (three exists() checks) is done
+    // Cache the resolved directory: filesystem probing (four exists() checks) is done
     // only once per process, even when multiple layers call findAssetsDir().
     // Use the error_code overload so filesystem errors (e.g. permission denied) are
     // treated as a non-match rather than propagating as exceptions.

--- a/src/UI/AssetPath.h
+++ b/src/UI/AssetPath.h
@@ -8,21 +8,23 @@ namespace UI
 
 /// Locate the runtime assets root directory by probing candidate paths in priority order.
 ///
-/// Supports three deployment layouts:
-///   1. Portable / build-dir:    \<exeDir\>/assets/
+/// Supports four deployment layouts:
+///   1. Developer / debug helper: \<exeDir\>/bin/assets/
+///      (when the executable directory is a build root and assets are copied under bin/)
+///   2. Portable / build-dir:      \<exeDir\>/assets/
 ///      (post-build copy, used during development and for portable installs)
-///   2. FHS, binary at prefix:   \<exeDir\>/share/\<project_name_lower\>/assets/
+///   3. FHS, binary at prefix:     \<exeDir\>/share/\<project_name_lower\>/assets/
 ///      (cmake --install PREFIX, binary lands at prefix root)
-///   3. FHS, binary in bin/:     \<exeDir\>/../share/\<project_name_lower\>/assets/
+///   4. FHS, binary in bin/:       \<exeDir\>/../share/\<project_name_lower\>/assets/
 ///      (standard Linux system install via DEB/RPM)
 ///
 /// The probe checks for the existence of the "fonts" subdirectory under each candidate.
-/// Returns the first match, or falls back to candidate 1 if none are found.
+/// Returns the first match, or falls back to \<exeDir\>/assets if none are found.
 [[nodiscard]] std::filesystem::path findAssetsDir();
 
 /// Testable inner implementation: selects the assets directory given a custom executable
 /// directory and an existence predicate. Probes candidate paths in priority order and
-/// returns the first for which \p probeExists returns true, or falls back to candidate 1.
+/// returns the first for which \p probeExists returns true, or falls back to \<exeDir\>/assets.
 [[nodiscard]] std::filesystem::path selectAssetsDir(const std::filesystem::path& exeDir,
                                                     const std::function<bool(const std::filesystem::path&)>& probeExists);
 

--- a/tests/UI/test_AssetPath.cpp
+++ b/tests/UI/test_AssetPath.cpp
@@ -12,19 +12,28 @@ namespace
 
 // ========== Candidate priority ==========
 
-TEST(AssetPathTest, ReturnsFirstCandidateWhenAllExist)
+TEST(AssetPathTest, ReturnsBinAssetsWhenAllCandidatesExist)
 {
-    // All candidates match: should return candidate 1 (build-dir layout)
+    // All candidates match: should return candidate 1 (bin/assets)
     const std::filesystem::path exeDir = "/fake/exe";
     const auto result = selectAssetsDir(exeDir, [](const std::filesystem::path& /*p*/) { return true; });
-    EXPECT_EQ(result, exeDir / "assets");
+    EXPECT_EQ(result, exeDir / "bin" / "assets");
+}
+
+TEST(AssetPathTest, ReturnsBinAssetsWhenExeDirIsBuildRoot)
+{
+    // Root executable layout: only <exeDir>/bin/assets exists.
+    const std::filesystem::path exeDir = "/fake/build-root";
+    const std::filesystem::path expected = exeDir / "bin" / "assets";
+    const auto result = selectAssetsDir(exeDir, [&](const std::filesystem::path& p) { return p == expected; });
+    EXPECT_EQ(result, expected);
 }
 
 TEST(AssetPathTest, SkipsFirstAndReturnsSecondCandidateOnMatch)
 {
-    // Only candidate 2 (FHS, binary at prefix root) matches
+    // Only candidate 2 (portable/build-dir assets) matches
     const std::filesystem::path exeDir = "/fake/prefix";
-    const std::filesystem::path expected = exeDir / TASKSMACK_INSTALL_DATADIR / TASKSMACK_PROJECT_NAME_LOWER / "assets";
+    const std::filesystem::path expected = exeDir / "assets";
     int callCount = 0;
     const auto result = selectAssetsDir(exeDir,
                                         [&](const std::filesystem::path& p)
@@ -36,13 +45,11 @@ TEST(AssetPathTest, SkipsFirstAndReturnsSecondCandidateOnMatch)
     EXPECT_EQ(callCount, 2); // candidate 1 was probed and missed
 }
 
-TEST(AssetPathTest, ReturnsThirdCandidateForFHSBinLayout)
+TEST(AssetPathTest, ReturnsThirdCandidateForFHSPrefixLayout)
 {
-    // Only candidate 3 (FHS, binary in bin/) matches
-    // exeDir = /usr/bin → candidate 3 = /usr/bin/../share/<app>/assets → /usr/share/<app>/assets
-    const std::filesystem::path exeDir = "/usr/bin";
-    const std::filesystem::path expected =
-        std::filesystem::path("/usr") / TASKSMACK_INSTALL_DATADIR / TASKSMACK_PROJECT_NAME_LOWER / "assets";
+    // Only candidate 3 (FHS, binary at prefix root) matches
+    const std::filesystem::path exeDir = "/fake/prefix";
+    const std::filesystem::path expected = exeDir / TASKSMACK_INSTALL_DATADIR / TASKSMACK_PROJECT_NAME_LOWER / "assets";
     int callCount = 0;
     const auto result = selectAssetsDir(exeDir,
                                         [&](const std::filesystem::path& p)
@@ -54,11 +61,29 @@ TEST(AssetPathTest, ReturnsThirdCandidateForFHSBinLayout)
     EXPECT_EQ(callCount, 3); // candidates 1 and 2 were probed and missed
 }
 
+TEST(AssetPathTest, ReturnsFourthCandidateForFHSBinLayout)
+{
+    // Only candidate 4 (FHS, binary in bin/) matches
+    // exeDir = /usr/bin → candidate 4 = /usr/bin/../share/<app>/assets → /usr/share/<app>/assets
+    const std::filesystem::path exeDir = "/usr/bin";
+    const std::filesystem::path expected =
+        std::filesystem::path("/usr") / TASKSMACK_INSTALL_DATADIR / TASKSMACK_PROJECT_NAME_LOWER / "assets";
+    int callCount = 0;
+    const auto result = selectAssetsDir(exeDir,
+                                        [&](const std::filesystem::path& p)
+                                        {
+                                            ++callCount;
+                                            return p == expected;
+                                        });
+    EXPECT_EQ(result, expected);
+    EXPECT_EQ(callCount, 4); // candidates 1, 2 and 3 were probed and missed
+}
+
 // ========== Fallback behavior ==========
 
 TEST(AssetPathTest, FallsBackToFirstCandidateWhenNoneExist)
 {
-    // No candidate matches: should return candidate 1 as fallback
+    // No candidate matches: should return <exeDir>/assets fallback
     const std::filesystem::path exeDir = "/nonexistent/exe";
     const auto result = selectAssetsDir(exeDir, [](const std::filesystem::path& /*p*/) { return false; });
     EXPECT_EQ(result, exeDir / "assets");


### PR DESCRIPTION
## Summary
This fixes missing fonts/themes when running Windows debug builds where assets are copied under `build/*/bin/assets`.

### Changes
- Runtime asset discovery now probes `bin/assets` first for developer/debug layout.
- Kept safe fallback to `<exeDir>/assets` if no candidate paths exist.
- Updated VS Code Windows launch configs to run from `build/*/bin/TaskSmack.exe`.
- Enhanced AssetPath unit tests with explicit build-root/bin-assets coverage.

### Why
In this layout, assets/fonts/themes exist in `build/win-debug/bin/assets`, while launch configs previously started `build/win-debug/TaskSmack.exe`, causing runtime lookup to miss fonts and fail startup.

## Validation
- Clean debug build: passed
- AssetPath tests: passed (6/6)
- Full test suite: passed (844/844, 2 expected skips)

## Files
- `.vscode/launch.json`
- `src/UI/AssetPath.cpp`
- `src/UI/AssetPath.h`
- `tests/UI/test_AssetPath.cpp`