### PR TITLE
test: PR6 coverage — LinuxDiskProbe injection constructor + synthetic diskstats read

### DIFF
--- a/src/Platform/Linux/LinuxDiskProbe.cpp
+++ b/src/Platform/Linux/LinuxDiskProbe.cpp
@@ -8,12 +8,15 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <ranges>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace Platform

--- a/src/Platform/Linux/LinuxDiskProbe.cpp
+++ b/src/Platform/Linux/LinuxDiskProbe.cpp
@@ -69,7 +69,8 @@ bool LinuxDiskProbe::shouldIncludeDevice(const std::string& deviceName)
         // (mmcblk0boot0, mmcblk0boot1) and RPMB devices that also end in a digit.
         if (deviceName.starts_with("mmcblk"))
         {
-            const std::string_view suffix{deviceName.data() + 6, deviceName.size() - 6};
+            constexpr std::string_view k_MmcblkPrefix{"mmcblk"};
+            const std::string_view suffix = std::string_view{deviceName}.substr(k_MmcblkPrefix.size());
             const bool allDigits = !suffix.empty() && std::ranges::all_of(suffix, [](unsigned char c) { return std::isdigit(c) != 0; });
             return allDigits;
         }

--- a/src/Platform/Linux/LinuxDiskProbe.cpp
+++ b/src/Platform/Linux/LinuxDiskProbe.cpp
@@ -55,11 +55,23 @@ bool LinuxDiskProbe::shouldIncludeDevice(const std::string& deviceName)
     // Check if it ends with a digit (likely a partition)
     if (!deviceName.empty() && (std::isdigit(static_cast<unsigned char>(deviceName.back())) != 0))
     {
-        // Exceptions: some whole-disk names end with a digit.
-        //   NVMe:  nvme0n1, nvme1n1  — contain "nvme", no 'p'
-        //   eMMC:  mmcblk0, mmcblk1  — contain "mmcblk", no 'p'
-        // Partitions (e.g. nvme0n1p1, mmcblk0p1) contain 'p' and are excluded.
-        return (deviceName.contains("nvme") || deviceName.contains("mmcblk")) && !deviceName.contains('p');
+        // Exception: NVMe whole namespaces (nvme0n1, nvme1n2) — contain "nvme", no 'p'.
+        if (deviceName.contains("nvme") && !deviceName.contains('p'))
+        {
+            return true;
+        }
+
+        // Exception: eMMC whole-disk devices (mmcblk0, mmcblk1).
+        // Match only "mmcblk" + all-digit suffix to exclude boot partitions
+        // (mmcblk0boot0, mmcblk0boot1) and RPMB devices that also end in a digit.
+        if (deviceName.starts_with("mmcblk"))
+        {
+            const std::string_view suffix{deviceName.data() + 6, deviceName.size() - 6};
+            const bool allDigits = !suffix.empty() && std::ranges::all_of(suffix, [](unsigned char c) { return std::isdigit(c) != 0; });
+            return allDigits;
+        }
+
+        return false;
     }
 
     return true;

--- a/src/Platform/Linux/LinuxDiskProbe.cpp
+++ b/src/Platform/Linux/LinuxDiskProbe.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <utility>
 
 namespace Platform
 {
@@ -54,9 +55,11 @@ bool LinuxDiskProbe::shouldIncludeDevice(const std::string& deviceName)
     // Check if it ends with a digit (likely a partition)
     if (!deviceName.empty() && (std::isdigit(static_cast<unsigned char>(deviceName.back())) != 0))
     {
-        // Exception: NVMe devices like "nvme0n1" end with a digit but are whole devices
-        // Include nvme0n1, nvme1n1, etc. but skip partitions like sda1, sda2, nvme0n1p1
-        return deviceName.contains("nvme") && !deviceName.contains('p');
+        // Exceptions: some whole-disk names end with a digit.
+        //   NVMe:  nvme0n1, nvme1n1  — contain "nvme", no 'p'
+        //   eMMC:  mmcblk0, mmcblk1  — contain "mmcblk", no 'p'
+        // Partitions (e.g. nvme0n1p1, mmcblk0p1) contain 'p' and are excluded.
+        return (deviceName.contains("nvme") || deviceName.contains("mmcblk")) && !deviceName.contains('p');
     }
 
     return true;

--- a/src/Platform/Linux/LinuxDiskProbe.cpp
+++ b/src/Platform/Linux/LinuxDiskProbe.cpp
@@ -10,6 +10,7 @@
 
 #include <cctype>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -17,10 +18,13 @@
 namespace Platform
 {
 
-LinuxDiskProbe::LinuxDiskProbe()
+LinuxDiskProbe::LinuxDiskProbe(std::filesystem::path diskstatsPath) : m_DiskstatsPath(std::move(diskstatsPath))
 {
     spdlog::debug("LinuxDiskProbe: initialized");
 }
+
+LinuxDiskProbe::LinuxDiskProbe() : LinuxDiskProbe("/proc/diskstats")
+{}
 
 bool LinuxDiskProbe::shouldIncludeDevice(const std::string& deviceName)
 {
@@ -62,10 +66,10 @@ SystemDiskCounters LinuxDiskProbe::read()
 {
     SystemDiskCounters result;
 
-    std::ifstream diskstats("/proc/diskstats");
+    std::ifstream diskstats(m_DiskstatsPath);
     if (!diskstats.is_open())
     {
-        spdlog::warn("LinuxDiskProbe: Failed to open /proc/diskstats");
+        spdlog::warn("LinuxDiskProbe: Failed to open {}", m_DiskstatsPath.string());
         return result;
     }
 

--- a/src/Platform/Linux/LinuxDiskProbe.h
+++ b/src/Platform/Linux/LinuxDiskProbe.h
@@ -3,6 +3,7 @@
 #include "Platform/IDiskProbe.h"
 
 #include <filesystem>
+#include <string>
 
 namespace Platform
 {

--- a/src/Platform/Linux/LinuxDiskProbe.h
+++ b/src/Platform/Linux/LinuxDiskProbe.h
@@ -28,9 +28,9 @@ class LinuxDiskProbe : public IDiskProbe
     [[nodiscard]] SystemDiskCounters read() override;
     [[nodiscard]] DiskCapabilities capabilities() const override;
 
+  private:
     [[nodiscard]] static bool shouldIncludeDevice(const std::string& deviceName);
 
-  private:
     std::filesystem::path m_DiskstatsPath;
 };
 

--- a/src/Platform/Linux/LinuxDiskProbe.h
+++ b/src/Platform/Linux/LinuxDiskProbe.h
@@ -2,6 +2,8 @@
 
 #include "Platform/IDiskProbe.h"
 
+#include <filesystem>
+
 namespace Platform
 {
 
@@ -11,6 +13,11 @@ class LinuxDiskProbe : public IDiskProbe
 {
   public:
     LinuxDiskProbe();
+
+    /// Testability constructor: reads from a custom diskstats path instead of
+    /// /proc/diskstats. Useful for unit tests that supply synthetic content.
+    explicit LinuxDiskProbe(std::filesystem::path diskstatsPath);
+
     ~LinuxDiskProbe() override = default;
 
     LinuxDiskProbe(const LinuxDiskProbe&) = delete;
@@ -21,8 +28,10 @@ class LinuxDiskProbe : public IDiskProbe
     [[nodiscard]] SystemDiskCounters read() override;
     [[nodiscard]] DiskCapabilities capabilities() const override;
 
-  private:
     [[nodiscard]] static bool shouldIncludeDevice(const std::string& deviceName);
+
+  private:
+    std::filesystem::path m_DiskstatsPath;
 };
 
 } // namespace Platform

--- a/tests/Platform/test_LinuxDiskProbe.cpp
+++ b/tests/Platform/test_LinuxDiskProbe.cpp
@@ -202,11 +202,14 @@ class LinuxDiskProbeReadTest : public ::testing::Test
     void writeDiskstats(const std::string& content) const
     {
         std::ofstream f(m_DiskstatsPath);
-        // Use EXPECT_* (not ASSERT_*): fatal assertions inside helper methods only
-        // return from the helper in gtest, so ASSERT_* would leave the test
-        // continuing with an unwritten file. EXPECT_* marks the test as failed
-        // while still propagating the error to the caller.
+        // ASSERT_* inside helpers only returns from the helper in gtest, so use
+        // EXPECT_* + early return: mark the test as failed and stop further stream
+        // operations on a bad handle so callers don't read a partially-written file.
         EXPECT_TRUE(f.is_open()) << "Failed to open temp diskstats file: " << m_DiskstatsPath;
+        if (!f.is_open())
+        {
+            return;
+        }
         f << content;
         f.flush();
         EXPECT_TRUE(f.good()) << "Failed to write temp diskstats file: " << m_DiskstatsPath;

--- a/tests/Platform/test_LinuxDiskProbe.cpp
+++ b/tests/Platform/test_LinuxDiskProbe.cpp
@@ -379,6 +379,15 @@ TEST_F(LinuxDiskProbeReadTest, MmcPartitionLineIsFiltered)
     EXPECT_TRUE(probe.read().disks.empty());
 }
 
+TEST_F(LinuxDiskProbeReadTest, MmcBootPartitionLineIsFiltered)
+{
+    // mmcblk0boot0 / mmcblk0boot1 end with a digit and contain "mmcblk" but the
+    // suffix after "mmcblk" is not all-digits ("0boot0"), so they must be excluded.
+    writeDiskstats(makeLine("mmcblk0boot0") + makeLine("mmcblk0boot1"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    EXPECT_TRUE(probe.read().disks.empty());
+}
+
 } // namespace
 } // namespace Platform
 

--- a/tests/Platform/test_LinuxDiskProbe.cpp
+++ b/tests/Platform/test_LinuxDiskProbe.cpp
@@ -202,10 +202,14 @@ class LinuxDiskProbeReadTest : public ::testing::Test
     void writeDiskstats(const std::string& content) const
     {
         std::ofstream f(m_DiskstatsPath);
-        ASSERT_TRUE(f.is_open()) << "Failed to open temp diskstats file: " << m_DiskstatsPath;
+        // Use EXPECT_* (not ASSERT_*): fatal assertions inside helper methods only
+        // return from the helper in gtest, so ASSERT_* would leave the test
+        // continuing with an unwritten file. EXPECT_* marks the test as failed
+        // while still propagating the error to the caller.
+        EXPECT_TRUE(f.is_open()) << "Failed to open temp diskstats file: " << m_DiskstatsPath;
         f << content;
         f.flush();
-        ASSERT_TRUE(f.good()) << "Failed to write temp diskstats file: " << m_DiskstatsPath;
+        EXPECT_TRUE(f.good()) << "Failed to write temp diskstats file: " << m_DiskstatsPath;
     }
 
     // Build one valid /proc/diskstats line with all required fields.

--- a/tests/Platform/test_LinuxDiskProbe.cpp
+++ b/tests/Platform/test_LinuxDiskProbe.cpp
@@ -360,12 +360,16 @@ TEST_F(LinuxDiskProbeReadTest, DeviceMapperLineIsFiltered)
     EXPECT_EQ(counters.disks[0].deviceName, "sda");
 }
 
-TEST_F(LinuxDiskProbeReadTest, MmcWholeDiskLineIsFiltered)
+TEST_F(LinuxDiskProbeReadTest, MmcWholeDiskLineIsIncluded)
 {
-    // mmcblk0 ends with a digit but has no "nvme" → treated as partition, excluded.
-    writeDiskstats(makeLine("mmcblk0"));
+    // mmcblk0 is a whole eMMC disk — it should be included now that the
+    // filter has an explicit exception for mmcblk<N> (no 'p' suffix).
+    writeDiskstats(makeLine("mmcblk0", 80, 160, 30, 60));
     LinuxDiskProbe probe(m_DiskstatsPath);
-    EXPECT_TRUE(probe.read().disks.empty());
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "mmcblk0");
 }
 
 TEST_F(LinuxDiskProbeReadTest, MmcPartitionLineIsFiltered)

--- a/tests/Platform/test_LinuxDiskProbe.cpp
+++ b/tests/Platform/test_LinuxDiskProbe.cpp
@@ -3,9 +3,9 @@
 ///
 /// Contains two test suites:
 ///   1. Integration tests that interact with the real /proc/diskstats filesystem.
-///   2. Unit tests using shouldIncludeDevice() directly and a synthetic diskstats
-///      file written to a temp path, covering all filter branches and read() paths
-///      that cannot be reliably triggered on real hardware.
+///   2. Unit tests using a synthetic diskstats file written to a temp path,
+///      covering all filter branches and read() paths that cannot be reliably
+///      triggered on real hardware.
 
 #include <gtest/gtest.h>
 
@@ -14,11 +14,14 @@
 #include "Platform/Linux/LinuxDiskProbe.h"
 #include "Platform/StorageTypes.h"
 
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <string>
 #include <thread>
+
+#include <unistd.h>
 
 namespace Platform
 {
@@ -169,98 +172,13 @@ TEST(LinuxDiskProbeTest, ConsecutiveReadsAreConsistent)
 } // namespace Platform
 
 // =============================================================================
-// shouldIncludeDevice — unit tests (all filter branches)
+// Synthetic diskstats read() — unit tests via temp file
 // =============================================================================
 
 namespace Platform
 {
 namespace
 {
-
-// ---- Loop devices -----------------------------------------------------------
-
-TEST(LinuxDiskProbeShouldIncludeTest, LoopDeviceIsExcluded)
-{
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("loop0"));
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("loop1"));
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("loop100"));
-}
-
-// ---- RAM devices ------------------------------------------------------------
-
-TEST(LinuxDiskProbeShouldIncludeTest, RamDeviceIsExcluded)
-{
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("ram0"));
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("ram1"));
-}
-
-// ---- SCSI / SATA whole disks ------------------------------------------------
-
-TEST(LinuxDiskProbeShouldIncludeTest, ScsiWholeDiskIsIncluded)
-{
-    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("sda"));
-    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("sdb"));
-    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("sdc"));
-}
-
-TEST(LinuxDiskProbeShouldIncludeTest, ScsiPartitionIsExcluded)
-{
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("sda1"));
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("sda2"));
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("sdb3"));
-}
-
-// ---- Virtual / cloud disks --------------------------------------------------
-
-TEST(LinuxDiskProbeShouldIncludeTest, VirtualDiskIsIncluded)
-{
-    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("vda"));
-    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("vdb"));
-}
-
-// ---- Device mapper (LVM) ----------------------------------------------------
-
-TEST(LinuxDiskProbeShouldIncludeTest, DeviceMapperIsExcluded)
-{
-    // dm-0 ends with a digit and does not contain "nvme" → excluded
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("dm-0"));
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("dm-1"));
-}
-
-// ---- NVMe whole namespaces --------------------------------------------------
-
-TEST(LinuxDiskProbeShouldIncludeTest, NvmeWholeNamespaceIsIncluded)
-{
-    // nvme0n1 ends with '1' (digit), contains "nvme", no 'p' → included
-    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("nvme0n1"));
-    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("nvme1n1"));
-    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("nvme0n2"));
-}
-
-TEST(LinuxDiskProbeShouldIncludeTest, NvmePartitionIsExcluded)
-{
-    // nvme0n1p1 ends with '1', contains "nvme", but also contains 'p' → excluded
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("nvme0n1p1"));
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("nvme0n1p2"));
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("nvme1n1p3"));
-}
-
-// ---- eMMC (mmcblk) ----------------------------------------------------------
-
-TEST(LinuxDiskProbeShouldIncludeTest, MmcWholeDiskIsExcluded)
-{
-    // mmcblk0 ends with '0' (digit), no "nvme" → excluded by partition heuristic
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("mmcblk0"));
-}
-
-TEST(LinuxDiskProbeShouldIncludeTest, MmcPartitionIsExcluded)
-{
-    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("mmcblk0p1"));
-}
-
-// =============================================================================
-// Synthetic diskstats read() — unit tests via temp file
-// =============================================================================
 
 class LinuxDiskProbeReadTest : public ::testing::Test
 {
@@ -284,7 +202,10 @@ class LinuxDiskProbeReadTest : public ::testing::Test
     void writeDiskstats(const std::string& content) const
     {
         std::ofstream f(m_DiskstatsPath);
+        ASSERT_TRUE(f.is_open()) << "Failed to open temp diskstats file: " << m_DiskstatsPath;
         f << content;
+        f.flush();
+        ASSERT_TRUE(f.good()) << "Failed to write temp diskstats file: " << m_DiskstatsPath;
     }
 
     // Build one valid /proc/diskstats line with all required fields.
@@ -416,6 +337,42 @@ TEST_F(LinuxDiskProbeReadTest, TotalCountersMatchSumOfParsedDisks)
     // readBytes = sectors * 512
     EXPECT_EQ(counters.totalReadBytes(), (200U + 400U) * 512U);
     EXPECT_EQ(counters.totalWriteBytes(), (100U + 160U) * 512U);
+}
+
+TEST_F(LinuxDiskProbeReadTest, VirtualDiskLineIsIncluded)
+{
+    writeDiskstats(makeLine("vda", 50, 100, 20, 40));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "vda");
+}
+
+TEST_F(LinuxDiskProbeReadTest, DeviceMapperLineIsFiltered)
+{
+    // dm-0 (LVM) must be excluded; sda alongside it must pass through.
+    writeDiskstats(makeLine("dm-0") + makeLine("sda"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "sda");
+}
+
+TEST_F(LinuxDiskProbeReadTest, MmcWholeDiskLineIsFiltered)
+{
+    // mmcblk0 ends with a digit but has no "nvme" → treated as partition, excluded.
+    writeDiskstats(makeLine("mmcblk0"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    EXPECT_TRUE(probe.read().disks.empty());
+}
+
+TEST_F(LinuxDiskProbeReadTest, MmcPartitionLineIsFiltered)
+{
+    writeDiskstats(makeLine("mmcblk0p1"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    EXPECT_TRUE(probe.read().disks.empty());
 }
 
 } // namespace

--- a/tests/Platform/test_LinuxDiskProbe.cpp
+++ b/tests/Platform/test_LinuxDiskProbe.cpp
@@ -1,8 +1,11 @@
 /// @file test_LinuxDiskProbe.cpp
-/// @brief Integration tests for Platform::LinuxDiskProbe
+/// @brief Tests for Platform::LinuxDiskProbe
 ///
-/// These are integration tests that interact with the real /proc/diskstats filesystem.
-/// They verify that the probe correctly reads and parses disk I/O information.
+/// Contains two test suites:
+///   1. Integration tests that interact with the real /proc/diskstats filesystem.
+///   2. Unit tests using shouldIncludeDevice() directly and a synthetic diskstats
+///      file written to a temp path, covering all filter branches and read() paths
+///      that cannot be reliably triggered on real hardware.
 
 #include <gtest/gtest.h>
 
@@ -12,7 +15,9 @@
 #include "Platform/StorageTypes.h"
 
 #include <chrono>
+#include <filesystem>
 #include <fstream>
+#include <string>
 #include <thread>
 
 namespace Platform
@@ -158,6 +163,259 @@ TEST(LinuxDiskProbeTest, ConsecutiveReadsAreConsistent)
 
     // Device list should be stable between consecutive reads
     EXPECT_EQ(counters1.disks.size(), counters2.disks.size());
+}
+
+} // namespace
+} // namespace Platform
+
+// =============================================================================
+// shouldIncludeDevice — unit tests (all filter branches)
+// =============================================================================
+
+namespace Platform
+{
+namespace
+{
+
+// ---- Loop devices -----------------------------------------------------------
+
+TEST(LinuxDiskProbeShouldIncludeTest, LoopDeviceIsExcluded)
+{
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("loop0"));
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("loop1"));
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("loop100"));
+}
+
+// ---- RAM devices ------------------------------------------------------------
+
+TEST(LinuxDiskProbeShouldIncludeTest, RamDeviceIsExcluded)
+{
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("ram0"));
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("ram1"));
+}
+
+// ---- SCSI / SATA whole disks ------------------------------------------------
+
+TEST(LinuxDiskProbeShouldIncludeTest, ScsiWholeDiskIsIncluded)
+{
+    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("sda"));
+    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("sdb"));
+    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("sdc"));
+}
+
+TEST(LinuxDiskProbeShouldIncludeTest, ScsiPartitionIsExcluded)
+{
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("sda1"));
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("sda2"));
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("sdb3"));
+}
+
+// ---- Virtual / cloud disks --------------------------------------------------
+
+TEST(LinuxDiskProbeShouldIncludeTest, VirtualDiskIsIncluded)
+{
+    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("vda"));
+    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("vdb"));
+}
+
+// ---- Device mapper (LVM) ----------------------------------------------------
+
+TEST(LinuxDiskProbeShouldIncludeTest, DeviceMapperIsExcluded)
+{
+    // dm-0 ends with a digit and does not contain "nvme" → excluded
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("dm-0"));
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("dm-1"));
+}
+
+// ---- NVMe whole namespaces --------------------------------------------------
+
+TEST(LinuxDiskProbeShouldIncludeTest, NvmeWholeNamespaceIsIncluded)
+{
+    // nvme0n1 ends with '1' (digit), contains "nvme", no 'p' → included
+    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("nvme0n1"));
+    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("nvme1n1"));
+    EXPECT_TRUE(LinuxDiskProbe::shouldIncludeDevice("nvme0n2"));
+}
+
+TEST(LinuxDiskProbeShouldIncludeTest, NvmePartitionIsExcluded)
+{
+    // nvme0n1p1 ends with '1', contains "nvme", but also contains 'p' → excluded
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("nvme0n1p1"));
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("nvme0n1p2"));
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("nvme1n1p3"));
+}
+
+// ---- eMMC (mmcblk) ----------------------------------------------------------
+
+TEST(LinuxDiskProbeShouldIncludeTest, MmcWholeDiskIsExcluded)
+{
+    // mmcblk0 ends with '0' (digit), no "nvme" → excluded by partition heuristic
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("mmcblk0"));
+}
+
+TEST(LinuxDiskProbeShouldIncludeTest, MmcPartitionIsExcluded)
+{
+    EXPECT_FALSE(LinuxDiskProbe::shouldIncludeDevice("mmcblk0p1"));
+}
+
+// =============================================================================
+// Synthetic diskstats read() — unit tests via temp file
+// =============================================================================
+
+class LinuxDiskProbeReadTest : public ::testing::Test
+{
+  protected:
+    std::filesystem::path m_DiskstatsPath;
+
+    void SetUp() override
+    {
+        static std::atomic<int> s_counter{0};
+        const auto seq = s_counter.fetch_add(1, std::memory_order_relaxed);
+        m_DiskstatsPath =
+            std::filesystem::temp_directory_path() / ("tasksmack_diskstats_" + std::to_string(getpid()) + "_" + std::to_string(seq));
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        std::filesystem::remove(m_DiskstatsPath, ec);
+    }
+
+    void writeDiskstats(const std::string& content) const
+    {
+        std::ofstream f(m_DiskstatsPath);
+        f << content;
+    }
+
+    // Build one valid /proc/diskstats line with all required fields.
+    // Fields: major minor name reads_completed reads_merged sectors_read
+    //         time_reading writes_completed writes_merged sectors_written
+    //         time_writing io_in_progress time_io weighted_time_io
+    static std::string makeLine(const std::string& name,
+                                uint64_t readsCompleted = 100,
+                                uint64_t sectorsRead = 200,
+                                uint64_t writesCompleted = 50,
+                                uint64_t sectorsWritten = 100)
+    {
+        return "8 0 " + name + " " + std::to_string(readsCompleted) + " 10 " + std::to_string(sectorsRead) + " 500 " +
+               std::to_string(writesCompleted) + " 5 " + std::to_string(sectorsWritten) + " 300 0 800 1000\n";
+    }
+};
+
+TEST_F(LinuxDiskProbeReadTest, EmptyFileReturnsNoDisks)
+{
+    writeDiskstats("");
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    EXPECT_TRUE(probe.read().disks.empty());
+}
+
+TEST_F(LinuxDiskProbeReadTest, MissingFileReturnsNoDisks)
+{
+    // Do NOT write the file — probe should log a warning and return empty.
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    EXPECT_TRUE(probe.read().disks.empty());
+}
+
+TEST_F(LinuxDiskProbeReadTest, ValidSdaLineIsIncluded)
+{
+    writeDiskstats(makeLine("sda", 100, 200, 50, 100));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "sda");
+    EXPECT_EQ(counters.disks[0].readsCompleted, 100U);
+    EXPECT_EQ(counters.disks[0].readSectors, 200U);
+    EXPECT_EQ(counters.disks[0].writesCompleted, 50U);
+    EXPECT_EQ(counters.disks[0].writeSectors, 100U);
+    EXPECT_EQ(counters.disks[0].sectorSize, 512U);
+    EXPECT_TRUE(counters.disks[0].isPhysicalDevice);
+}
+
+TEST_F(LinuxDiskProbeReadTest, LoopDeviceLineIsFiltered)
+{
+    writeDiskstats(makeLine("loop0") + makeLine("sda"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "sda");
+}
+
+TEST_F(LinuxDiskProbeReadTest, RamDeviceLineIsFiltered)
+{
+    writeDiskstats(makeLine("ram0") + makeLine("sdb"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "sdb");
+}
+
+TEST_F(LinuxDiskProbeReadTest, PartitionLineIsFiltered)
+{
+    writeDiskstats(makeLine("sda1") + makeLine("sda"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "sda");
+}
+
+TEST_F(LinuxDiskProbeReadTest, NvmeWholeNamespaceIsIncluded)
+{
+    writeDiskstats(makeLine("nvme0n1", 300, 600, 150, 400));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "nvme0n1");
+    EXPECT_EQ(counters.disks[0].readsCompleted, 300U);
+}
+
+TEST_F(LinuxDiskProbeReadTest, NvmePartitionLineIsFiltered)
+{
+    writeDiskstats(makeLine("nvme0n1p1") + makeLine("nvme0n1"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "nvme0n1");
+}
+
+TEST_F(LinuxDiskProbeReadTest, MalformedLineIsSkipped)
+{
+    // Too few fields — iss.fail() should trigger the continue path.
+    writeDiskstats("8 0 sda 100\n" + makeLine("sdb"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    // Malformed sda line skipped; sdb present
+    ASSERT_EQ(counters.disks.size(), 1U);
+    EXPECT_EQ(counters.disks[0].deviceName, "sdb");
+}
+
+TEST_F(LinuxDiskProbeReadTest, MultipleDisksAllParsed)
+{
+    writeDiskstats(makeLine("sda") + makeLine("sdb") + makeLine("nvme0n1"));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 3U);
+}
+
+TEST_F(LinuxDiskProbeReadTest, TotalCountersMatchSumOfParsedDisks)
+{
+    writeDiskstats(makeLine("sda", 100, 200, 50, 100) + makeLine("sdb", 200, 400, 80, 160));
+    LinuxDiskProbe probe(m_DiskstatsPath);
+    auto counters = probe.read();
+
+    ASSERT_EQ(counters.disks.size(), 2U);
+    EXPECT_EQ(counters.totalReadsCompleted(), 300U);
+    EXPECT_EQ(counters.totalWritesCompleted(), 130U);
+    // readBytes = sectors * 512
+    EXPECT_EQ(counters.totalReadBytes(), (200U + 400U) * 512U);
+    EXPECT_EQ(counters.totalWriteBytes(), (100U + 160U) * 512U);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Improves line/branch coverage for `LinuxDiskProbe` by adding path injection and a comprehensive unit test fixture suite. Also fixes a filter bug where eMMC whole-disk devices (`mmcblk0`) were incorrectly excluded.

### src/Platform/Linux/LinuxDiskProbe.h + LinuxDiskProbe.cpp

- Added `explicit LinuxDiskProbe(std::filesystem::path diskstatsPath)` injection constructor; default constructor delegates to it via `LinuxDiskProbe("/proc/diskstats")`
- `read()` now uses `m_DiskstatsPath` instead of a hardcoded literal — no behavior change for production use, enables full unit testing
- `shouldIncludeDevice()` remains private; branch coverage is driven through `read()` via synthetic diskstats content
- Added `#include <utility>` for `std::move` in the constructor initializer list
- **Bug fix:** eMMC whole-disk devices (`mmcblk0`, `mmcblk1`) are now correctly included; partitions (`mmcblk0p1`) remain excluded

### tests/Platform/test_LinuxDiskProbe.cpp — 9 → 25 tests

**`LinuxDiskProbeReadTest` fixture (16 new tests)** — synthetic diskstats file via temp path:

- `EmptyFileReturnsNoDisks`, `MissingFileReturnsNoDisks`
- `ValidSdaLineIsIncluded`, `LoopDeviceLineIsFiltered`, `RamDeviceLineIsFiltered`
- `PartitionLineIsFiltered`, `NvmeWholeNamespaceIsIncluded`, `NvmePartitionLineIsFiltered`
- `VirtualDiskLineIsIncluded`, `DeviceMapperLineIsFiltered`
- `MmcWholeDiskLineIsIncluded`, `MmcPartitionLineIsFiltered`
- `MalformedLineIsSkipped`, `MultipleDisksAllParsed`, `TotalCountersMatchSumOfParsedDisks`

Added `<atomic>` and `<unistd.h>` explicit includes; `writeDiskstats()` now asserts the file opened and wrote successfully.

### Tests

1154 tests passing (5 skipped — headless/GPU unavailable)