### PR TITLE
ci: fix Scorecard TokenPermissions alerts and CodeQL false positives

### DIFF
--- a/.github/workflows/build-linux-debug.yml
+++ b/.github/workflows/build-linux-debug.yml
@@ -15,7 +15,6 @@ jobs:
   build-linux-debug:
     permissions:
       contents: read
-      actions: write
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       os: ubuntu-24.04

--- a/.github/workflows/build-linux-release.yml
+++ b/.github/workflows/build-linux-release.yml
@@ -15,7 +15,6 @@ jobs:
   build-linux-release:
     permissions:
       contents: read
-      actions: write
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       os: ubuntu-24.04

--- a/.github/workflows/build-windows-debug.yml
+++ b/.github/workflows/build-windows-debug.yml
@@ -15,7 +15,6 @@ jobs:
   build-windows-debug:
     permissions:
       contents: read
-      actions: write
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       os: windows-latest

--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -15,7 +15,6 @@ jobs:
   build-windows-release:
     permissions:
       contents: read
-      actions: write
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
         build_type: [debug, release]
     permissions:
       contents: read
-      actions: write
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       os: ubuntu-24.04
@@ -123,7 +122,6 @@ jobs:
         build_type: [debug, release]
     permissions:
       contents: read
-      actions: write
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       os: windows-latest
@@ -148,7 +146,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -201,7 +198,6 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,15 +37,19 @@ jobs:
       - name: Setup Python for GLAD
         uses: ./.github/actions/setup-python-glad
 
+      # Configure before CodeQL init so CMake's try_compile() scratch files are
+      # compiled outside the CodeQL trace and never enter the analysis database.
+      # Doing this after init is what caused false-positive cpp/uninitialized-local
+      # alerts in build/debug/CMakeFiles/CMakeScratch/TryCompile-*/src.c.
+      - name: Configure
+        run: cmake --preset debug -DPython3_EXECUTABLE="$(which python)"
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: c-cpp
           queries: security-and-quality
           config-file: ./.github/codeql/codeql-config.yml
-
-      - name: Configure
-        run: cmake --preset debug -DPython3_EXECUTABLE="$(which python)"
 
       - name: Build
         run: cmake --build --preset debug

--- a/.github/workflows/heavy-checks.yml
+++ b/.github/workflows/heavy-checks.yml
@@ -50,7 +50,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -183,7 +182,6 @@ jobs:
     timeout-minutes: 35
     permissions:
       contents: read
-      actions: write
     env:
       LLVM_ROOT: C:\Program Files\LLVM
     steps:
@@ -313,7 +311,6 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
-      actions: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -68,7 +67,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -22,7 +22,8 @@ on:
         type: string
         default: '22.1.0'
 
-permissions: read-all
+# Deny all permissions by default; each job must explicitly declare what it needs.
+permissions: {}
 
 jobs:
   build-test:

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -22,6 +22,8 @@ on:
         type: string
         default: '22.1.0'
 
+permissions: read-all
+
 jobs:
   build-test:
     name: Build & Test (${{ inputs.os }} ${{ inputs.build_type }})
@@ -29,7 +31,6 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
-      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -43,7 +43,6 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
-      actions: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,7 +20,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## Summary

Two categories of code scanning alerts fixed in one pass.

---

### 1. Scorecard TokenPermissions (20 alerts across 10 workflow files)

Removed `actions: write` from every job that only builds, tests, or uploads artifacts. This permission is only needed when managing GitHub Actions workflow runs via the API (canceling, triggering). The `actions/upload-artifact` v4+ action uses `ACTIONS_RUNTIME_TOKEN` internally and does not require `actions: write` in the GITHUB_TOKEN scope.

Also added a top-level `permissions: {}` (deny all) to `reusable-build-test.yml`. Scorecard requires an explicit top-level permission block on reusable workflows; using deny-all forces every job to explicitly declare its own permissions rather than inheriting a broad default.

**Files changed:** `build-linux-debug.yml`, `build-linux-release.yml`, `build-windows-debug.yml`, `build-windows-release.yml`, `reusable-build-test.yml`, `sanitizers.yml`, `static-analysis.yml`, `ci.yml` (4 jobs), `heavy-checks.yml` (3 jobs), `release.yml` (2 jobs)

**Remaining write permissions are all legitimate and cannot be reduced:**
- `changelog.yml`: `contents: write` — pushes CHANGELOG.md to main
- `release.yml`: `contents: write` — creates GitHub releases
- `osv-scanner.yml`: `security-events: write` — uploads SARIF to Security tab
- `codeql.yml`: `security-events: write` — uploads CodeQL SARIF
- `scorecard.yml`: `security-events: write` + `id-token: write` — Scorecard SARIF
- `pr-labeler.yml`: `pull-requests: write` — labels PRs

---

### 2. CodeQL false positives: `cpp/uninitialized-local` in CMake try-compile files (alerts #2872, #2873, #2874)

**Root cause:** The `Configure` step (`cmake --preset debug`) was running *after* `Initialize CodeQL`. This meant CodeQL&#39;s build interceptor captured all of CMake&#39;s `try_compile()` test compilations — the probe files written to `build/debug/CMakeFiles/CMakeScratch/TryCompile-*/src.c`. Those generated C files intentionally contain uninitialized variables (to probe compiler behavior), so CodeQL flagged them as `cpp/uninitialized-local`. The `paths-ignore` config could not help because the files were already in the CodeQL analysis database before any path filtering could exclude them.

**Fix (`codeql.yml`):** Move the `Configure` step to run *before* `Initialize CodeQL`. CMake&#39;s configure-time probe compilations now happen outside the CodeQL build trace entirely. CodeQL only traces the actual source build (`cmake --build --preset debug`), so scratch files never enter the analysis database.

This is a **step reordering only** — no logic changes to the build or analysis itself. The `Build` step that CodeQL does trace is unchanged.