### PR TITLE
fix: repair three post-merge workflow failures from #511

### DIFF
--- a/.github/workflows/heavy-checks.yml
+++ b/.github/workflows/heavy-checks.yml
@@ -28,6 +28,8 @@ jobs:
         uses: ./.github/actions/setup-llvm
         with:
           llvm-version: ${{ env.LLVM_VERSION }}
+          install-clang-tidy: 'true'
+          install-clangd: 'true'
           install-coverage-tools: 'true'
 
       - name: Setup Python for GLAD
@@ -158,7 +160,6 @@ jobs:
           retention-days: 30
 
       - name: Upload coverage to Codecov
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/heavy-checks.yml
+++ b/.github/workflows/heavy-checks.yml
@@ -30,6 +30,7 @@ jobs:
           llvm-version: ${{ env.LLVM_VERSION }}
           install-clang-tidy: 'true'
           install-clangd: 'true'
+          install-clang-format: 'true'
           install-coverage-tools: 'true'
 
       - name: Setup Python for GLAD

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -25,6 +25,8 @@ jobs:
         uses: ./.github/actions/setup-llvm
         with:
           llvm-version: ${{ env.LLVM_VERSION }}
+          install-clang-tidy: 'true'
+          install-clangd: 'true'
 
       - name: Setup Python for GLAD
         uses: ./.github/actions/setup-python-glad

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -27,6 +27,7 @@ jobs:
           llvm-version: ${{ env.LLVM_VERSION }}
           install-clang-tidy: 'true'
           install-clangd: 'true'
+          install-clang-format: 'true'
 
       - name: Setup Python for GLAD
         uses: ./.github/actions/setup-python-glad

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,6 @@ permissions:
   security-events: write
   id-token: write
   contents: read
-  actions: write
 
 jobs:
   analysis:


### PR DESCRIPTION
## What

Fixes all three workflow failures triggered by the push of commit `05f8d1cf` (PR #511) to main.

## Root Causes & Fixes

### 1. `scorecard.yml` — permission error ([run 25509071695](https://github.com/mgradwohl/tasksmack/actions/runs/25509071695))

**Root cause:** `actions: write` in the global `permissions:` block. The `ossf/scorecard-action` with `publish_results: true` explicitly rejects any global permission set to write beyond its allowed set (`security-events: write`, `id-token: write`, `contents: read`). Error: *"workflow verification failed: global perm is set to write: permission for actions is set to write"*.

**Fix:** Remove `actions: write` from the global permissions block. `actions/upload-artifact` does not require this permission in practice.

### 2. `sanitizers.yml` — clang-tidy/clangd not found ([run 25509071700](https://github.com/mgradwohl/tasksmack/actions/runs/25509071700))

**Root cause:** The `validate-environment` job called `setup-llvm` without `install-clang-tidy: 'true'` or `install-clangd: 'true'`. Only system clang-tidy 18 was present; `check-prereqs.sh` requires ≥22 and also checks that `clangd` is on PATH. Error: *"clang-tidy: 18 — minimum required 22"* and *"clangd: not found"*.

**Fix:** Add `install-clang-tidy: 'true'` and `install-clangd: 'true'` to the `validate-environment` setup-llvm call.

### 3. `heavy-checks.yml` — workflow file issue, 0 jobs queued ([run 25509070873](https://github.com/mgradwohl/tasksmack/actions/runs/25509070873))

**Root cause (a):** `if: ${{ secrets.CODECOV_TOKEN != '' }}` on the Codecov upload step. GitHub Actions does **not** permit the `secrets` context in `if:` expressions — the workflow parser rejects the expression entirely before queuing any jobs. Confirmed via `gh workflow run` which returned: *"failed to parse workflow: Unrecognized named-value: 'secrets'"*.

**Fix:** Remove the `if:` guard. The step already has `fail_ci_if_error: false`, so an empty or missing token won't fail the build.

**Root cause (b):** Same as #2 — `validate-environment` in `heavy-checks.yml` also lacked `install-clang-tidy` and `install-clangd`, so `check-prereqs.sh` would have failed once (a) was resolved.

**Fix:** Add both install flags to `validate-environment` setup-llvm call alongside the existing `install-coverage-tools: 'true'`.

## Files Changed

- `.github/workflows/scorecard.yml` — remove `actions: write`
- `.github/workflows/sanitizers.yml` — add clang-tidy and clangd install flags to `validate-environment`
- `.github/workflows/heavy-checks.yml` — remove invalid `secrets` if-expression; add clang-tidy and clangd install flags to `validate-environment`