### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(POLICY CMP0069)
 endif()
 
 
-project(TaskSmack VERSION 0.5.0 LANGUAGES C CXX)
+project(TaskSmack VERSION 0.6.0 LANGUAGES C CXX)
 
 # Windows: Configure MSVC runtime library linkage for Clang
 if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Bumps `CMakeLists.txt` project version from 0.5.0 to 0.6.0 in preparation for the v0.6.0 release.