### PR TITLE
fix: move scorecard workflow permissions to job level

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,15 +8,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  id-token: write
-  contents: read
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## What

Fixes the Scorecard analysis job failure in [run 25564882873](https://github.com/mgradwohl/tasksmack/actions/runs/25564882873/job/75045679735).

## Root Cause

The scorecard webapp has tightened its workflow restrictions and now rejects **any** write permission at the global level — including `security-events: write`. The full error:

```
workflow verification failed: global perm is set to write: permission for security-events is set to write
```

PR #514 removed `actions: write` from the global block, but `security-events: write` and `id-token: write` remained there. The webapp previously only objected to `actions: write`; it now enforces that no write permissions exist globally.

## Fix

Set global `permissions: read-all` and move the three permissions the `analysis` job actually needs (`security-events: write`, `id-token: write`, `contents: read`) down to the job level. This matches the pattern required by the [ossf/scorecard-action workflow restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions) documentation.