### PR TITLE
test: PR3 coverage — Linux platform error path tests

### DIFF
--- a/tests/Platform/test_LinuxPathProvider.cpp
+++ b/tests/Platform/test_LinuxPathProvider.cpp
@@ -213,14 +213,19 @@ TEST(LinuxPathProviderTest, MultipleCallsReturnSamePaths)
 
 TEST(LinuxPathProviderTest, GetUserConfigDirFallsBackToCurrentDir_WhenBothEnvVarsEmpty)
 {
-    // When XDG_CONFIG_HOME and HOME are both unset/empty, getUserConfigDir()
+    // When XDG_CONFIG_HOME and HOME are both set to empty strings, getUserConfigDir()
     // falls back to std::filesystem::current_path() as a last resort.
     // This test covers the fallback branch (lines ~75-85 in LinuxPathProvider.cpp).
 
-    const char* savedXdg = std::getenv("XDG_CONFIG_HOME");
-    const char* savedHome = std::getenv("HOME");
-    const std::string origXdg = savedXdg ? savedXdg : "";
-    const std::string origHome = savedHome ? savedHome : "";
+    // Track both the original value AND whether the var was set at all.
+    // getenv() returns non-null for an empty value, so a bool is needed to
+    // distinguish "was set to empty string" from "was not set".
+    const char* rawXdg = std::getenv("XDG_CONFIG_HOME");
+    const char* rawHome = std::getenv("HOME");
+    const bool xdgWasSet = (rawXdg != nullptr);
+    const bool homeWasSet = (rawHome != nullptr);
+    const std::string origXdg = xdgWasSet ? rawXdg : "";
+    const std::string origHome = homeWasSet ? rawHome : "";
 
     setenv("XDG_CONFIG_HOME", "", 1);
     setenv("HOME", "", 1);
@@ -228,8 +233,8 @@ TEST(LinuxPathProviderTest, GetUserConfigDirFallsBackToCurrentDir_WhenBothEnvVar
     LinuxPathProvider provider;
     const auto dir = provider.getUserConfigDir();
 
-    // Restore environment
-    if (!origXdg.empty())
+    // Restore environment exactly as found
+    if (xdgWasSet)
     {
         setenv("XDG_CONFIG_HOME", origXdg.c_str(), 1);
     }
@@ -237,7 +242,7 @@ TEST(LinuxPathProviderTest, GetUserConfigDirFallsBackToCurrentDir_WhenBothEnvVar
     {
         unsetenv("XDG_CONFIG_HOME");
     }
-    if (!origHome.empty())
+    if (homeWasSet)
     {
         setenv("HOME", origHome.c_str(), 1);
     }
@@ -246,8 +251,12 @@ TEST(LinuxPathProviderTest, GetUserConfigDirFallsBackToCurrentDir_WhenBothEnvVar
         unsetenv("HOME");
     }
 
-    // The fallback must return a non-empty path (current_path() succeeds in test env)
-    EXPECT_FALSE(dir.empty());
+    // The fallback returns current_path() which is non-empty in normal test environments.
+    // Compare against the expected current_path() to confirm the right branch was taken.
+    std::error_code ec;
+    const auto expectedDir = std::filesystem::current_path(ec);
+    ASSERT_FALSE(ec) << "std::filesystem::current_path() failed: " << ec.message();
+    EXPECT_EQ(dir, expectedDir);
 }
 
 } // namespace

--- a/tests/Platform/test_LinuxPathProvider.cpp
+++ b/tests/Platform/test_LinuxPathProvider.cpp
@@ -211,6 +211,45 @@ TEST(LinuxPathProviderTest, MultipleCallsReturnSamePaths)
     EXPECT_EQ(config1, config2);
 }
 
+TEST(LinuxPathProviderTest, GetUserConfigDirFallsBackToCurrentDir_WhenBothEnvVarsEmpty)
+{
+    // When XDG_CONFIG_HOME and HOME are both unset/empty, getUserConfigDir()
+    // falls back to std::filesystem::current_path() as a last resort.
+    // This test covers the fallback branch (lines ~75-85 in LinuxPathProvider.cpp).
+
+    const char* savedXdg = std::getenv("XDG_CONFIG_HOME");
+    const char* savedHome = std::getenv("HOME");
+    const std::string origXdg = savedXdg ? savedXdg : "";
+    const std::string origHome = savedHome ? savedHome : "";
+
+    setenv("XDG_CONFIG_HOME", "", 1);
+    setenv("HOME", "", 1);
+
+    LinuxPathProvider provider;
+    const auto dir = provider.getUserConfigDir();
+
+    // Restore environment
+    if (!origXdg.empty())
+    {
+        setenv("XDG_CONFIG_HOME", origXdg.c_str(), 1);
+    }
+    else
+    {
+        unsetenv("XDG_CONFIG_HOME");
+    }
+    if (!origHome.empty())
+    {
+        setenv("HOME", origHome.c_str(), 1);
+    }
+    else
+    {
+        unsetenv("HOME");
+    }
+
+    // The fallback must return a non-empty path (current_path() succeeds in test env)
+    EXPECT_FALSE(dir.empty());
+}
+
 } // namespace
 } // namespace Platform
 

--- a/tests/Platform/test_LinuxPathProvider.cpp
+++ b/tests/Platform/test_LinuxPathProvider.cpp
@@ -227,8 +227,8 @@ TEST(LinuxPathProviderTest, GetUserConfigDirFallsBackToCurrentDir_WhenBothEnvVar
     const std::string origXdg = xdgWasSet ? rawXdg : "";
     const std::string origHome = homeWasSet ? rawHome : "";
 
-    setenv("XDG_CONFIG_HOME", "", 1);
-    setenv("HOME", "", 1);
+    ASSERT_EQ(0, setenv("XDG_CONFIG_HOME", "", 1));
+    ASSERT_EQ(0, setenv("HOME", "", 1));
 
     LinuxPathProvider provider;
     const auto dir = provider.getUserConfigDir();
@@ -236,19 +236,19 @@ TEST(LinuxPathProviderTest, GetUserConfigDirFallsBackToCurrentDir_WhenBothEnvVar
     // Restore environment exactly as found
     if (xdgWasSet)
     {
-        setenv("XDG_CONFIG_HOME", origXdg.c_str(), 1);
+        ASSERT_EQ(0, setenv("XDG_CONFIG_HOME", origXdg.c_str(), 1));
     }
     else
     {
-        unsetenv("XDG_CONFIG_HOME");
+        ASSERT_EQ(0, unsetenv("XDG_CONFIG_HOME"));
     }
     if (homeWasSet)
     {
-        setenv("HOME", origHome.c_str(), 1);
+        ASSERT_EQ(0, setenv("HOME", origHome.c_str(), 1));
     }
     else
     {
-        unsetenv("HOME");
+        ASSERT_EQ(0, unsetenv("HOME"));
     }
 
     // The fallback returns current_path() which is non-empty in normal test environments.

--- a/tests/Platform/test_LinuxProcessActions.cpp
+++ b/tests/Platform/test_LinuxProcessActions.cpp
@@ -244,5 +244,22 @@ TEST(LinuxProcessActionsTest, SetPriorityClampsBoundaryValues)
     }
 }
 
+// =============================================================================
+// Success Path Tests
+// =============================================================================
+
+TEST(LinuxProcessActionsTest, ResumeOwnProcess_Succeeds)
+{
+    // Send SIGCONT to our own process - safe because it's a no-op on a running process
+    // but exercises the sendSignal() success path (lines ~114-116 in LinuxProcessActions.cpp).
+    LinuxProcessActions actions;
+    int32_t ownPid = static_cast<int32_t>(getpid());
+
+    auto result = actions.resume(ownPid);
+
+    EXPECT_TRUE(result.success);
+    EXPECT_TRUE(result.errorMessage.empty());
+}
+
 } // namespace
 } // namespace Platform


### PR DESCRIPTION
## Summary

Targets previously uncovered branches in the Linux Platform layer that are reachable in the standard test environment (no RAPL hardware or root required).

### New tests

**`tests/Platform/test_LinuxPathProvider.cpp`**
- `GetUserConfigDirFallsBackToCurrentDir_WhenBothEnvVarsEmpty` — unsets both `XDG_CONFIG_HOME` and `HOME` to drive `getUserConfigDir()` into the `std::filesystem::current_path()` last-resort fallback branch

**`tests/Platform/test_LinuxProcessActions.cpp`**
- `ResumeOwnProcess_Succeeds` — sends `SIGCONT` to the test process itself (safe: no-op on a running process) to cover the `sendSignal()` success path (return `ProcessActionResult::ok()`)

### Why these are the right targets

The coverage analysis identified 344 uncovered lines across the 5 Platform Linux source files. The vast majority are:
- RAPL/power paths (require Intel RAPL hardware)
- Process-frozen paths (require cgroup freeze / root)
- File-not-open guards for `/proc/stat`, `/proc/meminfo`, `/proc/net/dev` (always succeed in CI)
- Netlink socket error paths (internal anonymous-namespace helpers, not accessible via public API)

The two tests here cover the branches that are both reachable and meaningful without privileged access.

### Notes

- Removed a `StopAndContinueOwnProcess` test that would have sent `SIGSTOP` to the test process itself — this hangs the ctest runner since the process suspends before calling `SIGCONT`
- `parseSocketMessage` turned out to be `private` so the planned `NetlinkSocketStats` edge-case tests were dropped

### Checklist
- [x] All 1051 tests pass (`ctest --preset debug`)
- [x] `clang-format` clean (pre-commit passed)
- [x] No new warnings
