### PR TITLE
fix: correct github/codeql-action SHA to underlying commit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/setup-python-glad
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: c-cpp
           queries: security-and-quality
@@ -51,6 +51,6 @@ jobs:
         run: cmake --build --preset debug
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           category: "/language:c-cpp"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           retention-days: 14
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

PR #531 introduced SHA-pinned references for `github/codeql-action`, but used the **annotated tag object SHA** instead of the **underlying commit SHA**. GitHub Actions resolves action references as commits; an annotated tag SHA returns HTTP 404 when looked up as a commit, causing the Scorecard and CodeQL workflows to fail immediately.

Verification:
- `GET /repos/github/codeql-action/git/commits/5e316336eb4f107009e477d4bfbfff13d7250fae` → **404** (not a commit)
- `GET /repos/github/codeql-action/git/tags/5e316336eb4f107009e477d4bfbfff13d7250fae` → object.sha = `68bde559dea0fdcac2102bfdf6230c5f70eb485e`, type = `commit` ✅

## Fix

Replace the annotated tag object SHA with the underlying commit SHA in all three references:

| File | Action | Old SHA (tag object) | New SHA (commit) |
|------|--------|----------------------|-----------------|
| `scorecard.yml` | `upload-sarif` | `5e316336...` | `68bde559...` |
| `codeql.yml` | `init` | `5e316336...` | `68bde559...` |
| `codeql.yml` | `analyze` | `5e316336...` | `68bde559...` |

Both point to `github/codeql-action@v4` — only the SHA type changes.

## Testing

After merge, the Scorecard and CodeQL workflow runs triggered by this PR merge should pass.