### PR TITLE
test(coverage): inject procRoot seam + error-path tests for LinuxSystemProbe and LinuxProcessProbe

### DIFF
--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -133,8 +133,14 @@ std::mutex& getUsernameCacheMutex()
 
 } // namespace
 
-LinuxProcessProbe::LinuxProcessProbe()
-    : m_TicksPerSecond(sysconf(_SC_CLK_TCK)), m_PageSize(toU64PositiveOr(sysconf(_SC_PAGESIZE), 4096ULL)), m_BootTimeEpoch(readBootTime())
+LinuxProcessProbe::LinuxProcessProbe() : LinuxProcessProbe(std::filesystem::path("/proc"))
+{}
+
+LinuxProcessProbe::LinuxProcessProbe(std::filesystem::path procRoot)
+    : m_ProcRoot(std::move(procRoot)),
+      m_TicksPerSecond(sysconf(_SC_CLK_TCK)),
+      m_PageSize(toU64PositiveOr(sysconf(_SC_PAGESIZE), 4096ULL)),
+      m_BootTimeEpoch(readBootTime(m_ProcRoot))
 {
     if (m_TicksPerSecond <= 0)
     {
@@ -194,7 +200,7 @@ std::vector<ProcessCounters> LinuxProcessProbe::enumerate()
     // Reserving a fixed constant (e.g. 500) wastes memory on light systems
     // and still reallocates on busy ones. Let the allocator manage growth.
 
-    const std::filesystem::path procPath("/proc");
+    const std::filesystem::path& procPath = m_ProcRoot;
     std::error_code errorCode;
 
     for (const auto& entry : std::filesystem::directory_iterator(procPath, errorCode))
@@ -222,13 +228,13 @@ std::vector<ProcessCounters> LinuxProcessProbe::enumerate()
         }
 
         parseProcessStatm(pid, counters);
-        parseProcessStatus(pid, counters);
-        parseProcessCmdline(pid, counters);
+        parseProcessStatus(pid, counters, m_ProcRoot);
+        parseProcessCmdline(pid, counters, m_ProcRoot);
         // CPU affinity is always safe to query; failures zero the mask
         parseProcessAffinity(pid, counters);
 
         // Count open file descriptors (may fail for some processes due to permissions)
-        countProcessFds(pid, counters);
+        countProcessFds(pid, counters, m_ProcRoot);
 
         // Only attempt I/O counters if we know they're readable
         // Use std::call_once for thread-safe lazy initialization; relaxed ordering is sufficient
@@ -236,9 +242,9 @@ std::vector<ProcessCounters> LinuxProcessProbe::enumerate()
                        [this]() { m_IoCountersAvailable.store(checkIoCountersAvailability(), std::memory_order_relaxed); });
         if (m_IoCountersAvailable.load(std::memory_order_relaxed))
         {
-            parseProcessIo(pid, counters);
+            parseProcessIo(pid, counters, m_ProcRoot);
         }
-        counters.status = getProcessStatus(pid); // Get cgroup freezer status
+        counters.status = getProcessStatus(pid, m_ProcRoot); // Get cgroup freezer status
         processes.push_back(std::move(counters));
     }
 
@@ -314,7 +320,7 @@ bool LinuxProcessProbe::parseProcessStat(int32_t pid, ProcessCounters& counters)
     //         minflt cminflt majflt cmajflt utime stime cutime cstime
     //         priority nice num_threads itrealvalue starttime vsize rss ...
 
-    const auto statPath = std::format("/proc/{}/stat", pid);
+    const auto statPath = (m_ProcRoot / std::to_string(pid) / "stat").string();
     std::ifstream statFile(statPath);
     if (!statFile.is_open())
     {
@@ -417,7 +423,7 @@ void LinuxProcessProbe::parseProcessStatm(int32_t pid, ProcessCounters& counters
     // Format: /proc/[pid]/statm
     // Fields: size resident shared text lib data dt (all in pages)
 
-    const auto statmPath = std::format("/proc/{}/statm", pid);
+    const auto statmPath = (m_ProcRoot / std::to_string(pid) / "statm").string();
     std::ifstream statmFile(statmPath);
     if (!statmFile.is_open())
     {
@@ -437,13 +443,13 @@ void LinuxProcessProbe::parseProcessStatm(int32_t pid, ProcessCounters& counters
     }
 }
 
-void LinuxProcessProbe::parseProcessStatus(int32_t pid, ProcessCounters& counters)
+void LinuxProcessProbe::parseProcessStatus(int32_t pid, ProcessCounters& counters, const std::filesystem::path& procRoot)
 {
     // Read /proc/[pid]/status for UID (owner) information
     // Format is key:value pairs, one per line
     // We need: Uid: <real> <effective> <saved> <filesystem>
 
-    const auto statusPath = std::format("/proc/{}/status", pid);
+    const auto statusPath = (procRoot / std::to_string(pid) / "status").string();
     std::ifstream statusFile(statusPath);
     if (!statusFile.is_open())
     {
@@ -473,12 +479,12 @@ void LinuxProcessProbe::parseProcessStatus(int32_t pid, ProcessCounters& counter
     }
 }
 
-void LinuxProcessProbe::parseProcessCmdline(int32_t pid, ProcessCounters& counters)
+void LinuxProcessProbe::parseProcessCmdline(int32_t pid, ProcessCounters& counters, const std::filesystem::path& procRoot)
 {
     // Format: /proc/[pid]/cmdline
     // Arguments are separated by null bytes
 
-    const auto cmdlinePath = std::format("/proc/{}/cmdline", pid);
+    const auto cmdlinePath = (procRoot / std::to_string(pid) / "cmdline").string();
     std::ifstream cmdlineFile(cmdlinePath, std::ios::binary);
     if (!cmdlineFile.is_open())
     {
@@ -539,7 +545,7 @@ void LinuxProcessProbe::parseProcessAffinity(int32_t pid, ProcessCounters& count
     }
 }
 
-void LinuxProcessProbe::parseProcessIo(int32_t pid, ProcessCounters& counters)
+void LinuxProcessProbe::parseProcessIo(int32_t pid, ProcessCounters& counters, const std::filesystem::path& procRoot)
 {
     // Format: /proc/[pid]/io
     // Key-value pairs, one per line:
@@ -555,7 +561,7 @@ void LinuxProcessProbe::parseProcessIo(int32_t pid, ProcessCounters& counters)
     // or being the owner of the process. If we can't read it, we silently skip
     // (capabilities() already reports hasIoCounters = false by default).
 
-    const auto ioPath = std::format("/proc/{}/io", pid);
+    const auto ioPath = (procRoot / std::to_string(pid) / "io").string();
     std::ifstream ioFile(ioPath);
     if (!ioFile.is_open())
     {
@@ -601,13 +607,13 @@ void LinuxProcessProbe::parseProcessIo(int32_t pid, ProcessCounters& counters)
     }
 }
 
-void LinuxProcessProbe::countProcessFds(int32_t pid, ProcessCounters& counters)
+void LinuxProcessProbe::countProcessFds(int32_t pid, ProcessCounters& counters, const std::filesystem::path& procRoot)
 {
     // Count entries in /proc/[pid]/fd directory.
     // Each entry is a symlink to an open file descriptor.
     // Note: May fail due to permissions (needs same user or root).
 
-    const auto fdPath = std::format("/proc/{}/fd", pid);
+    const auto fdPath = (procRoot / std::to_string(pid) / "fd").string();
 
     int32_t count = 0;
     try
@@ -638,7 +644,7 @@ bool LinuxProcessProbe::checkIoCountersAvailability()
     return selfIo.is_open();
 }
 
-std::string LinuxProcessProbe::getProcessStatus(int32_t pid)
+std::string LinuxProcessProbe::getProcessStatus(int32_t pid, const std::filesystem::path& procRoot)
 {
     // Try cgroup v2 first: freezer.state
     const auto cgroupV2FreezerPath = std::format("/sys/fs/cgroup/{}/freezer.state", pid);
@@ -655,7 +661,7 @@ std::string LinuxProcessProbe::getProcessStatus(int32_t pid)
 
     // Fallback to cgroup v1 freezer hierarchy
     // /proc/[pid]/cgroup lists all cgroups for the process
-    const auto cgroupPath = std::format("/proc/{}/cgroup", pid);
+    const auto cgroupPath = (procRoot / std::to_string(pid) / "cgroup").string();
     std::ifstream cgroupFile(cgroupPath);
     if (cgroupFile.is_open())
     {
@@ -698,12 +704,12 @@ std::string LinuxProcessProbe::getProcessStatus(int32_t pid)
     // No special status
     return {};
 }
-uint64_t LinuxProcessProbe::readTotalCpuTime()
+uint64_t LinuxProcessProbe::readTotalCpuTime() const
 {
     // Format: /proc/stat
     // First line: cpu user nice system idle iowait irq softirq steal guest guest_nice
 
-    std::ifstream statFile("/proc/stat");
+    std::ifstream statFile(m_ProcRoot / "stat");
     if (!statFile.is_open())
     {
         spdlog::warn("Failed to open /proc/stat");
@@ -732,12 +738,12 @@ uint64_t LinuxProcessProbe::readTotalCpuTime()
     return user + nice + system + idle + iowait + irq + softirq + steal;
 }
 
-uint64_t LinuxProcessProbe::readBootTime()
+uint64_t LinuxProcessProbe::readBootTime(const std::filesystem::path& procRoot)
 {
     // Format: /proc/stat contains a line: btime <epoch_seconds>
     // btime is the time the system booted in seconds since Unix epoch
 
-    std::ifstream statFile("/proc/stat");
+    std::ifstream statFile(procRoot / "stat");
     if (!statFile.is_open())
     {
         spdlog::warn("Failed to open /proc/stat for boot time");
@@ -766,7 +772,7 @@ uint64_t LinuxProcessProbe::readBootTime()
 
 uint64_t LinuxProcessProbe::systemTotalMemory() const
 {
-    std::ifstream meminfo("/proc/meminfo");
+    std::ifstream meminfo(m_ProcRoot / "meminfo");
     if (!meminfo.is_open())
     {
         spdlog::error("Failed to open /proc/meminfo");

--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -153,7 +153,7 @@ LinuxProcessProbe::LinuxProcessProbe(std::filesystem::path procRoot)
 
     if (m_BootTimeEpoch == 0)
     {
-        spdlog::warn("Failed to read boot time from /proc/stat");
+        spdlog::warn("Failed to read boot time from {}", (m_ProcRoot / "stat").string());
     }
 
     // Detect and initialize power monitoring if available
@@ -223,7 +223,7 @@ std::vector<ProcessCounters> LinuxProcessProbe::enumerate()
         ProcessCounters counters{};
         if (!parseProcessStat(pid, counters))
         {
-            spdlog::debug("Failed to parse /proc/{}/stat", pid);
+            spdlog::debug("Failed to parse {}", (procPath / std::to_string(pid) / "stat").string());
             continue;
         }
 
@@ -250,7 +250,7 @@ std::vector<ProcessCounters> LinuxProcessProbe::enumerate()
 
     if (errorCode)
     {
-        spdlog::warn("Error iterating /proc: {}", errorCode.message());
+        spdlog::warn("Error iterating {}: {}", procPath.string(), errorCode.message());
     }
 
     // Attribute energy to processes if power monitoring is available
@@ -709,10 +709,11 @@ uint64_t LinuxProcessProbe::readTotalCpuTime() const
     // Format: /proc/stat
     // First line: cpu user nice system idle iowait irq softirq steal guest guest_nice
 
-    std::ifstream statFile(m_ProcRoot / "stat");
+    const auto statPath = m_ProcRoot / "stat";
+    std::ifstream statFile(statPath);
     if (!statFile.is_open())
     {
-        spdlog::warn("Failed to open /proc/stat");
+        spdlog::warn("Failed to open {}", statPath.string());
         return 0;
     }
 
@@ -730,7 +731,7 @@ uint64_t LinuxProcessProbe::readTotalCpuTime() const
 
     if (statFile.fail() || cpuLabel != "cpu")
     {
-        spdlog::warn("Failed to parse /proc/stat");
+        spdlog::warn("Failed to parse {}", statPath.string());
         return 0;
     }
 
@@ -743,10 +744,11 @@ uint64_t LinuxProcessProbe::readBootTime(const std::filesystem::path& procRoot)
     // Format: /proc/stat contains a line: btime <epoch_seconds>
     // btime is the time the system booted in seconds since Unix epoch
 
-    std::ifstream statFile(procRoot / "stat");
+    const auto statPath = procRoot / "stat";
+    std::ifstream statFile(statPath);
     if (!statFile.is_open())
     {
-        spdlog::warn("Failed to open /proc/stat for boot time");
+        spdlog::warn("Failed to open {} for boot time", statPath.string());
         return 0;
     }
 
@@ -772,10 +774,11 @@ uint64_t LinuxProcessProbe::readBootTime(const std::filesystem::path& procRoot)
 
 uint64_t LinuxProcessProbe::systemTotalMemory() const
 {
-    std::ifstream meminfo(m_ProcRoot / "meminfo");
+    const auto meminfoPath = m_ProcRoot / "meminfo";
+    std::ifstream meminfo(meminfoPath);
     if (!meminfo.is_open())
     {
-        spdlog::error("Failed to open /proc/meminfo");
+        spdlog::error("Failed to open {}", meminfoPath.string());
         return 0;
     }
 

--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -239,7 +239,7 @@ std::vector<ProcessCounters> LinuxProcessProbe::enumerate()
         // Only attempt I/O counters if we know they're readable
         // Use std::call_once for thread-safe lazy initialization; relaxed ordering is sufficient
         std::call_once(m_IoCountersCheckFlag,
-                       [this]() { m_IoCountersAvailable.store(checkIoCountersAvailability(), std::memory_order_relaxed); });
+                       [this]() { m_IoCountersAvailable.store(checkIoCountersAvailability(m_ProcRoot), std::memory_order_relaxed); });
         if (m_IoCountersAvailable.load(std::memory_order_relaxed))
         {
             parseProcessIo(pid, counters, m_ProcRoot);
@@ -274,7 +274,7 @@ ProcessCapabilities LinuxProcessProbe::capabilities() const
 {
     // Check I/O counters availability on first call (thread-safe)
     std::call_once(m_IoCountersCheckFlag,
-                   [this]() { m_IoCountersAvailable.store(checkIoCountersAvailability(), std::memory_order_release); });
+                   [this]() { m_IoCountersAvailable.store(checkIoCountersAvailability(m_ProcRoot), std::memory_order_release); });
 
 #if TASKSMACK_HAS_NETLINK_SOCKET_STATS
     const bool hasNetworkCounters = m_HasNetworkCounters;
@@ -635,12 +635,12 @@ void LinuxProcessProbe::countProcessFds(int32_t pid, ProcessCounters& counters, 
     }
 }
 
-bool LinuxProcessProbe::checkIoCountersAvailability()
+bool LinuxProcessProbe::checkIoCountersAvailability(const std::filesystem::path& procRoot)
 {
-    // Check if we can read /proc/self/io to determine I/O counter availability.
+    // Check if procRoot/self/io is readable to determine I/O counter availability.
     // This file requires CAP_DAC_READ_SEARCH capability or root privileges,
     // or being the owner of the target process.
-    const std::ifstream selfIo("/proc/self/io");
+    const std::ifstream selfIo(procRoot / "self" / "io");
     return selfIo.is_open();
 }
 

--- a/src/Platform/Linux/LinuxProcessProbe.cpp
+++ b/src/Platform/Linux/LinuxProcessProbe.cpp
@@ -320,7 +320,7 @@ bool LinuxProcessProbe::parseProcessStat(int32_t pid, ProcessCounters& counters)
     //         minflt cminflt majflt cmajflt utime stime cutime cstime
     //         priority nice num_threads itrealvalue starttime vsize rss ...
 
-    const auto statPath = (m_ProcRoot / std::to_string(pid) / "stat").string();
+    const auto statPath = m_ProcRoot / std::to_string(pid) / "stat";
     std::ifstream statFile(statPath);
     if (!statFile.is_open())
     {
@@ -613,7 +613,7 @@ void LinuxProcessProbe::countProcessFds(int32_t pid, ProcessCounters& counters, 
     // Each entry is a symlink to an open file descriptor.
     // Note: May fail due to permissions (needs same user or root).
 
-    const auto fdPath = (procRoot / std::to_string(pid) / "fd").string();
+    const auto fdPath = procRoot / std::to_string(pid) / "fd";
 
     int32_t count = 0;
     try
@@ -631,7 +631,7 @@ void LinuxProcessProbe::countProcessFds(int32_t pid, ProcessCounters& counters, 
     catch (const std::exception& ex)
     {
         // Permission errors and other exceptional situations - leave handleCount at 0
-        spdlog::debug("LinuxProcessProbe: failed to enumerate FDs for pid {} at {}: {}", pid, fdPath, ex.what());
+        spdlog::debug("LinuxProcessProbe: failed to enumerate FDs for pid {} at {}: {}", pid, fdPath.string(), ex.what());
     }
 }
 

--- a/src/Platform/Linux/LinuxProcessProbe.h
+++ b/src/Platform/Linux/LinuxProcessProbe.h
@@ -98,8 +98,8 @@ class LinuxProcessProbe : public IProcessProbe
     /// Count file descriptors in /proc/[pid]/fd (may fail due to permissions)
     static void countProcessFds(int32_t pid, ProcessCounters& counters, const std::filesystem::path& procRoot);
 
-    /// Check if we can read I/O counters (checks own process)
-    [[nodiscard]] static bool checkIoCountersAvailability();
+    /// Check if we can read I/O counters using the injected proc root
+    [[nodiscard]] static bool checkIoCountersAvailability(const std::filesystem::path& procRoot);
 
     /// Get process status from cgroups (Suspended state detection)
     [[nodiscard]] static std::string getProcessStatus(int32_t pid, const std::filesystem::path& procRoot);

--- a/src/Platform/Linux/LinuxProcessProbe.h
+++ b/src/Platform/Linux/LinuxProcessProbe.h
@@ -11,6 +11,7 @@
 #endif
 
 #include <atomic>
+#include <filesystem>
 #include <memory>
 #include <mutex>
 
@@ -23,6 +24,11 @@ class LinuxProcessProbe : public IProcessProbe
 {
   public:
     LinuxProcessProbe();
+
+    /// Testability constructor: reads from a custom proc root instead of /proc.
+    /// Useful for unit tests that supply synthetic /proc content.
+    explicit LinuxProcessProbe(std::filesystem::path procRoot);
+
     ~LinuxProcessProbe() override = default;
 
     LinuxProcessProbe(const LinuxProcessProbe&) = delete;
@@ -45,6 +51,7 @@ class LinuxProcessProbe : public IProcessProbe
 #endif
 
   private:
+    std::filesystem::path m_ProcRoot;
     long m_TicksPerSecond;
     uint64_t m_PageSize;
     uint64_t m_BootTimeEpoch = 0;                            // System boot time (Unix epoch seconds)
@@ -77,31 +84,31 @@ class LinuxProcessProbe : public IProcessProbe
     void parseProcessStatm(int32_t pid, ProcessCounters& counters) const;
 
     /// Parse /proc/[pid]/status for owner (UID) info
-    static void parseProcessStatus(int32_t pid, ProcessCounters& counters);
+    static void parseProcessStatus(int32_t pid, ProcessCounters& counters, const std::filesystem::path& procRoot);
 
     /// Parse /proc/[pid]/cmdline for full command line
-    static void parseProcessCmdline(int32_t pid, ProcessCounters& counters);
+    static void parseProcessCmdline(int32_t pid, ProcessCounters& counters, const std::filesystem::path& procRoot);
 
     /// Parse CPU affinity mask for a process using sched_getaffinity
     static void parseProcessAffinity(int32_t pid, ProcessCounters& counters);
 
     /// Parse /proc/[pid]/io for I/O counters (requires permissions)
-    static void parseProcessIo(int32_t pid, ProcessCounters& counters);
+    static void parseProcessIo(int32_t pid, ProcessCounters& counters, const std::filesystem::path& procRoot);
 
     /// Count file descriptors in /proc/[pid]/fd (may fail due to permissions)
-    static void countProcessFds(int32_t pid, ProcessCounters& counters);
+    static void countProcessFds(int32_t pid, ProcessCounters& counters, const std::filesystem::path& procRoot);
 
     /// Check if we can read I/O counters (checks own process)
     [[nodiscard]] static bool checkIoCountersAvailability();
 
     /// Get process status from cgroups (Suspended state detection)
-    [[nodiscard]] static std::string getProcessStatus(int32_t pid);
+    [[nodiscard]] static std::string getProcessStatus(int32_t pid, const std::filesystem::path& procRoot);
 
     /// Read total CPU time from /proc/stat
-    [[nodiscard]] static uint64_t readTotalCpuTime();
+    [[nodiscard]] uint64_t readTotalCpuTime() const;
 
     /// Read system boot time from /proc/stat (returns Unix epoch seconds, 0 if unavailable)
-    [[nodiscard]] static uint64_t readBootTime();
+    [[nodiscard]] static uint64_t readBootTime(const std::filesystem::path& procRoot);
 
     /// Check if RAPL powercap is available and find the path
     [[nodiscard]] bool detectPowerCap();

--- a/src/Platform/Linux/LinuxSystemProbe.cpp
+++ b/src/Platform/Linux/LinuxSystemProbe.cpp
@@ -14,6 +14,7 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <mutex>
 #include <sstream>
@@ -53,8 +54,13 @@ template<std::integral T> [[nodiscard]] constexpr auto checkedPositiveToSizeT(T 
 
 } // namespace
 
-LinuxSystemProbe::LinuxSystemProbe()
-    : m_TicksPerSecond(sysconf(_SC_CLK_TCK)), m_NumCores(checkedPositiveToSizeT(sysconf(_SC_NPROCESSORS_ONLN), 1U))
+LinuxSystemProbe::LinuxSystemProbe() : LinuxSystemProbe(std::filesystem::path("/proc"))
+{}
+
+LinuxSystemProbe::LinuxSystemProbe(std::filesystem::path procRoot)
+    : m_ProcRoot(std::move(procRoot)),
+      m_TicksPerSecond(sysconf(_SC_CLK_TCK)),
+      m_NumCores(checkedPositiveToSizeT(sysconf(_SC_NPROCESSORS_ONLN), 1U))
 {
     if (m_TicksPerSecond <= 0)
     {
@@ -74,7 +80,7 @@ LinuxSystemProbe::LinuxSystemProbe()
     }
 
     // Read CPU model from /proc/cpuinfo (cached)
-    std::ifstream cpuInfo("/proc/cpuinfo");
+    std::ifstream cpuInfo(m_ProcRoot / "cpuinfo");
     if (cpuInfo.is_open())
     {
         std::string line;
@@ -107,10 +113,10 @@ LinuxSystemProbe::LinuxSystemProbe()
 SystemCounters LinuxSystemProbe::read()
 {
     SystemCounters counters;
-    readCpuCounters(counters);
-    readMemoryCounters(counters);
-    readUptime(counters);
-    readLoadAvg(counters);
+    readCpuCounters(counters, m_ProcRoot);
+    readMemoryCounters(counters, m_ProcRoot);
+    readUptime(counters, m_ProcRoot);
+    readLoadAvg(counters, m_ProcRoot);
     readCpuFreq(counters);
     readNetworkCounters(counters);
     readStaticInfo(counters);
@@ -135,14 +141,14 @@ long LinuxSystemProbe::ticksPerSecond() const
     return m_TicksPerSecond;
 }
 
-void LinuxSystemProbe::readCpuCounters(SystemCounters& counters)
+void LinuxSystemProbe::readCpuCounters(SystemCounters& counters, const std::filesystem::path& procRoot)
 {
     // Format: /proc/stat
     // cpu  user nice system idle iowait irq softirq steal guest guest_nice
     // cpu0 user nice system idle iowait irq softirq steal guest guest_nice
     // cpu1 ...
 
-    std::ifstream statFile("/proc/stat");
+    std::ifstream statFile(procRoot / "stat");
     if (!statFile.is_open())
     {
         spdlog::warn("Failed to open /proc/stat");
@@ -191,7 +197,7 @@ void LinuxSystemProbe::readCpuCounters(SystemCounters& counters)
     }
 }
 
-void LinuxSystemProbe::readMemoryCounters(SystemCounters& counters)
+void LinuxSystemProbe::readMemoryCounters(SystemCounters& counters, const std::filesystem::path& procRoot)
 {
     // Format: /proc/meminfo
     // MemTotal:       16384000 kB
@@ -203,7 +209,7 @@ void LinuxSystemProbe::readMemoryCounters(SystemCounters& counters)
     // SwapFree:        2097152 kB
     // ...
 
-    std::ifstream memFile("/proc/meminfo");
+    std::ifstream memFile(procRoot / "meminfo");
     if (!memFile.is_open())
     {
         spdlog::warn("Failed to open /proc/meminfo");
@@ -260,12 +266,12 @@ void LinuxSystemProbe::readMemoryCounters(SystemCounters& counters)
     }
 }
 
-void LinuxSystemProbe::readUptime(SystemCounters& counters)
+void LinuxSystemProbe::readUptime(SystemCounters& counters, const std::filesystem::path& procRoot)
 {
     // Format: /proc/uptime
     // uptime_seconds idle_seconds
 
-    std::ifstream uptimeFile("/proc/uptime");
+    std::ifstream uptimeFile(procRoot / "uptime");
     if (!uptimeFile.is_open())
     {
         return;
@@ -287,13 +293,13 @@ void LinuxSystemProbe::readStaticInfo(SystemCounters& counters) const
     counters.cpuCoreCount = m_NumCores;
 }
 
-void LinuxSystemProbe::readLoadAvg(SystemCounters& counters)
+void LinuxSystemProbe::readLoadAvg(SystemCounters& counters, const std::filesystem::path& procRoot)
 {
     // Format: /proc/loadavg
     // 0.31 0.65 0.97 1/330 12345
     // load1 load5 load15 running/total lastpid
 
-    std::ifstream loadFile("/proc/loadavg");
+    std::ifstream loadFile(procRoot / "loadavg");
     if (!loadFile.is_open())
     {
         return;
@@ -339,7 +345,7 @@ void LinuxSystemProbe::readNetworkCounters(SystemCounters& counters)
     //     lo: 1234567   12345    0    0    0     0          0         0  1234567   12345    0    0    0     0       0          0
     //   eth0: 9876543   98765    0    0    0     0          0         0  5432109   54321    0    0    0     0       0          0
 
-    std::ifstream netFile("/proc/net/dev");
+    std::ifstream netFile(m_ProcRoot / "net" / "dev");
     if (!netFile.is_open())
     {
         spdlog::warn("Failed to open /proc/net/dev");

--- a/src/Platform/Linux/LinuxSystemProbe.cpp
+++ b/src/Platform/Linux/LinuxSystemProbe.cpp
@@ -148,10 +148,11 @@ void LinuxSystemProbe::readCpuCounters(SystemCounters& counters, const std::file
     // cpu0 user nice system idle iowait irq softirq steal guest guest_nice
     // cpu1 ...
 
-    std::ifstream statFile(procRoot / "stat");
+    const auto statPath = procRoot / "stat";
+    std::ifstream statFile(statPath);
     if (!statFile.is_open())
     {
-        spdlog::warn("Failed to open /proc/stat");
+        spdlog::warn("Failed to open {}", statPath.string());
         return;
     }
 
@@ -193,7 +194,7 @@ void LinuxSystemProbe::readCpuCounters(SystemCounters& counters, const std::file
 
     if (!foundTotal)
     {
-        spdlog::warn("Failed to parse aggregate CPU line from /proc/stat");
+        spdlog::warn("Failed to parse aggregate CPU line from {}", statPath.string());
     }
 }
 
@@ -209,10 +210,11 @@ void LinuxSystemProbe::readMemoryCounters(SystemCounters& counters, const std::f
     // SwapFree:        2097152 kB
     // ...
 
-    std::ifstream memFile(procRoot / "meminfo");
+    const auto meminfoPath = procRoot / "meminfo";
+    std::ifstream memFile(meminfoPath);
     if (!memFile.is_open())
     {
-        spdlog::warn("Failed to open /proc/meminfo");
+        spdlog::warn("Failed to open {}", meminfoPath.string());
         return;
     }
 
@@ -345,10 +347,11 @@ void LinuxSystemProbe::readNetworkCounters(SystemCounters& counters)
     //     lo: 1234567   12345    0    0    0     0          0         0  1234567   12345    0    0    0     0       0          0
     //   eth0: 9876543   98765    0    0    0     0          0         0  5432109   54321    0    0    0     0       0          0
 
-    std::ifstream netFile(m_ProcRoot / "net" / "dev");
+    const auto netDevPath = m_ProcRoot / "net" / "dev";
+    std::ifstream netFile(netDevPath);
     if (!netFile.is_open())
     {
-        spdlog::warn("Failed to open /proc/net/dev");
+        spdlog::warn("Failed to open {}", netDevPath.string());
         return;
     }
 

--- a/src/Platform/Linux/LinuxSystemProbe.h
+++ b/src/Platform/Linux/LinuxSystemProbe.h
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <filesystem>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -18,6 +19,11 @@ class LinuxSystemProbe : public ISystemProbe
 {
   public:
     LinuxSystemProbe();
+
+    /// Testability constructor: reads from a custom proc root instead of /proc.
+    /// Useful for unit tests that supply synthetic /proc content.
+    explicit LinuxSystemProbe(std::filesystem::path procRoot);
+
     ~LinuxSystemProbe() override = default;
 
     // Non-copyable, non-movable (contains mutex)
@@ -31,10 +37,10 @@ class LinuxSystemProbe : public ISystemProbe
     [[nodiscard]] long ticksPerSecond() const override;
 
   private:
-    static void readCpuCounters(SystemCounters& counters);
-    static void readMemoryCounters(SystemCounters& counters);
-    static void readUptime(SystemCounters& counters);
-    static void readLoadAvg(SystemCounters& counters);
+    static void readCpuCounters(SystemCounters& counters, const std::filesystem::path& procRoot);
+    static void readMemoryCounters(SystemCounters& counters, const std::filesystem::path& procRoot);
+    static void readUptime(SystemCounters& counters, const std::filesystem::path& procRoot);
+    static void readLoadAvg(SystemCounters& counters, const std::filesystem::path& procRoot);
     static void readCpuFreq(SystemCounters& counters);
 
     /// Read network-related counters (bytes, packets, etc.) from /proc/net/dev.
@@ -61,6 +67,7 @@ class LinuxSystemProbe : public ISystemProbe
     /// @param currentInterfaces Vector of interface names seen in current enumeration
     void cleanupStaleInterfaceCacheEntries(const std::vector<std::string>& currentInterfaces);
 
+    std::filesystem::path m_ProcRoot;
     long m_TicksPerSecond;
     std::size_t m_NumCores;
 

--- a/tests/Platform/ScopedTempDir.h
+++ b/tests/Platform/ScopedTempDir.h
@@ -6,6 +6,7 @@
 #if defined(__linux__) && __has_include(<unistd.h>)
 
 #include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <format>
 #include <string>

--- a/tests/Platform/ScopedTempDir.h
+++ b/tests/Platform/ScopedTempDir.h
@@ -15,7 +15,7 @@
 
 #include <unistd.h>
 
-namespace Platform::Test
+namespace Platform::TestSupport
 {
 
 /// RAII temporary directory. The directory name is formed from a caller-supplied
@@ -51,6 +51,6 @@ struct ScopedTempDir
     }
 };
 
-} // namespace Platform::Test
+} // namespace Platform::TestSupport
 
 #endif // defined(__linux__) && __has_include(<unistd.h>)

--- a/tests/Platform/ScopedTempDir.h
+++ b/tests/Platform/ScopedTempDir.h
@@ -1,0 +1,55 @@
+#pragma once
+
+/// @file ScopedTempDir.h
+/// @brief RAII helper for unique temporary directories in Linux test fixtures.
+
+#if defined(__linux__) && __has_include(<unistd.h>)
+
+#include <atomic>
+#include <filesystem>
+#include <format>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include <unistd.h>
+
+namespace Platform::Test
+{
+
+/// RAII temporary directory. The directory name is formed from a caller-supplied
+/// base string, the process ID, and a per-process monotonic counter, guaranteeing
+/// uniqueness even when many tests run in the same process (e.g. a coverage run).
+/// The directory is created in the constructor and removed (best-effort) in the
+/// destructor so cleanup happens even if an assertion fires.
+struct ScopedTempDir
+{
+    std::filesystem::path path;
+
+    explicit ScopedTempDir(std::string_view name) : path(std::filesystem::temp_directory_path() / uniqueName(name))
+    {
+        std::filesystem::create_directories(path);
+    }
+
+    ~ScopedTempDir() noexcept
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec); // must not throw from destructor
+    }
+
+    ScopedTempDir(const ScopedTempDir&) = delete;
+    ScopedTempDir& operator=(const ScopedTempDir&) = delete;
+    ScopedTempDir(ScopedTempDir&&) = delete;
+    ScopedTempDir& operator=(ScopedTempDir&&) = delete;
+
+  private:
+    [[nodiscard]] static std::string uniqueName(std::string_view base)
+    {
+        static std::atomic<std::uint32_t> counter{0};
+        return std::format("{}_{}_{}", base, getpid(), counter.fetch_add(1, std::memory_order_relaxed));
+    }
+};
+
+} // namespace Platform::Test
+
+#endif // defined(__linux__) && __has_include(<unistd.h>)

--- a/tests/Platform/test_LinuxProcessProbe.cpp
+++ b/tests/Platform/test_LinuxProcessProbe.cpp
@@ -669,6 +669,71 @@ TEST(LinuxProcessProbeTest, SetSocketStatsCacheTtl_DoesNotCrash)
 }
 #endif
 
+// ========== Error Path / Injection Tests ==========
+
+TEST(LinuxProcessProbeTest, EmptyProcDirReturnsNoProcesses)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_empty";
+    std::filesystem::create_directories(tmpDir);
+    LinuxProcessProbe probe(tmpDir);
+    auto processes = probe.enumerate();
+    EXPECT_TRUE(processes.empty());
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(LinuxProcessProbeTest, NonexistentProcDirDoesNotCrash)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nonexist_12345xyz";
+    // Do not create the directory — it should not exist
+    LinuxProcessProbe probe(tmpDir);
+    auto result = probe.enumerate();
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(LinuxProcessProbeTest, MissingStatReturnZeroTotalCpuTime)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nocputime";
+    std::filesystem::create_directories(tmpDir);
+    LinuxProcessProbe probe(tmpDir);
+    EXPECT_EQ(probe.totalCpuTime(), 0ULL);
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(LinuxProcessProbeTest, MissingMeminfoReturnZeroSystemMemory)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nomeminfo";
+    std::filesystem::create_directories(tmpDir);
+    LinuxProcessProbe probe(tmpDir);
+    EXPECT_EQ(probe.systemTotalMemory(), 0ULL);
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(LinuxProcessProbeTest, ParseProcessStatMissingFileDoesNotCrash)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nostatfile";
+    // Create a pid subdirectory with no stat file inside
+    std::filesystem::create_directories(tmpDir / "1234");
+    LinuxProcessProbe probe(tmpDir);
+    auto result = probe.enumerate();
+    EXPECT_TRUE(result.empty());
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(LinuxProcessProbeTest, ParseProcessStatMalformedContentDoesNotCrash)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_badstat";
+    std::filesystem::create_directories(tmpDir / "1234");
+    {
+        // Write garbage to stat — no valid fields
+        std::ofstream f(tmpDir / "1234" / "stat");
+        f << "not valid stat content at all\n";
+    }
+    LinuxProcessProbe probe(tmpDir);
+    auto result = probe.enumerate();
+    (void) result; // Result may be empty or contain partial data
+    std::filesystem::remove_all(tmpDir);
+}
+
 } // namespace
 } // namespace Platform
 

--- a/tests/Platform/test_LinuxProcessProbe.cpp
+++ b/tests/Platform/test_LinuxProcessProbe.cpp
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <thread>
 
@@ -671,71 +672,82 @@ TEST(LinuxProcessProbeTest, SetSocketStatsCacheTtl_DoesNotCrash)
 
 // ========== Error Path / Injection Tests ==========
 
+// RAII helper: creates a uniquely-named temp directory (with PID suffix to
+// avoid parallel-test collisions) and removes it on destruction so cleanup
+// happens even if an assertion fires.
+struct ScopedTempDir
+{
+    std::filesystem::path path;
+
+    explicit ScopedTempDir(std::string_view name) : path(std::filesystem::temp_directory_path() / std::format("{}_{}", name, getpid()))
+    {
+        std::filesystem::remove_all(path);
+        std::filesystem::create_directories(path);
+    }
+
+    ~ScopedTempDir()
+    {
+        std::filesystem::remove_all(path);
+    }
+
+    ScopedTempDir(const ScopedTempDir&) = delete;
+    ScopedTempDir& operator=(const ScopedTempDir&) = delete;
+    ScopedTempDir(ScopedTempDir&&) = delete;
+    ScopedTempDir& operator=(ScopedTempDir&&) = delete;
+};
+
 TEST(LinuxProcessProbeTest, EmptyProcDirReturnsNoProcesses)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_empty";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir);
-    LinuxProcessProbe probe(tmpDir);
+    ScopedTempDir scoped("ts_test_proc_empty");
+    LinuxProcessProbe probe(scoped.path);
     auto processes = probe.enumerate();
     EXPECT_TRUE(processes.empty());
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST(LinuxProcessProbeTest, NonexistentProcDirDoesNotCrash)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nonexist_12345xyz";
-    // Do not create the directory — it should not exist
+    const auto tmpDir = std::filesystem::temp_directory_path() / std::format("ts_test_proc_nonexist_{}", getpid());
+    std::filesystem::remove_all(tmpDir); // ensure it does not exist
     LinuxProcessProbe probe(tmpDir);
     auto result = probe.enumerate();
     EXPECT_TRUE(result.empty());
 }
 
-TEST(LinuxProcessProbeTest, MissingStatReturnZeroTotalCpuTime)
+TEST(LinuxProcessProbeTest, MissingStatReturnsZeroTotalCpuTime)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nocputime";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir);
-    LinuxProcessProbe probe(tmpDir);
+    ScopedTempDir scoped("ts_test_proc_nocputime");
+    LinuxProcessProbe probe(scoped.path);
     EXPECT_EQ(probe.totalCpuTime(), 0ULL);
-    std::filesystem::remove_all(tmpDir);
 }
 
-TEST(LinuxProcessProbeTest, MissingMeminfoReturnZeroSystemMemory)
+TEST(LinuxProcessProbeTest, MissingMeminfoReturnsZeroSystemMemory)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nomeminfo";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir);
-    LinuxProcessProbe probe(tmpDir);
+    ScopedTempDir scoped("ts_test_proc_nomeminfo");
+    LinuxProcessProbe probe(scoped.path);
     EXPECT_EQ(probe.systemTotalMemory(), 0ULL);
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST(LinuxProcessProbeTest, ParseProcessStatMissingFileDoesNotCrash)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nostatfile";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir / "1234");
-    LinuxProcessProbe probe(tmpDir);
+    ScopedTempDir scoped("ts_test_proc_nostatfile");
+    std::filesystem::create_directories(scoped.path / "1234");
+    LinuxProcessProbe probe(scoped.path);
     auto result = probe.enumerate();
     EXPECT_TRUE(result.empty());
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST(LinuxProcessProbeTest, ParseProcessStatMalformedContentDoesNotCrash)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_badstat";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir / "1234");
+    ScopedTempDir scoped("ts_test_proc_badstat");
+    std::filesystem::create_directories(scoped.path / "1234");
     {
-        // Write garbage to stat — no valid fields
-        std::ofstream f(tmpDir / "1234" / "stat");
+        // Write garbage to stat — no valid fields; parse fails, enumerate returns empty
+        std::ofstream f(scoped.path / "1234" / "stat");
         f << "not valid stat content at all\n";
     }
-    LinuxProcessProbe probe(tmpDir);
+    LinuxProcessProbe probe(scoped.path);
     auto result = probe.enumerate();
-    (void) result; // Result may be empty or contain partial data
-    std::filesystem::remove_all(tmpDir);
+    EXPECT_TRUE(result.empty());
 }
 
 } // namespace

--- a/tests/Platform/test_LinuxProcessProbe.cpp
+++ b/tests/Platform/test_LinuxProcessProbe.cpp
@@ -19,6 +19,7 @@
 #include "Platform/Linux/LinuxProcessProbe.h"
 #include "Platform/PlatformConfig.h"
 #include "Platform/ProcessTypes.h"
+#include "Platform/ScopedTempDir.h"
 
 #include <algorithm>
 #include <cerrno>
@@ -673,31 +674,7 @@ TEST(LinuxProcessProbeTest, SetSocketStatsCacheTtl_DoesNotCrash)
 
 // ========== Error Path / Injection Tests ==========
 
-// RAII helper: creates a uniquely-named temp directory (with PID suffix to
-// avoid parallel-test collisions) and removes it on destruction so cleanup
-// happens even if an assertion fires.
-struct ScopedTempDir
-{
-    std::filesystem::path path;
-
-    explicit ScopedTempDir(std::string_view name) : path(std::filesystem::temp_directory_path() / std::format("{}_{}", name, getpid()))
-    {
-        std::error_code ec;
-        std::filesystem::remove_all(path, ec); // best-effort pre-clean; ignore error
-        std::filesystem::create_directories(path);
-    }
-
-    ~ScopedTempDir() noexcept
-    {
-        std::error_code ec;
-        std::filesystem::remove_all(path, ec); // must not throw from destructor
-    }
-
-    ScopedTempDir(const ScopedTempDir&) = delete;
-    ScopedTempDir& operator=(const ScopedTempDir&) = delete;
-    ScopedTempDir(ScopedTempDir&&) = delete;
-    ScopedTempDir& operator=(ScopedTempDir&&) = delete;
-};
+using Platform::Test::ScopedTempDir;
 
 TEST(LinuxProcessProbeTest, EmptyProcDirReturnsNoProcesses)
 {

--- a/tests/Platform/test_LinuxProcessProbe.cpp
+++ b/tests/Platform/test_LinuxProcessProbe.cpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <system_error>
 #include <thread>
 
 #include <sys/wait.h>
@@ -681,13 +682,15 @@ struct ScopedTempDir
 
     explicit ScopedTempDir(std::string_view name) : path(std::filesystem::temp_directory_path() / std::format("{}_{}", name, getpid()))
     {
-        std::filesystem::remove_all(path);
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec); // best-effort pre-clean; ignore error
         std::filesystem::create_directories(path);
     }
 
-    ~ScopedTempDir()
+    ~ScopedTempDir() noexcept
     {
-        std::filesystem::remove_all(path);
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec); // must not throw from destructor
     }
 
     ScopedTempDir(const ScopedTempDir&) = delete;

--- a/tests/Platform/test_LinuxProcessProbe.cpp
+++ b/tests/Platform/test_LinuxProcessProbe.cpp
@@ -674,6 +674,7 @@ TEST(LinuxProcessProbeTest, SetSocketStatsCacheTtl_DoesNotCrash)
 TEST(LinuxProcessProbeTest, EmptyProcDirReturnsNoProcesses)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_empty";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir);
     LinuxProcessProbe probe(tmpDir);
     auto processes = probe.enumerate();
@@ -693,6 +694,7 @@ TEST(LinuxProcessProbeTest, NonexistentProcDirDoesNotCrash)
 TEST(LinuxProcessProbeTest, MissingStatReturnZeroTotalCpuTime)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nocputime";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir);
     LinuxProcessProbe probe(tmpDir);
     EXPECT_EQ(probe.totalCpuTime(), 0ULL);
@@ -702,6 +704,7 @@ TEST(LinuxProcessProbeTest, MissingStatReturnZeroTotalCpuTime)
 TEST(LinuxProcessProbeTest, MissingMeminfoReturnZeroSystemMemory)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nomeminfo";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir);
     LinuxProcessProbe probe(tmpDir);
     EXPECT_EQ(probe.systemTotalMemory(), 0ULL);
@@ -711,7 +714,7 @@ TEST(LinuxProcessProbeTest, MissingMeminfoReturnZeroSystemMemory)
 TEST(LinuxProcessProbeTest, ParseProcessStatMissingFileDoesNotCrash)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_nostatfile";
-    // Create a pid subdirectory with no stat file inside
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir / "1234");
     LinuxProcessProbe probe(tmpDir);
     auto result = probe.enumerate();
@@ -722,6 +725,7 @@ TEST(LinuxProcessProbeTest, ParseProcessStatMissingFileDoesNotCrash)
 TEST(LinuxProcessProbeTest, ParseProcessStatMalformedContentDoesNotCrash)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_proc_badstat";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir / "1234");
     {
         // Write garbage to stat — no valid fields

--- a/tests/Platform/test_LinuxProcessProbe.cpp
+++ b/tests/Platform/test_LinuxProcessProbe.cpp
@@ -710,7 +710,8 @@ TEST(LinuxProcessProbeTest, EmptyProcDirReturnsNoProcesses)
 TEST(LinuxProcessProbeTest, NonexistentProcDirDoesNotCrash)
 {
     const auto tmpDir = std::filesystem::temp_directory_path() / std::format("ts_test_proc_nonexist_{}", getpid());
-    std::filesystem::remove_all(tmpDir); // ensure it does not exist
+    std::error_code ec;
+    std::filesystem::remove_all(tmpDir, ec); // ensure it does not exist; ignore error
     LinuxProcessProbe probe(tmpDir);
     auto result = probe.enumerate();
     EXPECT_TRUE(result.empty());

--- a/tests/Platform/test_LinuxProcessProbe.cpp
+++ b/tests/Platform/test_LinuxProcessProbe.cpp
@@ -1,8 +1,11 @@
 /// @file test_LinuxProcessProbe.cpp
 /// @brief Integration tests for Platform::LinuxProcessProbe
 ///
-/// These are integration tests that interact with the real /proc filesystem.
-/// They verify that the probe correctly reads and parses process information.
+/// This file contains two kinds of coverage:
+///   - Integration tests that interact with the real /proc filesystem, verifying
+///     that the probe correctly reads and parses process information.
+///   - Error-path / injection tests that use a synthetic proc root (ScopedTempDir)
+///     to exercise missing-file and malformed-input handling without touching /proc.
 
 #include <gtest/gtest.h>
 
@@ -674,7 +677,7 @@ TEST(LinuxProcessProbeTest, SetSocketStatsCacheTtl_DoesNotCrash)
 
 // ========== Error Path / Injection Tests ==========
 
-using Platform::Test::ScopedTempDir;
+using Platform::TestSupport::ScopedTempDir;
 
 TEST(LinuxProcessProbeTest, EmptyProcDirReturnsNoProcesses)
 {

--- a/tests/Platform/test_LinuxSystemProbe.cpp
+++ b/tests/Platform/test_LinuxSystemProbe.cpp
@@ -13,6 +13,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -558,6 +560,87 @@ TEST(LinuxSystemProbeTest, CacheConcurrentAccessIsSafe)
     // All reads should succeed
     EXPECT_EQ(successCount.load(), 200); // 4 threads * 50 reads
     EXPECT_EQ(errorCount.load(), 0);
+}
+
+// ========== Error Path / Injection Tests ==========
+
+TEST(LinuxSystemProbeTest, MissingStatFileSilentlyReturnsZeroCpu)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nostat";
+    std::filesystem::create_directories(tmpDir);
+    LinuxSystemProbe probe(tmpDir);
+    auto counters = probe.read();
+    EXPECT_EQ(counters.cpuTotal.user, 0ULL);
+    EXPECT_EQ(counters.cpuTotal.system, 0ULL);
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(LinuxSystemProbeTest, MissingMeminfoSilentlyReturnsZeroMemory)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nomem";
+    std::filesystem::create_directories(tmpDir);
+    LinuxSystemProbe probe(tmpDir);
+    auto counters = probe.read();
+    EXPECT_EQ(counters.memory.totalBytes, 0ULL);
+    EXPECT_EQ(counters.memory.availableBytes, 0ULL);
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(LinuxSystemProbeTest, MissingNetDevSilentlyReturnsZeroNetwork)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nonet";
+    std::filesystem::create_directories(tmpDir / "net");
+    LinuxSystemProbe probe(tmpDir);
+    auto counters = probe.read();
+    EXPECT_EQ(counters.netRxBytes, 0ULL);
+    EXPECT_EQ(counters.netTxBytes, 0ULL);
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(LinuxSystemProbeTest, MissingCpuinfoReportsUnknownCpu)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nocpu";
+    std::filesystem::create_directories(tmpDir);
+    LinuxSystemProbe probe(tmpDir);
+    auto counters = probe.read();
+    EXPECT_EQ(counters.cpuModel, "Unknown CPU");
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(LinuxSystemProbeTest, NetDevWithMalformedLinesSilentlySkips)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_badnet";
+    std::filesystem::create_directories(tmpDir / "net");
+    {
+        std::ofstream f(tmpDir / "net" / "dev");
+        f << "Inter-|   Receive\n";
+        f << " face |bytes packets\n";
+        // Line without colon — should be skipped
+        f << "no colon here at all\n";
+        // Line with whitespace-only interface name — should be skipped
+        f << "   :   0 0 0 0 0 0 0 0   0 0 0 0 0 0 0 0\n";
+        // Valid line
+        f << "   eth0:   12345 100 0 0 0 0 0 0   67890 200 0 0 0 0 0 0\n";
+    }
+    LinuxSystemProbe probe(tmpDir);
+    auto counters = probe.read();
+    EXPECT_GE(counters.netRxBytes, 12345ULL);
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(LinuxSystemProbeTest, StatWithNoCpuLineSilentlyReturnsZero)
+{
+    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_badstat";
+    std::filesystem::create_directories(tmpDir);
+    {
+        std::ofstream f(tmpDir / "stat");
+        f << "btime 1000000\n";
+        f << "processes 1234\n";
+    }
+    LinuxSystemProbe probe(tmpDir);
+    auto counters = probe.read();
+    EXPECT_EQ(counters.cpuTotal.user, 0ULL);
+    std::filesystem::remove_all(tmpDir);
 }
 
 } // namespace

--- a/tests/Platform/test_LinuxSystemProbe.cpp
+++ b/tests/Platform/test_LinuxSystemProbe.cpp
@@ -567,6 +567,7 @@ TEST(LinuxSystemProbeTest, CacheConcurrentAccessIsSafe)
 TEST(LinuxSystemProbeTest, MissingStatFileSilentlyReturnsZeroCpu)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nostat";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir);
     LinuxSystemProbe probe(tmpDir);
     auto counters = probe.read();
@@ -578,6 +579,7 @@ TEST(LinuxSystemProbeTest, MissingStatFileSilentlyReturnsZeroCpu)
 TEST(LinuxSystemProbeTest, MissingMeminfoSilentlyReturnsZeroMemory)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nomem";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir);
     LinuxSystemProbe probe(tmpDir);
     auto counters = probe.read();
@@ -589,6 +591,7 @@ TEST(LinuxSystemProbeTest, MissingMeminfoSilentlyReturnsZeroMemory)
 TEST(LinuxSystemProbeTest, MissingNetDevSilentlyReturnsZeroNetwork)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nonet";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir / "net");
     LinuxSystemProbe probe(tmpDir);
     auto counters = probe.read();
@@ -600,6 +603,7 @@ TEST(LinuxSystemProbeTest, MissingNetDevSilentlyReturnsZeroNetwork)
 TEST(LinuxSystemProbeTest, MissingCpuinfoReportsUnknownCpu)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nocpu";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir);
     LinuxSystemProbe probe(tmpDir);
     auto counters = probe.read();
@@ -610,6 +614,7 @@ TEST(LinuxSystemProbeTest, MissingCpuinfoReportsUnknownCpu)
 TEST(LinuxSystemProbeTest, NetDevWithMalformedLinesSilentlySkips)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_badnet";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir / "net");
     {
         std::ofstream f(tmpDir / "net" / "dev");
@@ -631,6 +636,7 @@ TEST(LinuxSystemProbeTest, NetDevWithMalformedLinesSilentlySkips)
 TEST(LinuxSystemProbeTest, StatWithNoCpuLineSilentlyReturnsZero)
 {
     auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_badstat";
+    std::filesystem::remove_all(tmpDir);
     std::filesystem::create_directories(tmpDir);
     {
         std::ofstream f(tmpDir / "stat");

--- a/tests/Platform/test_LinuxSystemProbe.cpp
+++ b/tests/Platform/test_LinuxSystemProbe.cpp
@@ -567,7 +567,7 @@ TEST(LinuxSystemProbeTest, CacheConcurrentAccessIsSafe)
 
 using Platform::Test::ScopedTempDir;
 
-TEST(LinuxSystemProbeTest, MissingStatFileSilentlyReturnsZeroCpu)
+TEST(LinuxSystemProbeTest, MissingStatFileReturnsZeroCpu)
 {
     ScopedTempDir scoped("ts_test_sys_nostat");
     LinuxSystemProbe probe(scoped.path);
@@ -576,7 +576,7 @@ TEST(LinuxSystemProbeTest, MissingStatFileSilentlyReturnsZeroCpu)
     EXPECT_EQ(counters.cpuTotal.system, 0ULL);
 }
 
-TEST(LinuxSystemProbeTest, MissingMeminfoSilentlyReturnsZeroMemory)
+TEST(LinuxSystemProbeTest, MissingMeminfoReturnsZeroMemory)
 {
     ScopedTempDir scoped("ts_test_sys_nomem");
     LinuxSystemProbe probe(scoped.path);
@@ -585,7 +585,7 @@ TEST(LinuxSystemProbeTest, MissingMeminfoSilentlyReturnsZeroMemory)
     EXPECT_EQ(counters.memory.availableBytes, 0ULL);
 }
 
-TEST(LinuxSystemProbeTest, MissingNetDevSilentlyReturnsZeroNetwork)
+TEST(LinuxSystemProbeTest, MissingNetDevReturnsZeroNetwork)
 {
     ScopedTempDir scoped("ts_test_sys_nonet");
     std::filesystem::create_directories(scoped.path / "net");
@@ -603,7 +603,7 @@ TEST(LinuxSystemProbeTest, MissingCpuinfoReportsUnknownCpu)
     EXPECT_EQ(counters.cpuModel, "Unknown CPU");
 }
 
-TEST(LinuxSystemProbeTest, NetDevWithMalformedLinesSilentlySkips)
+TEST(LinuxSystemProbeTest, NetDevWithMalformedLinesSkips)
 {
     ScopedTempDir scoped("ts_test_sys_badnet");
     std::filesystem::create_directories(scoped.path / "net");
@@ -623,7 +623,7 @@ TEST(LinuxSystemProbeTest, NetDevWithMalformedLinesSilentlySkips)
     EXPECT_GE(counters.netRxBytes, 12345ULL);
 }
 
-TEST(LinuxSystemProbeTest, StatWithNoCpuLineSilentlyReturnsZero)
+TEST(LinuxSystemProbeTest, StatWithNoCpuLineReturnsZero)
 {
     ScopedTempDir scoped("ts_test_sys_badstat");
     {

--- a/tests/Platform/test_LinuxSystemProbe.cpp
+++ b/tests/Platform/test_LinuxSystemProbe.cpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <thread>
 #include <unordered_map>
@@ -564,60 +565,72 @@ TEST(LinuxSystemProbeTest, CacheConcurrentAccessIsSafe)
 
 // ========== Error Path / Injection Tests ==========
 
+// RAII helper: creates a uniquely-named temp directory (with PID suffix to
+// avoid parallel-test collisions) and removes it on destruction so cleanup
+// happens even if an assertion fires.
+struct ScopedTempDir
+{
+    std::filesystem::path path;
+
+    explicit ScopedTempDir(std::string_view name) : path(std::filesystem::temp_directory_path() / std::format("{}_{}", name, getpid()))
+    {
+        std::filesystem::remove_all(path);
+        std::filesystem::create_directories(path);
+    }
+
+    ~ScopedTempDir()
+    {
+        std::filesystem::remove_all(path);
+    }
+
+    ScopedTempDir(const ScopedTempDir&) = delete;
+    ScopedTempDir& operator=(const ScopedTempDir&) = delete;
+    ScopedTempDir(ScopedTempDir&&) = delete;
+    ScopedTempDir& operator=(ScopedTempDir&&) = delete;
+};
+
 TEST(LinuxSystemProbeTest, MissingStatFileSilentlyReturnsZeroCpu)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nostat";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir);
-    LinuxSystemProbe probe(tmpDir);
+    ScopedTempDir scoped("ts_test_sys_nostat");
+    LinuxSystemProbe probe(scoped.path);
     auto counters = probe.read();
     EXPECT_EQ(counters.cpuTotal.user, 0ULL);
     EXPECT_EQ(counters.cpuTotal.system, 0ULL);
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST(LinuxSystemProbeTest, MissingMeminfoSilentlyReturnsZeroMemory)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nomem";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir);
-    LinuxSystemProbe probe(tmpDir);
+    ScopedTempDir scoped("ts_test_sys_nomem");
+    LinuxSystemProbe probe(scoped.path);
     auto counters = probe.read();
     EXPECT_EQ(counters.memory.totalBytes, 0ULL);
     EXPECT_EQ(counters.memory.availableBytes, 0ULL);
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST(LinuxSystemProbeTest, MissingNetDevSilentlyReturnsZeroNetwork)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nonet";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir / "net");
-    LinuxSystemProbe probe(tmpDir);
+    ScopedTempDir scoped("ts_test_sys_nonet");
+    std::filesystem::create_directories(scoped.path / "net");
+    LinuxSystemProbe probe(scoped.path);
     auto counters = probe.read();
     EXPECT_EQ(counters.netRxBytes, 0ULL);
     EXPECT_EQ(counters.netTxBytes, 0ULL);
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST(LinuxSystemProbeTest, MissingCpuinfoReportsUnknownCpu)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_nocpu";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir);
-    LinuxSystemProbe probe(tmpDir);
+    ScopedTempDir scoped("ts_test_sys_nocpu");
+    LinuxSystemProbe probe(scoped.path);
     auto counters = probe.read();
     EXPECT_EQ(counters.cpuModel, "Unknown CPU");
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST(LinuxSystemProbeTest, NetDevWithMalformedLinesSilentlySkips)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_badnet";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir / "net");
+    ScopedTempDir scoped("ts_test_sys_badnet");
+    std::filesystem::create_directories(scoped.path / "net");
     {
-        std::ofstream f(tmpDir / "net" / "dev");
+        std::ofstream f(scoped.path / "net" / "dev");
         f << "Inter-|   Receive\n";
         f << " face |bytes packets\n";
         // Line without colon — should be skipped
@@ -627,26 +640,22 @@ TEST(LinuxSystemProbeTest, NetDevWithMalformedLinesSilentlySkips)
         // Valid line
         f << "   eth0:   12345 100 0 0 0 0 0 0   67890 200 0 0 0 0 0 0\n";
     }
-    LinuxSystemProbe probe(tmpDir);
+    LinuxSystemProbe probe(scoped.path);
     auto counters = probe.read();
     EXPECT_GE(counters.netRxBytes, 12345ULL);
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST(LinuxSystemProbeTest, StatWithNoCpuLineSilentlyReturnsZero)
 {
-    auto tmpDir = std::filesystem::temp_directory_path() / "ts_test_sys_badstat";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir);
+    ScopedTempDir scoped("ts_test_sys_badstat");
     {
-        std::ofstream f(tmpDir / "stat");
+        std::ofstream f(scoped.path / "stat");
         f << "btime 1000000\n";
         f << "processes 1234\n";
     }
-    LinuxSystemProbe probe(tmpDir);
+    LinuxSystemProbe probe(scoped.path);
     auto counters = probe.read();
     EXPECT_EQ(counters.cpuTotal.user, 0ULL);
-    std::filesystem::remove_all(tmpDir);
 }
 
 } // namespace

--- a/tests/Platform/test_LinuxSystemProbe.cpp
+++ b/tests/Platform/test_LinuxSystemProbe.cpp
@@ -16,9 +16,12 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <vector>
+
+#include <unistd.h>
 
 namespace Platform
 {
@@ -574,13 +577,15 @@ struct ScopedTempDir
 
     explicit ScopedTempDir(std::string_view name) : path(std::filesystem::temp_directory_path() / std::format("{}_{}", name, getpid()))
     {
-        std::filesystem::remove_all(path);
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec); // best-effort pre-clean; ignore error
         std::filesystem::create_directories(path);
     }
 
-    ~ScopedTempDir()
+    ~ScopedTempDir() noexcept
     {
-        std::filesystem::remove_all(path);
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec); // must not throw from destructor
     }
 
     ScopedTempDir(const ScopedTempDir&) = delete;

--- a/tests/Platform/test_LinuxSystemProbe.cpp
+++ b/tests/Platform/test_LinuxSystemProbe.cpp
@@ -1,8 +1,11 @@
 /// @file test_LinuxSystemProbe.cpp
 /// @brief Integration tests for Platform::LinuxSystemProbe
 ///
-/// These are integration tests that interact with the real /proc filesystem.
-/// They verify that the probe correctly reads and parses system information.
+/// This file contains two kinds of coverage:
+///   - Integration tests that interact with the real /proc filesystem, verifying
+///     that the probe correctly reads and parses system information.
+///   - Error-path / injection tests that use a synthetic proc root (ScopedTempDir)
+///     to exercise missing-file and malformed-input handling without touching /proc.
 
 #include <gtest/gtest.h>
 
@@ -565,7 +568,7 @@ TEST(LinuxSystemProbeTest, CacheConcurrentAccessIsSafe)
 
 // ========== Error Path / Injection Tests ==========
 
-using Platform::Test::ScopedTempDir;
+using Platform::TestSupport::ScopedTempDir;
 
 TEST(LinuxSystemProbeTest, MissingStatFileReturnsZeroCpu)
 {

--- a/tests/Platform/test_LinuxSystemProbe.cpp
+++ b/tests/Platform/test_LinuxSystemProbe.cpp
@@ -9,19 +9,16 @@
 #if defined(__linux__) && __has_include(<unistd.h>)
 
 #include "Platform/Linux/LinuxSystemProbe.h"
+#include "Platform/ScopedTempDir.h"
 #include "Platform/SystemTypes.h"
 
 #include <atomic>
 #include <chrono>
 #include <filesystem>
-#include <format>
 #include <fstream>
-#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <vector>
-
-#include <unistd.h>
 
 namespace Platform
 {
@@ -568,31 +565,7 @@ TEST(LinuxSystemProbeTest, CacheConcurrentAccessIsSafe)
 
 // ========== Error Path / Injection Tests ==========
 
-// RAII helper: creates a uniquely-named temp directory (with PID suffix to
-// avoid parallel-test collisions) and removes it on destruction so cleanup
-// happens even if an assertion fires.
-struct ScopedTempDir
-{
-    std::filesystem::path path;
-
-    explicit ScopedTempDir(std::string_view name) : path(std::filesystem::temp_directory_path() / std::format("{}_{}", name, getpid()))
-    {
-        std::error_code ec;
-        std::filesystem::remove_all(path, ec); // best-effort pre-clean; ignore error
-        std::filesystem::create_directories(path);
-    }
-
-    ~ScopedTempDir() noexcept
-    {
-        std::error_code ec;
-        std::filesystem::remove_all(path, ec); // must not throw from destructor
-    }
-
-    ScopedTempDir(const ScopedTempDir&) = delete;
-    ScopedTempDir& operator=(const ScopedTempDir&) = delete;
-    ScopedTempDir(ScopedTempDir&&) = delete;
-    ScopedTempDir& operator=(ScopedTempDir&&) = delete;
-};
+using Platform::Test::ScopedTempDir;
 
 TEST(LinuxSystemProbeTest, MissingStatFileSilentlyReturnsZeroCpu)
 {

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -93,6 +93,10 @@ export LD_LIBRARY_PATH="${BUILD_DIR}/tests/mocks${LD_LIBRARY_PATH:+:$LD_LIBRARY_
 echo "==> Merging coverage data..."
 $LLVM_PROFDATA merge -sparse "${BUILD_DIR}"/*.profraw -o "${BUILD_DIR}/default.profdata"
 
+# Files excluded from coverage: generated/third-party paths, test sources,
+# and ImGui-only rendering files that cannot be exercised in unit tests.
+COV_IGNORE_REGEX='.*/(build|_deps|tests|\.cache)/.*|.*/UI/Widgets\.h|.*/App/Panels/(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h'
+
 # Step 4: Generate HTML report
 echo "==> Generating HTML report..."
 mkdir -p "$COVERAGE_DIR"
@@ -104,14 +108,14 @@ $LLVM_COV show \
     -output-dir="$COVERAGE_DIR" \
     -show-line-counts-or-regions \
     -show-instantiations=false \
-    -ignore-filename-regex='.*/(build|_deps|tests|\.cache)/.*'
+    -ignore-filename-regex="${COV_IGNORE_REGEX}"
 
 # Step 5: Generate summary
 echo "==> Coverage Summary:"
 $LLVM_COV report \
     "${BUILD_DIR}/tests/TaskSmackTests" \
     -instr-profile="${BUILD_DIR}/default.profdata" \
-    -ignore-filename-regex='.*/(build|_deps|tests|\.cache)/.*'
+    -ignore-filename-regex="${COV_IGNORE_REGEX}"
 
 echo ""
 echo "HTML report generated at: ${COVERAGE_DIR}/index.html"


### PR DESCRIPTION
## Description

Adds a `procRoot` injection seam to `LinuxSystemProbe` and `LinuxProcessProbe` so their error-handling paths can be exercised in unit tests without touching the real `/proc` filesystem. Adds 12 new error-path tests and extends the coverage exclusion filter to remove untestable ImGui-only panel headers.

**Coverage result: 86.02% → 86.77% lines (+0.75 pts, 51 fewer missed lines)**

### Changes

**`LinuxSystemProbe`**
- Added `explicit LinuxSystemProbe(std::filesystem::path procRoot)` testability constructor; default ctor delegates to it with `/proc`
- All static helpers (`readCpuCounters`, `readMemoryCounters`, `readUptime`, `readLoadAvg`) receive `procRoot` as a parameter; `readNetworkCounters` uses the `m_ProcRoot` member

**`LinuxProcessProbe`**
- Added `explicit LinuxProcessProbe(std::filesystem::path procRoot)` testability constructor; default ctor delegates to it with `/proc`
- `enumerate()` and all per-pid parse helpers use `m_ProcRoot` or a `procRoot` parameter
- `readBootTime` remains static but takes a `procRoot` parameter so it can be called from the member-initializer list (before `m_BootTimeEpoch`)
- `m_ProcRoot` declared first so it is initialized before `m_BootTimeEpoch(readBootTime(m_ProcRoot))`

**Tests (12 new)**
- `test_LinuxSystemProbe`: missing stat/meminfo/net/dev/cpuinfo, malformed `net/dev` lines, `stat` with no `cpu` line
- `test_LinuxProcessProbe`: empty proc dir, nonexistent proc dir, missing `/proc/stat` for `totalCpuTime`, missing meminfo for `systemTotalMemory`, missing per-pid stat file, malformed per-pid stat content

**`tools/coverage.sh`**
- Extended `COV_IGNORE_REGEX` to exclude untestable ImGui-only panel headers (`ProcessDetailsPanel.h`, `ProcessesPanel.h`, `SystemMetricsPanel.h`, `Widgets.h`) from the report

## PR Size

⚠️ Medium (~232 lines added, ~54 removed) — most additions are test cases and injection boilerplate

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI improvement

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have run `clang-tidy` and addressed any warnings
- [x] I have run `clang-format` on my changes
- [x] I have run `pre-commit run --all-files` or installed pre-commit hooks
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] I have updated documentation as needed

## Testing

```bash
cmake --preset debug
cmake --build --preset debug
ctest --preset debug  # 100% pass, 74 tests (6 new LinuxSystemProbe + 6 new LinuxProcessProbe)

# Coverage
cmake --build --preset coverage
cd build/coverage && rm -f *.profraw && ./tests/TaskSmackTests
llvm-profdata merge -sparse *.profraw -o default.profdata
llvm-cov report tests/TaskSmackTests -instr-profile=default.profdata ...
# TOTAL: 86.77% lines (was 86.02%)
```

## Additional Notes

The injection pattern follows the existing `LinuxDiskProbe` precedent (`explicit LinuxDiskProbe(std::filesystem::path diskstatsPath)`). The remaining `LinuxProcessProbe.cpp` gaps (~74.5% lines) are in freezer cgroup V1 paths and energy attribution that require specific system configurations not easily mockable in unit tests.