### PR TITLE
ci(pre-commit): use official pre-commit/action to fix PinnedDependencies alert

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,21 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: '3.14'
-          cache: 'pip'
-
-      - name: Install pre-commit
-        run: pip install pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: pre-commit-
-
       - name: Run pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          extra_args: --all-files --show-diff-on-failure


### PR DESCRIPTION
## Summary

Fixes the Scorecard **PinnedDependencies** alert (#2862) raised against `.github/workflows/pre-commit.yml`.

### Problem

The workflow previously ran four manual steps:
1. `actions/setup-python`
2. `pip install pre-commit` — **unflagged, un-pinned pip install** (the alert)
3. Manual `actions/cache` for pre-commit environments
4. `pre-commit run --all-files`

The `pip install pre-commit` step installs an unpinned package at runtime, which Scorecard flags as a supply-chain risk.

### Fix

Replaced all four steps with the single official action:

```yaml
- uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
  with:
    extra_args: --all-files --show-diff-on-failure
```

- **SHA-pinned** at the commit hash for `v3.0.1` — satisfies Scorecard's PinnedDependencies requirement
- Handles Python setup, pre-commit installation, environment caching, and execution internally
- No functional change to what gets checked

### Alerts addressed

| Alert | File | Status |
|-------|------|--------|
| PinnedDependencies #2862 | `.github/workflows/pre-commit.yml` | Fixed by this PR |
| PinnedDependencies #2861 | `tools/generate-icons.sh` | Previously dismissed as false positive (dev-only tool, not a workflow) |
