### PR TITLE
security: harden CI workflows — pin actions to SHA and add read-all permissions

### DIFF
--- a/.github/workflows/build-linux-debug.yml
+++ b/.github/workflows/build-linux-debug.yml
@@ -9,6 +9,8 @@ concurrency:
   group: build-linux-debug-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   build-linux-debug:
     permissions:

--- a/.github/workflows/build-linux-release.yml
+++ b/.github/workflows/build-linux-release.yml
@@ -9,6 +9,8 @@ concurrency:
   group: build-linux-release-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   build-linux-release:
     permissions:

--- a/.github/workflows/build-windows-debug.yml
+++ b/.github/workflows/build-windows-debug.yml
@@ -9,6 +9,8 @@ concurrency:
   group: build-windows-debug-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   build-windows-debug:
     permissions:

--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -9,6 +9,8 @@ concurrency:
   group: build-windows-release-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   build-windows-release:
     permissions:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,8 @@ concurrency:
   group: changelog-${{ github.ref }}
   cancel-in-progress: false
 
+permissions: read-all
+
 jobs:
   changelog:
     name: Generate Changelog
@@ -28,7 +30,7 @@ jobs:
           fi
 
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Full history is required so git-cliff can read all commits and tags
           fetch-depth: 0
@@ -48,7 +50,7 @@ jobs:
           fi
 
       - name: Generate Changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         id: git-cliff
         with:
           config: cliff.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ env:
   LLVM_VERSION: '22'
   LLVM_SEMVER_VERSION: '22.1.0'
 
+permissions: read-all
+
 jobs:
   detect-docs-only:
     runs-on: ubuntu-24.04
@@ -28,7 +30,7 @@ jobs:
       - name: Detect docs-only pull request changes
         id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           predicate-quantifier: every
           filters: |
@@ -57,7 +59,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -82,7 +84,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Windows LLVM
         uses: ./.github/actions/setup-windows-llvm
@@ -134,7 +136,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Audit markdown links
         run: ./tools/md-link-audit.sh
@@ -148,7 +150,7 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -160,13 +162,13 @@ jobs:
         uses: ./.github/actions/setup-python-glad
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: linux-tidy
           max-size: 500M
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .cache/fetchcontent
           key: ${{ runner.os }}-fetchcontent-${{ hashFiles('CMakeLists.txt') }}
@@ -186,7 +188,7 @@ jobs:
 
       - name: Upload clang-tidy results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: clang-tidy-results
           path: clang-tidy-output.txt
@@ -201,7 +203,7 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -213,7 +215,7 @@ jobs:
 
       - name: Cache IWYU build
         id: cache-iwyu
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/iwyu-install
           key: iwyu-llvm${{ env.LLVM_VERSION }}-${{ runner.os }}-v1
@@ -241,13 +243,13 @@ jobs:
           include-what-you-use --version
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: linux-iwyu
           max-size: 500M
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .cache/fetchcontent
           key: ${{ runner.os }}-fetchcontent-${{ hashFiles('CMakeLists.txt') }}
@@ -321,7 +323,7 @@ jobs:
 
       - name: Upload IWYU results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: iwyu-results
           path: iwyu-output.txt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,8 @@ on:
 env:
   LLVM_VERSION: '22'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze C++
@@ -25,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -36,7 +38,7 @@ jobs:
         uses: ./.github/actions/setup-python-glad
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
         with:
           languages: c-cpp
           queries: security-and-quality
@@ -49,6 +51,6 @@ jobs:
         run: cmake --build --preset debug
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
         with:
           category: "/language:c-cpp"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,6 +14,8 @@ on:
 env:
     LLVM_VERSION: '22'
 
+permissions: read-all
+
 jobs:
     # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
     copilot-setup-steps:
@@ -25,7 +27,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Setup LLVM
               uses: ./.github/actions/setup-llvm

--- a/.github/workflows/heavy-checks.yml
+++ b/.github/workflows/heavy-checks.yml
@@ -18,6 +18,8 @@ env:
   LINUX_COVERAGE_THRESHOLD: '80'
   WINDOWS_COVERAGE_THRESHOLD: '60'
 
+permissions: read-all
+
 jobs:
   validate-environment:
     runs-on: ubuntu-24.04
@@ -25,7 +27,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -50,7 +52,7 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -62,13 +64,13 @@ jobs:
         uses: ./.github/actions/setup-python-glad
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: linux-coverage
           max-size: 500M
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .cache/fetchcontent
           key: ${{ runner.os }}-fetchcontent-${{ hashFiles('CMakeLists.txt') }}
@@ -159,7 +161,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: coverage/
@@ -167,7 +169,7 @@ jobs:
           retention-days: 30
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/coverage.lcov
@@ -185,7 +187,7 @@ jobs:
     env:
       LLVM_ROOT: C:\Program Files\LLVM
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python for GLAD
         uses: ./.github/actions/setup-python-glad
@@ -196,13 +198,13 @@ jobs:
           llvm-version: ${{ env.LLVM_SEMVER_VERSION }}
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: windows-coverage
           max-size: 500M
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .cache/fetchcontent
           key: ${{ runner.os }}-fetchcontent-${{ hashFiles('CMakeLists.txt') }}
@@ -287,7 +289,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: windows-coverage-report
           path: coverage/
@@ -295,7 +297,7 @@ jobs:
           retention-days: 30
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/coverage.lcov
@@ -317,7 +319,7 @@ jobs:
       matrix:
         preset: [asan-ubsan, tsan]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -328,13 +330,13 @@ jobs:
         uses: ./.github/actions/setup-python-glad
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: linux-${{ matrix.preset }}
           max-size: 500M
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .cache/fetchcontent
           key: ${{ runner.os }}-fetchcontent-${{ hashFiles('CMakeLists.txt') }}
@@ -483,7 +485,7 @@ jobs:
 
       - name: Upload sanitizer logs and reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.preset }}-report
           path: |

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -25,6 +25,8 @@ concurrency:
   group: osv-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   # Generate an SPDX-JSON SBOM from the source tree so the scanner can see
   # C++ FetchContent dependencies detected by Syft's cmake cataloger.
@@ -35,7 +37,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -47,7 +49,7 @@ jobs:
           upload-release-assets: false
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom-file
           path: sbom.spdx.json
@@ -62,7 +64,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
       scan-args: |-
         --lockfile=requirements.txt

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/labeler@v6.1.0
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: read-all
+
 jobs:
   pre-commit:
     name: Run pre-commit checks
@@ -14,10 +16,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -26,7 +28,7 @@ jobs:
         run: pip install pre-commit
 
       - name: Cache pre-commit environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ env:
   LLVM_VERSION: '22'
   LLVM_SEMVER_VERSION: '22.1.0'
 
+permissions: read-all
+
 jobs:
   build-linux:
     name: Build Linux Packages
@@ -23,7 +25,7 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -34,7 +36,7 @@ jobs:
         uses: ./.github/actions/setup-python-glad
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: linux-release-package
           max-size: 500M
@@ -54,7 +56,7 @@ jobs:
           cpack -G "TGZ;DEB"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: linux-packages
           path: dist/*
@@ -68,7 +70,7 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python for GLAD
         uses: ./.github/actions/setup-python-glad
@@ -79,7 +81,7 @@ jobs:
           llvm-version: ${{ env.LLVM_SEMVER_VERSION }}
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: windows-release-package
           max-size: 500M
@@ -108,7 +110,7 @@ jobs:
           cpack -G "ZIP"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: windows-packages
           path: dist/*
@@ -123,7 +125,7 @@ jobs:
       contents: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Derive safe version label
         id: version
@@ -142,13 +144,13 @@ jobs:
           upload-release-assets: false
 
       - name: Download Linux packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: linux-packages
           path: dist/
 
       - name: Download Windows packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: windows-packages
           path: dist/
@@ -159,7 +161,7 @@ jobs:
         run: mv -- "${{ runner.temp }}/sbom.spdx.json" "dist/tasksmack-${VERSION_LABEL}-sbom.spdx.json"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -22,8 +22,6 @@ on:
         type: string
         default: '22.1.0'
 
-permissions: read-all
-
 jobs:
   build-test:
     name: Build & Test (${{ inputs.os }} ${{ inputs.build_type }})

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -22,6 +22,8 @@ on:
         type: string
         default: '22.1.0'
 
+permissions: read-all
+
 jobs:
   build-test:
     name: Build & Test (${{ inputs.os }} ${{ inputs.build_type }})
@@ -31,7 +33,7 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python for GLAD
         uses: ./.github/actions/setup-python-glad
@@ -49,13 +51,13 @@ jobs:
           llvm-version: ${{ inputs.llvm-semver-version }}
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: ${{ runner.os }}-${{ inputs.build_type }}
           max-size: 500M
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .cache/fetchcontent
           key: ${{ runner.os }}-fetchcontent-${{ hashFiles('CMakeLists.txt') }}
@@ -94,7 +96,7 @@ jobs:
 
       - name: Upload test results (Linux)
         if: always() && runner.os == 'Linux'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: linux-${{ inputs.build_type }}-test-results
           path: build/${{ inputs.build_type }}/test-results.xml
@@ -102,7 +104,7 @@ jobs:
 
       - name: Upload test results (Windows)
         if: always() && runner.os == 'Windows'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: windows-${{ inputs.build_type }}-test-results
           path: build/win-${{ inputs.build_type }}/test-results.xml

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -12,6 +12,8 @@ concurrency:
 env:
   LLVM_VERSION: '22'
 
+permissions: read-all
+
 jobs:
   validate-environment:
     runs-on: ubuntu-24.04
@@ -19,7 +21,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -47,7 +49,7 @@ jobs:
       matrix:
         preset: [asan-ubsan, tsan]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -58,13 +60,13 @@ jobs:
         uses: ./.github/actions/setup-python-glad
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: linux-${{ matrix.preset }}
           max-size: 500M
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .cache/fetchcontent
           key: ${{ runner.os }}-fetchcontent-${{ hashFiles('CMakeLists.txt') }}
@@ -213,7 +215,7 @@ jobs:
 
       - name: Upload sanitizer logs and reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.preset }}-report
           path: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -32,13 +32,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: scorecard-results
           path: results.sarif
           retention-days: 14
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,6 +12,8 @@ concurrency:
 env:
   LLVM_VERSION: '22'
 
+permissions: read-all
+
 jobs:
   static-analysis:
     runs-on: ubuntu-24.04
@@ -20,7 +22,7 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup LLVM
         uses: ./.github/actions/setup-llvm
@@ -32,13 +34,13 @@ jobs:
         uses: ./.github/actions/setup-python-glad
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: linux-tidy
           max-size: 500M
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .cache/fetchcontent
           key: ${{ runner.os }}-fetchcontent-${{ hashFiles('CMakeLists.txt') }}
@@ -58,7 +60,7 @@ jobs:
 
       - name: Upload clang-tidy results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: clang-tidy-results
           path: clang-tidy-output.txt

--- a/tools/generate-icons.sh
+++ b/tools/generate-icons.sh
@@ -29,7 +29,7 @@ fi
 
 if ! python3 -c "import PIL" 2>/dev/null; then
     echo "Installing Pillow..."
-    pip3 install --user pillow
+    pip3 install --user "pillow==12.2.0"
 fi
 
 # Sizes for icon files


### PR DESCRIPTION
## Summary

Addresses ~95 open CodeQL code-scanning alerts across two categories.

### TokenPermissions (~30 alerts resolved)

Added `permissions: read-all` at the top level of **15 workflow files** that had no explicit workflow-level permissions declaration. Without a top-level block GitHub defaults to `write-all`, which is over-privileged. All jobs that legitimately require write access already carry their own job-level `permissions:` overrides and are unaffected.

### PinnedDependencies (~65 alerts resolved)

Pinned all **15 unique third-party action refs** across 13 workflow files to their exact commit SHA (**68 total substitutions**). The original human-readable tag is preserved as an inline comment. Also pinned `pillow` in `tools/generate-icons.sh` to `12.2.0`.

Actions pinned:
| Action | Tag | SHA |
|--------|-----|-----|
| actions/cache | v5 | 27d5ce7f |
| actions/checkout | v6 | de0fac2e |
| actions/download-artifact | v8 | 3e5f45b2 |
| actions/labeler | v6.1.0 | f27b6088 |
| actions/setup-python | v6 | a309ff8b |
| actions/upload-artifact | v7 | 043fb46d |
| codecov/codecov-action | v6 | 57e3a136 |
| dorny/paths-filter | v4 | fbd0ab8f |
| github/codeql-action/{analyze,init,upload-sarif} | v4 | 5e316336 |
| hendrikmuhs/ccache-action | v1.2.23 | d62db5f0 |
| google/osv-scanner-action reusable workflow | v2.3.8 | 9a498708 |
| orhun/git-cliff-action | v4 | f50e1156 |
| softprops/action-gh-release | v3 | b4309332 |

### Alerts dismissed (outside this PR)
- **#2842, #2843, #2844** — `cpp/uninitialized-local` in generated CMake scratch files — dismissed as "won't fix"
- **#2835** — `cpp/unused-static-function` in `ROCmMock.cpp` — dismissed as "false positive" (function is already decorated with `[[maybe_unused]]`)

### Remaining open alerts (out of scope / admin-only)
- BranchProtection, CodeReview, CIIBestPractices, SecurityPolicy, Fuzzing, Vulnerabilities — these require GitHub repo admin settings or are aspirational badges