### PR TITLE
fix: correct LSAN suppression for statically-linked SDL3 EGL leak

### DIFF
--- a/tests/sanitizer-suppressions/lsan.supp
+++ b/tests/sanitizer-suppressions/lsan.supp
@@ -1,6 +1,10 @@
 # LeakSanitizer suppressions for TaskSmack tests
 #
-# SDL3 intentionally retains internal subsystem state after SDL_Quit() for
-# performance reasons. LeakSanitizer reports this as leaked, but it is expected
+# SDL3 is built as a static library (SDL_STATIC ON), so LSAN cannot match
+# module names like "libSDL3". Suppressions must match function names instead.
+#
+# SDL_EGL_InitializeOffscreen allocates an EGL display and context that SDL3
+# intentionally retains after SDL_Quit() for performance reasons (avoiding
+# re-initialization overhead). LSAN reports this as leaked, but it is expected
 # behavior in SDL3's cleanup model and not a TaskSmack bug.
-leak:libSDL3
+leak:SDL_EGL_InitializeOffscreen


### PR DESCRIPTION
## Problem

The `sanitizers (asan-ubsan)` CI job on `main` (run #25898151667, commit `8048f0e`) was failing with:

```
SUMMARY: AddressSanitizer: 2808 byte(s) leaked in 2 allocation(s)
```

across 5 test processes. The leak came from `SDL_EGL_InitializeOffscreen`, which allocates an EGL display/context that SDL3 intentionally retains after `SDL_Quit()`.

## Root Cause

PR #534 added `tests/sanitizer-suppressions/lsan.supp` with:

```
leak:libSDL3
```

This suppression **never fires** because SDL3 is built as a **static library** (`SDL_STATIC ON` / `SDL_SHARED OFF` in `CMakeLists.txt`). LSAN can only match module names (like `libSDL3`) for **shared** libraries. With static linking, suppressions must match **function names** in the call stack.

## Fix

Replace `leak:libSDL3` with `leak:SDL_EGL_InitializeOffscreen` — the SDL3 function that appears in the leak stack when the offscreen video driver initializes EGL. Added a comment explaining why function-name matching is required for static libraries.

## Verification

Locally reproduced the leak with `SDL_VIDEODRIVER=offscreen` + `detect_leaks=1`, confirmed 2 allocations from `SDL_EGL_InitializeOffscreen`. With the new suppression:

```
Suppressions used:
  count      bytes template
     53     142040 SDL_EGL_InitializeOffscreen
```

All 28 `WindowTest.*` + `ApplicationTest.*` tests pass with no LSAN errors.