### PR TITLE
test: PR2 coverage — UserConfig load/save, SystemModel power, ThemeLoader array colors

### DIFF
--- a/tests/App/test_UserConfig.cpp
+++ b/tests/App/test_UserConfig.cpp
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <random>
 #include <string>
 #include <utility>
 #include <vector>
@@ -285,11 +286,29 @@ class UserConfigLoadSaveTest : public ::testing::Test
         // Save the original path so TearDown can restore it.
         m_OriginalPath = UserConfig::get().configPath();
 
-        m_TempDir = std::filesystem::temp_directory_path() / "tasksmack_test_userconfig";
-        // Remove any leftovers from a prior run before recreating
-        std::error_code ec;
-        std::filesystem::remove_all(m_TempDir, ec);
-        std::filesystem::create_directories(m_TempDir);
+        // Create a unique temp directory exclusive to this test process.
+        // Use std::random_device + a create_directory retry loop so we
+        // provably start with a fresh, exclusive directory. ctest runs each
+        // test executable in a separate process with -j$(nproc); a retry loop is the
+        // only reliable way to guarantee we never share state between tests.
+        const auto base = std::filesystem::temp_directory_path() / "tasksmack_ucls_";
+        std::random_device rd;
+        constexpr int kMaxRetries = 100;
+        for (int attempt = 0; attempt < kMaxRetries; ++attempt)
+        {
+            m_TempDir = base;
+            m_TempDir += std::to_string(rd());
+            std::error_code ec;
+            if (std::filesystem::create_directory(m_TempDir, ec) && !ec)
+            {
+                break;
+            }
+            if (attempt == kMaxRetries - 1)
+            {
+                FAIL() << "Failed to create unique temp directory after " << kMaxRetries << " attempts";
+            }
+        }
+
         m_ConfigPath = m_TempDir / "config.toml";
         // Reset singleton to a clean state pointing at our temp file
         UserConfig::get().resetConfigPathForTesting(m_ConfigPath);

--- a/tests/App/test_UserConfig.cpp
+++ b/tests/App/test_UserConfig.cpp
@@ -6,8 +6,11 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
+#include <fstream>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace App
 {
@@ -272,9 +275,149 @@ TEST(UserSettingsTest, ZeroWindowDimensionsAreStorable)
     EXPECT_EQ(settings.windowHeight, 0);
 }
 
-// Note: Additional integration tests for the helper functions would require
-// refactoring UserConfig to accept a configurable path for testing, as it
-// currently uses a singleton pattern with a fixed config location.
+// ========== UserConfig load() / save() integration (uses resetConfigPathForTesting) ==========
+
+class UserConfigLoadSaveTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        m_TempDir = std::filesystem::temp_directory_path() / "tasksmack_test_userconfig";
+        // Remove any leftovers from a prior run before recreating
+        std::error_code ec;
+        std::filesystem::remove_all(m_TempDir, ec);
+        std::filesystem::create_directories(m_TempDir);
+        m_ConfigPath = m_TempDir / "config.toml";
+        // Reset singleton to a clean state pointing at our temp file
+        UserConfig::get().resetConfigPathForTesting(m_ConfigPath);
+    }
+
+    void TearDown() override
+    {
+        // Reset again so subsequent tests start clean
+        UserConfig::get().resetConfigPathForTesting(m_ConfigPath);
+        std::error_code ec;
+        std::filesystem::remove_all(m_TempDir, ec);
+    }
+
+    std::filesystem::path m_TempDir;
+    std::filesystem::path m_ConfigPath;
+};
+
+TEST_F(UserConfigLoadSaveTest, LoadDoesNothingWhenFileAbsent)
+{
+    UserConfig::get().load();
+    // Should keep defaults
+    EXPECT_EQ(UserConfig::get().settings().refreshIntervalMs, Domain::Sampling::REFRESH_INTERVAL_DEFAULT_MS);
+}
+
+TEST_F(UserConfigLoadSaveTest, LoadIsIdempotent)
+{
+    // First load seeds defaults; second call must be a no-op (isLoaded guard)
+    UserConfig::get().load();
+    UserConfig::get().settings().refreshIntervalMs = 9999;
+    UserConfig::get().load(); // should not re-read or reset
+    EXPECT_EQ(UserConfig::get().settings().refreshIntervalMs, 9999);
+}
+
+TEST_F(UserConfigLoadSaveTest, LoadHandlesTomlParseError)
+{
+    // Unclosed string literal — causes toml::parse_error (EOF in string)
+    // without triggering parser debug assertions
+    {
+        std::ofstream f(m_ConfigPath);
+        f << "interval_ms = \"unclosed string\n";
+    }
+    UserConfig::get().load(); // should not throw
+    EXPECT_EQ(UserConfig::get().settings().refreshIntervalMs, Domain::Sampling::REFRESH_INTERVAL_DEFAULT_MS);
+}
+
+TEST_F(UserConfigLoadSaveTest, LoadSwapsProgressThresholdsWhenInverted)
+{
+    // Write a config where low > high — load() must swap them
+    {
+        std::ofstream f(m_ConfigPath);
+        f << "[ui]\n";
+        f << "progress_color_low_threshold = 80.0\n";
+        f << "progress_color_high_threshold = 20.0\n";
+    }
+    UserConfig::get().load();
+    const auto& s = UserConfig::get().settings();
+    EXPECT_LE(s.progressColorLowThreshold, s.progressColorHighThreshold);
+}
+
+TEST_F(UserConfigLoadSaveTest, LoadParsesAllFontSizes)
+{
+    const std::vector<std::pair<std::string, UI::FontSize>> cases = {
+        {"small", UI::FontSize::Small},
+        {"medium", UI::FontSize::Medium},
+        {"large", UI::FontSize::Large},
+        {"extra-large", UI::FontSize::ExtraLarge},
+        {"huge", UI::FontSize::Huge},
+        {"even-huger", UI::FontSize::EvenHuger},
+    };
+
+    for (const auto& [str, expected] : cases)
+    {
+        UserConfig::get().resetConfigPathForTesting(m_ConfigPath);
+        {
+            std::ofstream f(m_ConfigPath);
+            f << "[font]\nsize = \"" << str << "\"\n";
+        }
+        UserConfig::get().load();
+        EXPECT_EQ(UserConfig::get().settings().fontSize, expected) << "Failed for font size: " << str;
+    }
+}
+
+TEST_F(UserConfigLoadSaveTest, LoadClampsInsaneWindowPosition)
+{
+    // Values far outside ±100000 must be reset to nullopt
+    {
+        std::ofstream f(m_ConfigPath);
+        f << "[window]\n";
+        f << "x = 999999999\n";
+        f << "y = -999999999\n";
+    }
+    UserConfig::get().load();
+    EXPECT_FALSE(UserConfig::get().settings().windowPosX.has_value());
+    EXPECT_FALSE(UserConfig::get().settings().windowPosY.has_value());
+}
+
+TEST_F(UserConfigLoadSaveTest, SaveCreatesFileAndRoundTrips)
+{
+    auto& cfg = UserConfig::get();
+    cfg.settings().refreshIntervalMs = 2000;
+    cfg.settings().themeId = "dracula";
+    cfg.settings().windowPosX = 150;
+    cfg.settings().windowPosY = 250;
+    cfg.save();
+
+    ASSERT_TRUE(std::filesystem::exists(m_ConfigPath));
+
+    cfg.resetConfigPathForTesting(m_ConfigPath);
+    cfg.load();
+    EXPECT_EQ(cfg.settings().refreshIntervalMs, 2000);
+    EXPECT_EQ(cfg.settings().themeId, "dracula");
+    EXPECT_TRUE(cfg.settings().windowPosX.has_value());
+    EXPECT_EQ(*cfg.settings().windowPosX, 150);
+    EXPECT_TRUE(cfg.settings().windowPosY.has_value());
+    EXPECT_EQ(*cfg.settings().windowPosY, 250);
+}
+
+TEST_F(UserConfigLoadSaveTest, SaveWithNoOptionalWindowPos)
+{
+    auto& cfg = UserConfig::get();
+    cfg.settings().windowPosX.reset();
+    cfg.settings().windowPosY.reset();
+    cfg.save();
+
+    ASSERT_TRUE(std::filesystem::exists(m_ConfigPath));
+
+    cfg.resetConfigPathForTesting(m_ConfigPath);
+    cfg.load();
+    EXPECT_FALSE(cfg.settings().windowPosX.has_value());
+    EXPECT_FALSE(cfg.settings().windowPosY.has_value());
+}
 
 } // namespace
 } // namespace App

--- a/tests/App/test_UserConfig.cpp
+++ b/tests/App/test_UserConfig.cpp
@@ -282,6 +282,9 @@ class UserConfigLoadSaveTest : public ::testing::Test
   protected:
     void SetUp() override
     {
+        // Save the original path so TearDown can restore it.
+        m_OriginalPath = UserConfig::get().configPath();
+
         m_TempDir = std::filesystem::temp_directory_path() / "tasksmack_test_userconfig";
         // Remove any leftovers from a prior run before recreating
         std::error_code ec;
@@ -294,14 +297,16 @@ class UserConfigLoadSaveTest : public ::testing::Test
 
     void TearDown() override
     {
-        // Reset again so subsequent tests start clean
-        UserConfig::get().resetConfigPathForTesting(m_ConfigPath);
+        // Restore the real platform config path before removing the temp directory,
+        // so the singleton is never left pointing at a non-existent file.
+        UserConfig::get().resetConfigPathForTesting(m_OriginalPath);
         std::error_code ec;
         std::filesystem::remove_all(m_TempDir, ec);
     }
 
     std::filesystem::path m_TempDir;
     std::filesystem::path m_ConfigPath;
+    std::filesystem::path m_OriginalPath;
 };
 
 TEST_F(UserConfigLoadSaveTest, LoadDoesNothingWhenFileAbsent)

--- a/tests/Domain/test_SystemModel.cpp
+++ b/tests/Domain/test_SystemModel.cpp
@@ -12,6 +12,7 @@
 #include "Domain/SamplingConfig.h"
 #include "Domain/SystemModel.h"
 #include "Mocks/MockProbes.h"
+#include "Platform/PowerTypes.h"
 #include "Platform/SystemTypes.h"
 
 #include <gtest/gtest.h>
@@ -25,6 +26,7 @@ using TestMocks::makeCpuCounters;
 using TestMocks::makeInterfaceCounters;
 using TestMocks::makeMemoryCounters;
 using TestMocks::makeSystemCounters;
+using TestMocks::MockPowerProbe;
 using TestMocks::MockSystemProbe;
 
 // =============================================================================
@@ -1281,4 +1283,113 @@ TEST(SystemModelTest, BatteryChargeHistoryTracked)
     // Battery charge history should exist
     auto chargeHist = model.batteryChargeHistory();
     EXPECT_FALSE(chargeHist.empty());
+}
+
+// =============================================================================
+// Power Status (computePowerStatus via refresh)
+// =============================================================================
+
+TEST(SystemModelTest, PowerStatus_NoBattery_WhenNoPowerProbe)
+{
+    auto probe = std::make_unique<MockSystemProbe>();
+    probe->setCounters(makeSystemCounters(makeCpuCounters(0, 0, 0, 1000), makeMemoryCounters(1024, 512)));
+
+    Domain::SystemModel model(std::move(probe)); // no power probe
+    model.refresh();
+
+    EXPECT_FALSE(model.snapshot().power.hasBattery);
+}
+
+TEST(SystemModelTest, PowerStatus_HasBattery_WhenPowerProbeReportsIt)
+{
+    auto sysProbe = std::make_unique<MockSystemProbe>();
+    sysProbe->setCounters(makeSystemCounters(makeCpuCounters(0, 0, 0, 1000), makeMemoryCounters(1024, 512)));
+
+    auto powerProbe = std::make_unique<MockPowerProbe>();
+    Platform::PowerCapabilities caps;
+    caps.hasBattery = true;
+    powerProbe->setCapabilities(caps);
+
+    Platform::PowerCounters counters;
+    counters.state = Platform::BatteryState::Discharging;
+    counters.isOnAc = false;
+    counters.chargePercent = 75;
+    counters.powerNowW = 12.5;
+    counters.healthPercent = 95;
+    counters.technology = "Li-ion";
+    counters.model = "TestBattery";
+    counters.timeToEmptySec = 7200;
+    powerProbe->setCounters(counters);
+
+    Domain::SystemModel model(std::move(sysProbe), std::move(powerProbe));
+    model.refresh();
+
+    const auto& power = model.snapshot().power;
+    EXPECT_TRUE(power.hasBattery);
+    EXPECT_FALSE(power.isOnAc);
+    EXPECT_FALSE(power.isCharging);
+    EXPECT_TRUE(power.isDischarging);
+    EXPECT_FALSE(power.isFull);
+    EXPECT_EQ(power.chargePercent, 75);
+    EXPECT_DOUBLE_EQ(power.powerWatts, 12.5);
+    EXPECT_EQ(power.healthPercent, 95);
+    EXPECT_EQ(power.technology, "Li-ion");
+    EXPECT_EQ(power.model, "TestBattery");
+    EXPECT_EQ(power.timeToEmptySec, 7200ULL);
+}
+
+TEST(SystemModelTest, PowerStatus_Charging)
+{
+    auto sysProbe = std::make_unique<MockSystemProbe>();
+    sysProbe->setCounters(makeSystemCounters(makeCpuCounters(0, 0, 0, 1000), makeMemoryCounters(1024, 512)));
+
+    auto powerProbe = std::make_unique<MockPowerProbe>();
+    Platform::PowerCapabilities caps;
+    caps.hasBattery = true;
+    powerProbe->setCapabilities(caps);
+
+    Platform::PowerCounters counters;
+    counters.state = Platform::BatteryState::Charging;
+    counters.isOnAc = true;
+    counters.chargePercent = 50;
+    counters.timeToFullSec = 3600;
+    powerProbe->setCounters(counters);
+
+    Domain::SystemModel model(std::move(sysProbe), std::move(powerProbe));
+    model.refresh();
+
+    const auto& power = model.snapshot().power;
+    EXPECT_TRUE(power.hasBattery);
+    EXPECT_TRUE(power.isOnAc);
+    EXPECT_TRUE(power.isCharging);
+    EXPECT_FALSE(power.isDischarging);
+    EXPECT_FALSE(power.isFull);
+    EXPECT_EQ(power.timeToFullSec, 3600ULL);
+}
+
+TEST(SystemModelTest, PowerStatus_Full)
+{
+    auto sysProbe = std::make_unique<MockSystemProbe>();
+    sysProbe->setCounters(makeSystemCounters(makeCpuCounters(0, 0, 0, 1000), makeMemoryCounters(1024, 512)));
+
+    auto powerProbe = std::make_unique<MockPowerProbe>();
+    Platform::PowerCapabilities caps;
+    caps.hasBattery = true;
+    powerProbe->setCapabilities(caps);
+
+    Platform::PowerCounters counters;
+    counters.state = Platform::BatteryState::Full;
+    counters.isOnAc = true;
+    counters.chargePercent = 100;
+    powerProbe->setCounters(counters);
+
+    Domain::SystemModel model(std::move(sysProbe), std::move(powerProbe));
+    model.refresh();
+
+    const auto& power = model.snapshot().power;
+    EXPECT_TRUE(power.hasBattery);
+    EXPECT_TRUE(power.isOnAc);
+    EXPECT_FALSE(power.isCharging);
+    EXPECT_FALSE(power.isDischarging);
+    EXPECT_TRUE(power.isFull);
 }

--- a/tests/Mocks/MockProbes.h
+++ b/tests/Mocks/MockProbes.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
+#include "Platform/IPowerProbe.h"
 #include "Platform/IProcessProbe.h"
 #include "Platform/ISystemProbe.h"
+#include "Platform/PowerTypes.h"
 #include "Platform/ProcessTypes.h"
 #include "Platform/SystemTypes.h"
 
@@ -364,6 +366,39 @@ class MockSystemProbe : public Platform::ISystemProbe
     Platform::SystemCapabilities m_Capabilities;
     long m_TicksPerSecond = 100;
     std::atomic<int> m_ReadCount{0};
+};
+
+// =============================================================================
+// Mock Power Probe
+// =============================================================================
+
+/// Mock implementation of IPowerProbe for testing.
+class MockPowerProbe : public Platform::IPowerProbe
+{
+  public:
+    void setCounters(Platform::PowerCounters counters)
+    {
+        m_Counters = std::move(counters);
+    }
+
+    void setCapabilities(Platform::PowerCapabilities caps)
+    {
+        m_Capabilities = caps;
+    }
+
+    [[nodiscard]] Platform::PowerCounters read() override
+    {
+        return m_Counters;
+    }
+
+    [[nodiscard]] Platform::PowerCapabilities capabilities() const override
+    {
+        return m_Capabilities;
+    }
+
+  private:
+    Platform::PowerCounters m_Counters;
+    Platform::PowerCapabilities m_Capabilities;
 };
 
 // =============================================================================

--- a/tests/Mocks/MockProbes.h
+++ b/tests/Mocks/MockProbes.h
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace TestMocks

--- a/tests/UI/test_ThemeLoader.cpp
+++ b/tests/UI/test_ThemeLoader.cpp
@@ -185,7 +185,8 @@ modal_window_dim_background = "#0000004D"
 }
 
 // Build a full-valid theme body with the [charts].cpu value replaced by cpuValue.
-// Accepts any TOML value: a hex string (e.g. "#FF0000") or an array (e.g. "[0.0, 0.47, 0.83]").
+// Accepts any valid TOML value for cpu, e.g. a quoted hex string ("#FF0000")
+// or an array ([0.0, 0.47, 0.83]).
 // Used by tests that exercise the array-format color parsing path for chart colors.
 [[nodiscard]] auto buildFullThemeWithCpuColor(std::string_view cpuValue) -> std::string
 {

--- a/tests/UI/test_ThemeLoader.cpp
+++ b/tests/UI/test_ThemeLoader.cpp
@@ -184,6 +184,40 @@ modal_window_dim_background = "#0000004D"
     return body;
 }
 
+// Build a full-valid theme body with the [charts].cpu value replaced by cpuValue.
+// Accepts any TOML value: a hex string (e.g. "#FF0000") or an array (e.g. "[0.0, 0.47, 0.83]").
+// Used by tests that exercise the array-format color parsing path for chart colors.
+[[nodiscard]] auto buildFullThemeWithCpuColor(std::string_view cpuValue) -> std::string
+{
+    std::string body = k_FullThemeTomlBody;
+    // Replace the cpu line — it appears exactly once in [charts].
+    const std::string oldLine = "cpu = \"#0078D4\"";
+    const std::size_t pos = body.find(oldLine);
+    if (pos == std::string::npos)
+    {
+        throw std::runtime_error("buildFullThemeWithCpuColor: cpu key not found in k_FullThemeTomlBody");
+    }
+    body.replace(pos, oldLine.size(), std::string("cpu = ") + std::string(cpuValue));
+    return body;
+}
+
+// Build a full-valid theme body with the [accents].colors value replaced by accentsValue.
+// Accepts any TOML array value, e.g. a mixed array of hex strings and inline [r,g,b] arrays.
+// Used by tests that exercise the array-element color parsing path for accents.
+[[nodiscard]] auto buildFullThemeWithAccents(std::string_view accentsValue) -> std::string
+{
+    std::string body = k_FullThemeTomlBody;
+    // Replace the colors line — it appears exactly once in [accents].
+    const std::string oldLine = R"(colors = ["#0078D4", "#E74856", "#10893E", "#8E8CD8", "#F7630C", "#00B7C3", "#FFB900", "#E3008C"])";
+    const std::size_t pos = body.find(oldLine);
+    if (pos == std::string::npos)
+    {
+        throw std::runtime_error("buildFullThemeWithAccents: colors key not found in k_FullThemeTomlBody");
+    }
+    body.replace(pos, oldLine.size(), std::string("colors = ") + std::string(accentsValue));
+    return body;
+}
+
 // ========== hexToImVec4 Tests ==========
 
 TEST(ThemeLoaderTest, HexToImVec4_ValidSixDigit)
@@ -1414,149 +1448,9 @@ TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_PriorityBadgeTextColor_DefaultsToWhit
 
 TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_ArrayColorRgbForChartCpu)
 {
-    // Use inline [r, g, b] array format for charts.cpu (exercises parseColorView array path)
-    const std::string body = R"(
-[meta]
-name = "Array RGB Charts"
-
-[accents]
-colors = ["#0078D4", "#E74856", "#10893E", "#8E8CD8", "#F7630C", "#00B7C3", "#FFB900", "#E3008C"]
-
-[progress]
-low = "#00FF00"
-medium = "#FFFF00"
-high = "#FF0000"
-
-[semantic]
-text_primary = "#FFFFFF"
-text_disabled = "#808080"
-text_muted = "#CCCCCC"
-text_error = "#FF0000"
-text_warning = "#FFA500"
-text_success = "#00FF00"
-text_info = "#00FFFF"
-
-[status]
-running = "#00FF00"
-sleeping = "#0000FF"
-disk_sleep = "#FFA500"
-zombie = "#FF0000"
-stopped = "#FF00FF"
-idle = "#808080"
-
-[charts]
-cpu = [0.0, 0.47, 0.83]
-memory = "#10893E"
-io = "#E74856"
-io_write = "#F7630C"
-
-[cpu_breakdown]
-user = "#0078D4"
-system = "#E74856"
-iowait = "#FFB900"
-idle = "#808080"
-
-[charts.gpu]
-utilization = "#0078D4"
-memory = "#10893E"
-temperature = "#E74856"
-power = "#FFB900"
-encoder = "#00B7C3"
-decoder = "#8E8CD8"
-clock = "#E3008C"
-fan = "#808080"
-
-[buttons.success]
-normal = "#10893E"
-hovered = "#2AA84E"
-active = "#0A6B2E"
-
-[ui.window]
-background = "#1E1E1E"
-child_background = "#252526"
-popup_background = "#2D2D30"
-border = "#3F3F46"
-
-[ui.frame]
-background = "#333337"
-background_hovered = "#3E3E42"
-background_active = "#0078D4"
-
-[ui.title]
-background = "#2D2D30"
-background_active = "#0078D4"
-background_collapsed = "#3F3F46"
-
-[ui.bars]
-menu = "#2D2D30"
-status = "#2D2D30"
-
-[ui.scrollbar]
-background = "#1E1E1E"
-grab = "#5A5A5A"
-grab_hovered = "#808080"
-grab_active = "#0078D4"
-
-[ui.controls]
-check_mark = "#FFFFFF"
-slider_grab = "#5A5A5A"
-slider_grab_active = "#0078D4"
-
-[ui.button]
-normal = "#333337"
-hovered = "#3E3E42"
-active = "#0078D4"
-
-[ui.header]
-normal = "#333337"
-hovered = "#3E3E42"
-active = "#0078D4"
-
-[ui.separator]
-normal = "#3F3F46"
-hovered = "#5A5A5A"
-active = "#0078D4"
-
-[ui.resize_grip]
-normal = "#3F3F46"
-hovered = "#5A5A5A"
-active = "#0078D4"
-
-[ui.tab]
-normal = "#2D2D30"
-hovered = "#3E3E42"
-active = "#0078D4"
-active_overline = "#FFFFFF"
-unfocused = "#252526"
-unfocused_active = "#3F3F46"
-unfocused_active_overline = "#808080"
-
-[ui.docking]
-preview = "#0078D480"
-empty_background = "#1E1E1E"
-
-[ui.plot]
-lines = "#0078D4"
-lines_hovered = "#60CDFF"
-histogram = "#10893E"
-histogram_hovered = "#6CCB5F"
-
-[ui.table]
-header_background = "#333337"
-border_strong = "#3F3F46"
-border_light = "#2D2D30"
-row_background = "#00000000"
-row_background_alt = "#FFFFFF0D"
-
-[ui.misc]
-text_selected_background = "#0078D480"
-drag_drop_target = "#FFB900"
-nav_highlight = "#0078D4"
-nav_windowing_highlight = "#FFFFFFB3"
-nav_windowing_dim_background = "#0000004D"
-modal_window_dim_background = "#0000004D"
-)";
-    createThemeFile("array-rgb-charts.toml", body);
+    // [r, g, b] array exercises parseColorView array path; alpha defaults to 1.0
+    const std::string toml = std::string("[meta]\nname = \"Array RGB Charts\"\n\n") + buildFullThemeWithCpuColor("[0.0, 0.47, 0.83]");
+    createThemeFile("array-rgb-charts.toml", toml);
 
     auto theme = ThemeLoader::loadTheme(m_TempDir / "array-rgb-charts.toml");
     ASSERT_TRUE(theme.has_value());
@@ -1570,149 +1464,10 @@ modal_window_dim_background = "#0000004D"
 
 TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_ArrayColorRgbaForChartCpu)
 {
-    // Use inline [r, g, b, a] array format (exercises parseColorView with explicit alpha)
-    const std::string body = R"(
-[meta]
-name = "Array RGBA Charts"
-
-[accents]
-colors = ["#0078D4", "#E74856", "#10893E", "#8E8CD8", "#F7630C", "#00B7C3", "#FFB900", "#E3008C"]
-
-[progress]
-low = "#00FF00"
-medium = "#FFFF00"
-high = "#FF0000"
-
-[semantic]
-text_primary = "#FFFFFF"
-text_disabled = "#808080"
-text_muted = "#CCCCCC"
-text_error = "#FF0000"
-text_warning = "#FFA500"
-text_success = "#00FF00"
-text_info = "#00FFFF"
-
-[status]
-running = "#00FF00"
-sleeping = "#0000FF"
-disk_sleep = "#FFA500"
-zombie = "#FF0000"
-stopped = "#FF00FF"
-idle = "#808080"
-
-[charts]
-cpu = [0.0, 0.47, 0.83, 0.75]
-memory = "#10893E"
-io = "#E74856"
-io_write = "#F7630C"
-
-[cpu_breakdown]
-user = "#0078D4"
-system = "#E74856"
-iowait = "#FFB900"
-idle = "#808080"
-
-[charts.gpu]
-utilization = "#0078D4"
-memory = "#10893E"
-temperature = "#E74856"
-power = "#FFB900"
-encoder = "#00B7C3"
-decoder = "#8E8CD8"
-clock = "#E3008C"
-fan = "#808080"
-
-[buttons.success]
-normal = "#10893E"
-hovered = "#2AA84E"
-active = "#0A6B2E"
-
-[ui.window]
-background = "#1E1E1E"
-child_background = "#252526"
-popup_background = "#2D2D30"
-border = "#3F3F46"
-
-[ui.frame]
-background = "#333337"
-background_hovered = "#3E3E42"
-background_active = "#0078D4"
-
-[ui.title]
-background = "#2D2D30"
-background_active = "#0078D4"
-background_collapsed = "#3F3F46"
-
-[ui.bars]
-menu = "#2D2D30"
-status = "#2D2D30"
-
-[ui.scrollbar]
-background = "#1E1E1E"
-grab = "#5A5A5A"
-grab_hovered = "#808080"
-grab_active = "#0078D4"
-
-[ui.controls]
-check_mark = "#FFFFFF"
-slider_grab = "#5A5A5A"
-slider_grab_active = "#0078D4"
-
-[ui.button]
-normal = "#333337"
-hovered = "#3E3E42"
-active = "#0078D4"
-
-[ui.header]
-normal = "#333337"
-hovered = "#3E3E42"
-active = "#0078D4"
-
-[ui.separator]
-normal = "#3F3F46"
-hovered = "#5A5A5A"
-active = "#0078D4"
-
-[ui.resize_grip]
-normal = "#3F3F46"
-hovered = "#5A5A5A"
-active = "#0078D4"
-
-[ui.tab]
-normal = "#2D2D30"
-hovered = "#3E3E42"
-active = "#0078D4"
-active_overline = "#FFFFFF"
-unfocused = "#252526"
-unfocused_active = "#3F3F46"
-unfocused_active_overline = "#808080"
-
-[ui.docking]
-preview = "#0078D480"
-empty_background = "#1E1E1E"
-
-[ui.plot]
-lines = "#0078D4"
-lines_hovered = "#60CDFF"
-histogram = "#10893E"
-histogram_hovered = "#6CCB5F"
-
-[ui.table]
-header_background = "#333337"
-border_strong = "#3F3F46"
-border_light = "#2D2D30"
-row_background = "#00000000"
-row_background_alt = "#FFFFFF0D"
-
-[ui.misc]
-text_selected_background = "#0078D480"
-drag_drop_target = "#FFB900"
-nav_highlight = "#0078D4"
-nav_windowing_highlight = "#FFFFFFB3"
-nav_windowing_dim_background = "#0000004D"
-modal_window_dim_background = "#0000004D"
-)";
-    createThemeFile("array-rgba-charts.toml", body);
+    // [r, g, b, a] array exercises parseColorView with explicit alpha
+    const std::string toml =
+        std::string("[meta]\nname = \"Array RGBA Charts\"\n\n") + buildFullThemeWithCpuColor("[0.0, 0.47, 0.83, 0.75]");
+    createThemeFile("array-rgba-charts.toml", toml);
 
     auto theme = ThemeLoader::loadTheme(m_TempDir / "array-rgba-charts.toml");
     ASSERT_TRUE(theme.has_value());
@@ -1726,154 +1481,15 @@ modal_window_dim_background = "#0000004D"
 
 TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_AccentsInArrayColorFormat)
 {
-    // Use [[r,g,b], [r,g,b,a], ...] format for accents.colors
-    // (exercises parseColorNode array path via loadColorArray)
-    const std::string body = R"(
-[meta]
-name = "Accents Array Format"
-
-[accents]
-colors = [
+    // Mixed [[r,g,b], [r,g,b,a], "#hex", ...] accents exercises parseColorNode array path
+    // via loadColorArray<N>: each element dispatches through parseColorNode.
+    constexpr std::string_view accentsValue = R"([
   [1.0, 0.0, 0.0],
   [0.0, 1.0, 0.0, 0.8],
   "#10893E", "#8E8CD8", "#F7630C", "#00B7C3", "#FFB900", "#E3008C"
-]
-
-[progress]
-low = "#00FF00"
-medium = "#FFFF00"
-high = "#FF0000"
-
-[semantic]
-text_primary = "#FFFFFF"
-text_disabled = "#808080"
-text_muted = "#CCCCCC"
-text_error = "#FF0000"
-text_warning = "#FFA500"
-text_success = "#00FF00"
-text_info = "#00FFFF"
-
-[status]
-running = "#00FF00"
-sleeping = "#0000FF"
-disk_sleep = "#FFA500"
-zombie = "#FF0000"
-stopped = "#FF00FF"
-idle = "#808080"
-
-[charts]
-cpu = "#0078D4"
-memory = "#10893E"
-io = "#E74856"
-io_write = "#F7630C"
-
-[cpu_breakdown]
-user = "#0078D4"
-system = "#E74856"
-iowait = "#FFB900"
-idle = "#808080"
-
-[charts.gpu]
-utilization = "#0078D4"
-memory = "#10893E"
-temperature = "#E74856"
-power = "#FFB900"
-encoder = "#00B7C3"
-decoder = "#8E8CD8"
-clock = "#E3008C"
-fan = "#808080"
-
-[buttons.success]
-normal = "#10893E"
-hovered = "#2AA84E"
-active = "#0A6B2E"
-
-[ui.window]
-background = "#1E1E1E"
-child_background = "#252526"
-popup_background = "#2D2D30"
-border = "#3F3F46"
-
-[ui.frame]
-background = "#333337"
-background_hovered = "#3E3E42"
-background_active = "#0078D4"
-
-[ui.title]
-background = "#2D2D30"
-background_active = "#0078D4"
-background_collapsed = "#3F3F46"
-
-[ui.bars]
-menu = "#2D2D30"
-status = "#2D2D30"
-
-[ui.scrollbar]
-background = "#1E1E1E"
-grab = "#5A5A5A"
-grab_hovered = "#808080"
-grab_active = "#0078D4"
-
-[ui.controls]
-check_mark = "#FFFFFF"
-slider_grab = "#5A5A5A"
-slider_grab_active = "#0078D4"
-
-[ui.button]
-normal = "#333337"
-hovered = "#3E3E42"
-active = "#0078D4"
-
-[ui.header]
-normal = "#333337"
-hovered = "#3E3E42"
-active = "#0078D4"
-
-[ui.separator]
-normal = "#3F3F46"
-hovered = "#5A5A5A"
-active = "#0078D4"
-
-[ui.resize_grip]
-normal = "#3F3F46"
-hovered = "#5A5A5A"
-active = "#0078D4"
-
-[ui.tab]
-normal = "#2D2D30"
-hovered = "#3E3E42"
-active = "#0078D4"
-active_overline = "#FFFFFF"
-unfocused = "#252526"
-unfocused_active = "#3F3F46"
-unfocused_active_overline = "#808080"
-
-[ui.docking]
-preview = "#0078D480"
-empty_background = "#1E1E1E"
-
-[ui.plot]
-lines = "#0078D4"
-lines_hovered = "#60CDFF"
-histogram = "#10893E"
-histogram_hovered = "#6CCB5F"
-
-[ui.table]
-header_background = "#333337"
-border_strong = "#3F3F46"
-border_light = "#2D2D30"
-row_background = "#00000000"
-row_background_alt = "#FFFFFF0D"
-
-[ui.misc]
-text_selected_background = "#0078D480"
-drag_drop_target = "#FFB900"
-nav_highlight = "#0078D4"
-nav_windowing_highlight = "#FFFFFFB3"
-nav_windowing_dim_background = "#0000004D"
-modal_window_dim_background = "#0000004D"
-)";
-    createThemeFile("accents-array-format.toml", body);
+])";
+    const std::string toml = std::string("[meta]\nname = \"Accents Array Format\"\n\n") + buildFullThemeWithAccents(accentsValue);
+    createThemeFile("accents-array-format.toml", toml);
 
     auto theme = ThemeLoader::loadTheme(m_TempDir / "accents-array-format.toml");
     ASSERT_TRUE(theme.has_value());

--- a/tests/UI/test_ThemeLoader.cpp
+++ b/tests/UI/test_ThemeLoader.cpp
@@ -1410,5 +1410,486 @@ TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_PriorityBadgeTextColor_DefaultsToWhit
     expectColorNear(theme->priorityBadgeTextColor, ImVec4(1.0F, 1.0F, 1.0F, 1.0F));
 }
 
+// ========== Array-format color parsing ==========
+
+TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_ArrayColorRgbForChartCpu)
+{
+    // Use inline [r, g, b] array format for charts.cpu (exercises parseColorView array path)
+    const std::string body = R"(
+[meta]
+name = "Array RGB Charts"
+
+[accents]
+colors = ["#0078D4", "#E74856", "#10893E", "#8E8CD8", "#F7630C", "#00B7C3", "#FFB900", "#E3008C"]
+
+[progress]
+low = "#00FF00"
+medium = "#FFFF00"
+high = "#FF0000"
+
+[semantic]
+text_primary = "#FFFFFF"
+text_disabled = "#808080"
+text_muted = "#CCCCCC"
+text_error = "#FF0000"
+text_warning = "#FFA500"
+text_success = "#00FF00"
+text_info = "#00FFFF"
+
+[status]
+running = "#00FF00"
+sleeping = "#0000FF"
+disk_sleep = "#FFA500"
+zombie = "#FF0000"
+stopped = "#FF00FF"
+idle = "#808080"
+
+[charts]
+cpu = [0.0, 0.47, 0.83]
+memory = "#10893E"
+io = "#E74856"
+io_write = "#F7630C"
+
+[cpu_breakdown]
+user = "#0078D4"
+system = "#E74856"
+iowait = "#FFB900"
+idle = "#808080"
+
+[charts.gpu]
+utilization = "#0078D4"
+memory = "#10893E"
+temperature = "#E74856"
+power = "#FFB900"
+encoder = "#00B7C3"
+decoder = "#8E8CD8"
+clock = "#E3008C"
+fan = "#808080"
+
+[buttons.success]
+normal = "#10893E"
+hovered = "#2AA84E"
+active = "#0A6B2E"
+
+[ui.window]
+background = "#1E1E1E"
+child_background = "#252526"
+popup_background = "#2D2D30"
+border = "#3F3F46"
+
+[ui.frame]
+background = "#333337"
+background_hovered = "#3E3E42"
+background_active = "#0078D4"
+
+[ui.title]
+background = "#2D2D30"
+background_active = "#0078D4"
+background_collapsed = "#3F3F46"
+
+[ui.bars]
+menu = "#2D2D30"
+status = "#2D2D30"
+
+[ui.scrollbar]
+background = "#1E1E1E"
+grab = "#5A5A5A"
+grab_hovered = "#808080"
+grab_active = "#0078D4"
+
+[ui.controls]
+check_mark = "#FFFFFF"
+slider_grab = "#5A5A5A"
+slider_grab_active = "#0078D4"
+
+[ui.button]
+normal = "#333337"
+hovered = "#3E3E42"
+active = "#0078D4"
+
+[ui.header]
+normal = "#333337"
+hovered = "#3E3E42"
+active = "#0078D4"
+
+[ui.separator]
+normal = "#3F3F46"
+hovered = "#5A5A5A"
+active = "#0078D4"
+
+[ui.resize_grip]
+normal = "#3F3F46"
+hovered = "#5A5A5A"
+active = "#0078D4"
+
+[ui.tab]
+normal = "#2D2D30"
+hovered = "#3E3E42"
+active = "#0078D4"
+active_overline = "#FFFFFF"
+unfocused = "#252526"
+unfocused_active = "#3F3F46"
+unfocused_active_overline = "#808080"
+
+[ui.docking]
+preview = "#0078D480"
+empty_background = "#1E1E1E"
+
+[ui.plot]
+lines = "#0078D4"
+lines_hovered = "#60CDFF"
+histogram = "#10893E"
+histogram_hovered = "#6CCB5F"
+
+[ui.table]
+header_background = "#333337"
+border_strong = "#3F3F46"
+border_light = "#2D2D30"
+row_background = "#00000000"
+row_background_alt = "#FFFFFF0D"
+
+[ui.misc]
+text_selected_background = "#0078D480"
+drag_drop_target = "#FFB900"
+nav_highlight = "#0078D4"
+nav_windowing_highlight = "#FFFFFFB3"
+nav_windowing_dim_background = "#0000004D"
+modal_window_dim_background = "#0000004D"
+)";
+    createThemeFile("array-rgb-charts.toml", body);
+
+    auto theme = ThemeLoader::loadTheme(m_TempDir / "array-rgb-charts.toml");
+    ASSERT_TRUE(theme.has_value());
+
+    // cpu = [0.0, 0.47, 0.83] → approximately Windows Blue
+    EXPECT_NEAR(theme->chartCpu.x, 0.0F, 0.02F);
+    EXPECT_NEAR(theme->chartCpu.y, 0.47F, 0.02F);
+    EXPECT_NEAR(theme->chartCpu.z, 0.83F, 0.02F);
+    EXPECT_NEAR(theme->chartCpu.w, 1.0F, 0.01F); // alpha defaults to 1.0
+}
+
+TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_ArrayColorRgbaForChartCpu)
+{
+    // Use inline [r, g, b, a] array format (exercises parseColorView with explicit alpha)
+    const std::string body = R"(
+[meta]
+name = "Array RGBA Charts"
+
+[accents]
+colors = ["#0078D4", "#E74856", "#10893E", "#8E8CD8", "#F7630C", "#00B7C3", "#FFB900", "#E3008C"]
+
+[progress]
+low = "#00FF00"
+medium = "#FFFF00"
+high = "#FF0000"
+
+[semantic]
+text_primary = "#FFFFFF"
+text_disabled = "#808080"
+text_muted = "#CCCCCC"
+text_error = "#FF0000"
+text_warning = "#FFA500"
+text_success = "#00FF00"
+text_info = "#00FFFF"
+
+[status]
+running = "#00FF00"
+sleeping = "#0000FF"
+disk_sleep = "#FFA500"
+zombie = "#FF0000"
+stopped = "#FF00FF"
+idle = "#808080"
+
+[charts]
+cpu = [0.0, 0.47, 0.83, 0.75]
+memory = "#10893E"
+io = "#E74856"
+io_write = "#F7630C"
+
+[cpu_breakdown]
+user = "#0078D4"
+system = "#E74856"
+iowait = "#FFB900"
+idle = "#808080"
+
+[charts.gpu]
+utilization = "#0078D4"
+memory = "#10893E"
+temperature = "#E74856"
+power = "#FFB900"
+encoder = "#00B7C3"
+decoder = "#8E8CD8"
+clock = "#E3008C"
+fan = "#808080"
+
+[buttons.success]
+normal = "#10893E"
+hovered = "#2AA84E"
+active = "#0A6B2E"
+
+[ui.window]
+background = "#1E1E1E"
+child_background = "#252526"
+popup_background = "#2D2D30"
+border = "#3F3F46"
+
+[ui.frame]
+background = "#333337"
+background_hovered = "#3E3E42"
+background_active = "#0078D4"
+
+[ui.title]
+background = "#2D2D30"
+background_active = "#0078D4"
+background_collapsed = "#3F3F46"
+
+[ui.bars]
+menu = "#2D2D30"
+status = "#2D2D30"
+
+[ui.scrollbar]
+background = "#1E1E1E"
+grab = "#5A5A5A"
+grab_hovered = "#808080"
+grab_active = "#0078D4"
+
+[ui.controls]
+check_mark = "#FFFFFF"
+slider_grab = "#5A5A5A"
+slider_grab_active = "#0078D4"
+
+[ui.button]
+normal = "#333337"
+hovered = "#3E3E42"
+active = "#0078D4"
+
+[ui.header]
+normal = "#333337"
+hovered = "#3E3E42"
+active = "#0078D4"
+
+[ui.separator]
+normal = "#3F3F46"
+hovered = "#5A5A5A"
+active = "#0078D4"
+
+[ui.resize_grip]
+normal = "#3F3F46"
+hovered = "#5A5A5A"
+active = "#0078D4"
+
+[ui.tab]
+normal = "#2D2D30"
+hovered = "#3E3E42"
+active = "#0078D4"
+active_overline = "#FFFFFF"
+unfocused = "#252526"
+unfocused_active = "#3F3F46"
+unfocused_active_overline = "#808080"
+
+[ui.docking]
+preview = "#0078D480"
+empty_background = "#1E1E1E"
+
+[ui.plot]
+lines = "#0078D4"
+lines_hovered = "#60CDFF"
+histogram = "#10893E"
+histogram_hovered = "#6CCB5F"
+
+[ui.table]
+header_background = "#333337"
+border_strong = "#3F3F46"
+border_light = "#2D2D30"
+row_background = "#00000000"
+row_background_alt = "#FFFFFF0D"
+
+[ui.misc]
+text_selected_background = "#0078D480"
+drag_drop_target = "#FFB900"
+nav_highlight = "#0078D4"
+nav_windowing_highlight = "#FFFFFFB3"
+nav_windowing_dim_background = "#0000004D"
+modal_window_dim_background = "#0000004D"
+)";
+    createThemeFile("array-rgba-charts.toml", body);
+
+    auto theme = ThemeLoader::loadTheme(m_TempDir / "array-rgba-charts.toml");
+    ASSERT_TRUE(theme.has_value());
+
+    // cpu = [0.0, 0.47, 0.83, 0.75] — explicit alpha 0.75
+    EXPECT_NEAR(theme->chartCpu.x, 0.0F, 0.02F);
+    EXPECT_NEAR(theme->chartCpu.y, 0.47F, 0.02F);
+    EXPECT_NEAR(theme->chartCpu.z, 0.83F, 0.02F);
+    EXPECT_NEAR(theme->chartCpu.w, 0.75F, 0.02F);
+}
+
+TEST_F(ThemeLoaderDiscoveryTest, LoadTheme_AccentsInArrayColorFormat)
+{
+    // Use [[r,g,b], [r,g,b,a], ...] format for accents.colors
+    // (exercises parseColorNode array path via loadColorArray)
+    const std::string body = R"(
+[meta]
+name = "Accents Array Format"
+
+[accents]
+colors = [
+  [1.0, 0.0, 0.0],
+  [0.0, 1.0, 0.0, 0.8],
+  "#10893E", "#8E8CD8", "#F7630C", "#00B7C3", "#FFB900", "#E3008C"
+]
+
+[progress]
+low = "#00FF00"
+medium = "#FFFF00"
+high = "#FF0000"
+
+[semantic]
+text_primary = "#FFFFFF"
+text_disabled = "#808080"
+text_muted = "#CCCCCC"
+text_error = "#FF0000"
+text_warning = "#FFA500"
+text_success = "#00FF00"
+text_info = "#00FFFF"
+
+[status]
+running = "#00FF00"
+sleeping = "#0000FF"
+disk_sleep = "#FFA500"
+zombie = "#FF0000"
+stopped = "#FF00FF"
+idle = "#808080"
+
+[charts]
+cpu = "#0078D4"
+memory = "#10893E"
+io = "#E74856"
+io_write = "#F7630C"
+
+[cpu_breakdown]
+user = "#0078D4"
+system = "#E74856"
+iowait = "#FFB900"
+idle = "#808080"
+
+[charts.gpu]
+utilization = "#0078D4"
+memory = "#10893E"
+temperature = "#E74856"
+power = "#FFB900"
+encoder = "#00B7C3"
+decoder = "#8E8CD8"
+clock = "#E3008C"
+fan = "#808080"
+
+[buttons.success]
+normal = "#10893E"
+hovered = "#2AA84E"
+active = "#0A6B2E"
+
+[ui.window]
+background = "#1E1E1E"
+child_background = "#252526"
+popup_background = "#2D2D30"
+border = "#3F3F46"
+
+[ui.frame]
+background = "#333337"
+background_hovered = "#3E3E42"
+background_active = "#0078D4"
+
+[ui.title]
+background = "#2D2D30"
+background_active = "#0078D4"
+background_collapsed = "#3F3F46"
+
+[ui.bars]
+menu = "#2D2D30"
+status = "#2D2D30"
+
+[ui.scrollbar]
+background = "#1E1E1E"
+grab = "#5A5A5A"
+grab_hovered = "#808080"
+grab_active = "#0078D4"
+
+[ui.controls]
+check_mark = "#FFFFFF"
+slider_grab = "#5A5A5A"
+slider_grab_active = "#0078D4"
+
+[ui.button]
+normal = "#333337"
+hovered = "#3E3E42"
+active = "#0078D4"
+
+[ui.header]
+normal = "#333337"
+hovered = "#3E3E42"
+active = "#0078D4"
+
+[ui.separator]
+normal = "#3F3F46"
+hovered = "#5A5A5A"
+active = "#0078D4"
+
+[ui.resize_grip]
+normal = "#3F3F46"
+hovered = "#5A5A5A"
+active = "#0078D4"
+
+[ui.tab]
+normal = "#2D2D30"
+hovered = "#3E3E42"
+active = "#0078D4"
+active_overline = "#FFFFFF"
+unfocused = "#252526"
+unfocused_active = "#3F3F46"
+unfocused_active_overline = "#808080"
+
+[ui.docking]
+preview = "#0078D480"
+empty_background = "#1E1E1E"
+
+[ui.plot]
+lines = "#0078D4"
+lines_hovered = "#60CDFF"
+histogram = "#10893E"
+histogram_hovered = "#6CCB5F"
+
+[ui.table]
+header_background = "#333337"
+border_strong = "#3F3F46"
+border_light = "#2D2D30"
+row_background = "#00000000"
+row_background_alt = "#FFFFFF0D"
+
+[ui.misc]
+text_selected_background = "#0078D480"
+drag_drop_target = "#FFB900"
+nav_highlight = "#0078D4"
+nav_windowing_highlight = "#FFFFFFB3"
+nav_windowing_dim_background = "#0000004D"
+modal_window_dim_background = "#0000004D"
+)";
+    createThemeFile("accents-array-format.toml", body);
+
+    auto theme = ThemeLoader::loadTheme(m_TempDir / "accents-array-format.toml");
+    ASSERT_TRUE(theme.has_value());
+
+    // accents[0] = [1.0, 0.0, 0.0] → red, alpha defaults to 1.0
+    EXPECT_NEAR(theme->accents[0].x, 1.0F, 0.02F);
+    EXPECT_NEAR(theme->accents[0].y, 0.0F, 0.02F);
+    EXPECT_NEAR(theme->accents[0].z, 0.0F, 0.02F);
+    EXPECT_NEAR(theme->accents[0].w, 1.0F, 0.02F);
+
+    // accents[1] = [0.0, 1.0, 0.0, 0.8] → green with alpha 0.8
+    EXPECT_NEAR(theme->accents[1].x, 0.0F, 0.02F);
+    EXPECT_NEAR(theme->accents[1].y, 1.0F, 0.02F);
+    EXPECT_NEAR(theme->accents[1].z, 0.0F, 0.02F);
+    EXPECT_NEAR(theme->accents[1].w, 0.8F, 0.02F);
+}
+
 } // namespace
 } // namespace UI


### PR DESCRIPTION
## Coverage PR #2

Adds tests for three previously under-covered source files, targeting the missed lines identified in the coverage plan.

### Files covered

**`src/App/UserConfig.cpp`** (~29 missed lines)
- `LoadDoesNothingWhenFileAbsent` — no file → keeps defaults
- `LoadIsIdempotent` — `m_IsLoaded` guard prevents re-read
- `LoadHandlesTomlParseError` — unclosed string → parse error caught, keeps defaults
- `LoadSwapsProgressThresholdsWhenInverted` — low > high → swap logic
- `LoadParsesAllFontSizes` — all 6 font size strings (small/medium/large/extra-large/huge/even-huger)
- `LoadClampsInsaneWindowPosition` — x/y > ±100000 → nullopt
- `SaveCreatesFileAndRoundTrips` — full save/load round-trip
- `SaveWithNoOptionalWindowPos` — save without optional window position

**`src/Domain/SystemModel.cpp`** (~29 missed lines — `computePowerStatus()` branches)
- `PowerStatus_NoBattery_WhenNoPowerProbe` — no power probe → `hasBattery=false`
- `PowerStatus_HasBattery_WhenPowerProbeReportsIt` — discharging state, all fields verified
- `PowerStatus_Charging` — charging state, `isOnAc=true`, `timeToFullSec`
- `PowerStatus_Full` — full state, `isOnAc=true`

**`src/UI/ThemeLoader.cpp`** (~26 missed lines — array color paths)
- `LoadTheme_ArrayColorRgbForChartCpu` — `[r, g, b]` array, alpha defaults to 1.0
- `LoadTheme_ArrayColorRgbaForChartCpu` — `[r, g, b, a]` array, explicit alpha
- `LoadTheme_AccentsInArrayColorFormat` — mixed accent array: RGB arrays, RGBA arrays, hex strings

### Infrastructure
- Added `MockPowerProbe` to `tests/Mocks/MockProbes.h` implementing `IPowerProbe`
- Fixed test fixture `SetUp()` to remove stale temp files before each test (cross-run isolation)

### Test count
1047 tests, 100% pass (2 skipped as always: kernel thread null cmdline, DRM GPU integration)
