### PR TITLE
fix: address Scorecard VulnerabilitiesID, SecurityPolicyID, and BranchProtectionID

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,10 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in this project, please report it responsibly:
+If you discover a security vulnerability in this project, please report it responsibly using [GitHub's private vulnerability reporting](https://github.com/mgradwohl/tasksmack/security/advisories/new):
 
 1. **Do not** open a public GitHub issue for security vulnerabilities
-2. Instead, please email the maintainer directly or use GitHub's private vulnerability reporting feature
+2. Use GitHub's private vulnerability reporting: https://github.com/mgradwohl/tasksmack/security/advisories/new
 
 ### What to Include
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 filelock>=3.29.0
-jinja2
-pre-commit
+jinja2>=3.1.4
+pre-commit>=4.0.0


### PR DESCRIPTION
## Summary

Three Scorecard alerts addressed in one pass.

---

### 1. VulnerabilitiesID (#2772) — `requirements.txt`

Pinned minimum safe versions for the two previously-unpinned packages:

- `jinja2>=3.1.4` — 3.1.4 (Dec 2023) fixed GHSA-h75v-3vvj-5mfj; all 9 listed CVEs (PYSEC-2019-217, PYSEC-2014-8, PYSEC-2014-82, PYSEC-2021-66, etc.) affect versions older than 3.x and are fully resolved at 3.1.4+
- `pre-commit>=4.0.0` — pins past all known pre-commit CVEs
- `filelock>=3.29.0` — already pinned, unchanged

---

### 2. SecurityPolicyID (#2771) — `SECURITY.md`

Scorecard requires at least one URL in the security policy file to consider it "linked". Added a direct link to GitHub's private vulnerability reporting page for this repo:
`https://github.com/mgradwohl/tasksmack/security/advisories/new`

---

### 3. BranchProtectionID (#2670) — configured via GitHub API (not a code change)

Branch protection rules applied directly to `main` (separate from this commit):
- Required status checks: `build-linux-debug / Build & Test (ubuntu-24.04 debug)`, `build-linux-release / Build & Test (ubuntu-24.04 release)`, `Run pre-commit checks`
- No force pushes
- No branch deletion
- Linear history required
- Reviews not required (solo project)
