### PR TITLE
test: add Factory function tests and aggregateByPid saturation coverage (PR4)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ else()
         Platform/test_LinuxROCmGPUProbe.cpp
         Platform/test_NetlinkSocketStats.cpp
         Platform/test_DRMGPUProbe.cpp
+        Platform/test_Factory.cpp
     )
     set(PLATFORM_SRC_UNDER_TEST
         ${CMAKE_SOURCE_DIR}/src/Platform/Linux/Factory.cpp

--- a/tests/Platform/test_Factory.cpp
+++ b/tests/Platform/test_Factory.cpp
@@ -1,0 +1,68 @@
+/// @file test_Factory.cpp
+/// @brief Tests that Platform::Factory functions return valid non-null objects.
+///
+/// Each make*() function is a one-liner factory. These tests ensure every factory
+/// function is exercised so coverage accounts for all factory implementations.
+
+#include "Platform/Factory.h"
+#include "Platform/IDiskProbe.h"
+#include "Platform/IGPUProbe.h"
+#include "Platform/IPathProvider.h"
+#include "Platform/IPowerProbe.h"
+#include "Platform/IProcessActions.h"
+#include "Platform/IProcessProbe.h"
+#include "Platform/ISystemProbe.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace Platform
+{
+namespace
+{
+
+TEST(FactoryTest, MakeProcessProbeReturnsNonNull)
+{
+    auto probe = makeProcessProbe();
+    EXPECT_NE(probe, nullptr);
+}
+
+TEST(FactoryTest, MakeProcessActionsReturnsNonNull)
+{
+    auto actions = makeProcessActions();
+    EXPECT_NE(actions, nullptr);
+}
+
+TEST(FactoryTest, MakeSystemProbeReturnsNonNull)
+{
+    auto probe = makeSystemProbe();
+    EXPECT_NE(probe, nullptr);
+}
+
+TEST(FactoryTest, MakeDiskProbeReturnsNonNull)
+{
+    auto probe = makeDiskProbe();
+    EXPECT_NE(probe, nullptr);
+}
+
+TEST(FactoryTest, MakePathProviderReturnsNonNull)
+{
+    auto provider = makePathProvider();
+    EXPECT_NE(provider, nullptr);
+}
+
+TEST(FactoryTest, MakePowerProbeReturnsNonNull)
+{
+    auto probe = makePowerProbe();
+    EXPECT_NE(probe, nullptr);
+}
+
+TEST(FactoryTest, MakeGPUProbeReturnsNonNull)
+{
+    auto probe = makeGPUProbe();
+    EXPECT_NE(probe, nullptr);
+}
+
+} // namespace
+} // namespace Platform

--- a/tests/Platform/test_NetlinkSocketStats.cpp
+++ b/tests/Platform/test_NetlinkSocketStats.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <thread>
 
 #include <unistd.h>
@@ -253,6 +254,42 @@ TEST(AggregateByPidTest, LargeByteCountersAreHandled)
     ASSERT_EQ(result.size(), 1UL);
     EXPECT_EQ(result[100].first, 0xFFFFFFFFFFFFFF00ULL);
     EXPECT_EQ(result[100].second, 0x7FFFFFFFFFFFFFFFULL);
+}
+
+TEST(AggregateByPidTest, SaturatesReceivedOnOverflow)
+{
+    // Two sockets for the same PID whose bytesReceived sum would overflow uint64_t.
+    // First socket fills received to UINT64_MAX - 10, second tries to add 20 — overflow.
+    constexpr auto kMax = std::numeric_limits<std::uint64_t>::max();
+    std::vector<SocketStats> sockets;
+    sockets.push_back({.inode = 1, .bytesReceived = kMax - 10ULL, .bytesSent = 0ULL});
+    sockets.push_back({.inode = 2, .bytesReceived = 20ULL, .bytesSent = 0ULL});
+
+    std::unordered_map<std::uint64_t, std::int32_t> inodeToPid;
+    inodeToPid[1] = 42;
+    inodeToPid[2] = 42; // Same PID — accumulation will overflow
+
+    auto result = aggregateByPid(sockets, inodeToPid);
+    ASSERT_EQ(result.size(), 1UL);
+    // Should saturate to UINT64_MAX rather than wrapping around
+    EXPECT_EQ(result[42].first, kMax);
+}
+
+TEST(AggregateByPidTest, SaturatesSentOnOverflow)
+{
+    // Two sockets for the same PID whose bytesSent sum would overflow uint64_t.
+    constexpr auto kMax = std::numeric_limits<std::uint64_t>::max();
+    std::vector<SocketStats> sockets;
+    sockets.push_back({.inode = 3, .bytesReceived = 0ULL, .bytesSent = kMax - 5ULL});
+    sockets.push_back({.inode = 4, .bytesReceived = 0ULL, .bytesSent = 10ULL});
+
+    std::unordered_map<std::uint64_t, std::int32_t> inodeToPid;
+    inodeToPid[3] = 99;
+    inodeToPid[4] = 99; // Same PID
+
+    auto result = aggregateByPid(sockets, inodeToPid);
+    ASSERT_EQ(result.size(), 1UL);
+    EXPECT_EQ(result[99].second, kMax);
 }
 
 // ----- Cache Tests -----


### PR DESCRIPTION
## Summary

Fourth in the coverage-push series. Targets two previously under-covered Linux Platform files.

### Changes

**`tests/Platform/test_Factory.cpp`** (new file — 7 tests)
- Covers all 7 `Platform::make*()` factory functions: `makeProcessProbe`, `makeProcessActions`, `makeSystemProbe`, `makeDiskProbe`, `makePathProvider`, `makePowerProbe`, `makeGPUProbe`
- `makeGPUProbe()` and `makeDiskProbe()` had **zero** prior test coverage in `src/Platform/Linux/Factory.cpp`
- Each test simply asserts the returned `unique_ptr` is non-null (smoke test for construction)

**`tests/Platform/test_NetlinkSocketStats.cpp`** (2 new tests)
- `AggregateByPidTest.SaturatesReceivedOnOverflow`: two sockets for the same PID whose `bytesReceived` sum would exceed `UINT64_MAX`; expects saturation to `UINT64_MAX` 
- `AggregateByPidTest.SaturatesSentOnOverflow`: same pattern for `bytesSent`
- Covers the previously-untested saturation branches in `aggregateByPid()`

### Coverage targets
- `src/Platform/Linux/Factory.cpp`: `makeGPUProbe` and `makeDiskProbe` body lines newly covered
- `src/Platform/Linux/NetlinkSocketStats.cpp`: overflow-guard branches in `aggregateByPid()` newly covered

### Testing
- 1075/1075 tests pass (`ctest --preset debug`)
- 2 tests skipped (environment-dependent: no RAPL, no DRM GPU in CI)
- All pre-commit hooks pass (clang-format, whitespace, merge-conflict checks)