### PR TITLE
fix: align LCOV ignore regex with local coverage exclusions

### DIFF
--- a/.github/workflows/heavy-checks.yml
+++ b/.github/workflows/heavy-checks.yml
@@ -143,21 +143,6 @@ jobs:
             echo "❌ **Coverage Check Failed:** Could not find coverage output file" >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Generate LCOV file for Codecov
-        run: |
-          llvm_cov_bin="$(command -v llvm-cov || command -v llvm-cov-22 || true)"
-          if [ -z "$llvm_cov_bin" ]; then
-            echo "llvm-cov not found on PATH"
-            exit 1
-          fi
-          mkdir -p coverage
-          "$llvm_cov_bin" export \
-            build/coverage/tests/TaskSmackTests \
-            -instr-profile=build/coverage/default.profdata \
-            -format=lcov \
-            -ignore-filename-regex='.*/(build|_deps|tests|\.cache)/.*|.*/UI/Widgets\.h|.*/App/Panels/(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h' \
-            > coverage/coverage.lcov
-
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/heavy-checks.yml
+++ b/.github/workflows/heavy-checks.yml
@@ -155,7 +155,7 @@ jobs:
             build/coverage/tests/TaskSmackTests \
             -instr-profile=build/coverage/default.profdata \
             -format=lcov \
-            -ignore-filename-regex='.*/(build|_deps|tests|\.cache)/.*' \
+            -ignore-filename-regex='.*/(build|_deps|tests|\.cache)/.*|.*/UI/Widgets\.h|.*/App/Panels/(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h' \
             > coverage/coverage.lcov
 
       - name: Upload coverage report

--- a/tools/coverage.ps1
+++ b/tools/coverage.ps1
@@ -83,6 +83,11 @@ try {
     & $LlvmProfdata merge -sparse $profrawFiles -o "$BuildDir\default.profdata"
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+    # Files excluded from coverage: generated/third-party paths, test sources,
+    # and ImGui-only rendering files that cannot be exercised in unit tests.
+    # Keep in sync with tools/coverage.sh COV_IGNORE_REGEX.
+    $IgnoreRegex = ".*(\\|/)(build|_deps|tests|\.cache)(\\|/).*|(\\|/)UI(\\|/)Widgets\.h|(\\|/)App(\\|/)Panels(\\|/)(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h"
+
     # Step 4: Generate HTML report
     Write-Host "==> Generating HTML report..."
     New-Item -ItemType Directory -Force -Path $CoverageDir | Out-Null
@@ -94,7 +99,7 @@ try {
         "-output-dir=$CoverageDir" `
         -show-line-counts-or-regions `
         -show-instantiations=false `
-        "-ignore-filename-regex=.*(\\|/)(build|_deps|tests|\.cache)(\\|/).*|(\\|/)UI(\\|/)Widgets\.h|(\\|/)App(\\|/)Panels(\\|/)(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h"
+        "-ignore-filename-regex=$IgnoreRegex"
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     # Step 5: Generate LCOV file for Codecov
@@ -104,7 +109,7 @@ try {
         "$BuildDir\tests\TaskSmackTests.exe" `
         "-instr-profile=$BuildDir\default.profdata" `
         -format=lcov `
-        "-ignore-filename-regex=.*(\\|/)(build|_deps|tests|\.cache)(\\|/).*|(\\|/)UI(\\|/)Widgets\.h|(\\|/)App(\\|/)Panels(\\|/)(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h" `
+        "-ignore-filename-regex=$IgnoreRegex" `
         | Set-Content -Path $lcovPath -Encoding utf8NoBOM
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -113,7 +118,7 @@ try {
     & $LlvmCov report `
         "$BuildDir\tests\TaskSmackTests.exe" `
         "-instr-profile=$BuildDir\default.profdata" `
-        "-ignore-filename-regex=.*(\\|/)(build|_deps|tests|\.cache)(\\|/).*|(\\|/)UI(\\|/)Widgets\.h|(\\|/)App(\\|/)Panels(\\|/)(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h"
+        "-ignore-filename-regex=$IgnoreRegex"
 
     Write-Host ""
     Write-Host "HTML report generated at: $CoverageDir\index.html" -ForegroundColor Green

--- a/tools/coverage.ps1
+++ b/tools/coverage.ps1
@@ -94,7 +94,7 @@ try {
         "-output-dir=$CoverageDir" `
         -show-line-counts-or-regions `
         -show-instantiations=false `
-        "-ignore-filename-regex=.*(\\|/)(build|_deps|tests|\.cache)(\\|/).*"
+        "-ignore-filename-regex=.*(\\|/)(build|_deps|tests|\.cache)(\\|/).*|(\\|/)UI(\\|/)Widgets\.h|(\\|/)App(\\|/)Panels(\\|/)(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h"
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     # Step 5: Generate LCOV file for Codecov
@@ -104,7 +104,7 @@ try {
         "$BuildDir\tests\TaskSmackTests.exe" `
         "-instr-profile=$BuildDir\default.profdata" `
         -format=lcov `
-        "-ignore-filename-regex=.*(\\|/)(build|_deps|tests|\.cache)(\\|/).*" `
+        "-ignore-filename-regex=.*(\\|/)(build|_deps|tests|\.cache)(\\|/).*|(\\|/)UI(\\|/)Widgets\.h|(\\|/)App(\\|/)Panels(\\|/)(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h" `
         | Set-Content -Path $lcovPath -Encoding utf8NoBOM
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -113,7 +113,7 @@ try {
     & $LlvmCov report `
         "$BuildDir\tests\TaskSmackTests.exe" `
         "-instr-profile=$BuildDir\default.profdata" `
-        "-ignore-filename-regex=.*(\\|/)(build|_deps|tests|\.cache)(\\|/).*"
+        "-ignore-filename-regex=.*(\\|/)(build|_deps|tests|\.cache)(\\|/).*|(\\|/)UI(\\|/)Widgets\.h|(\\|/)App(\\|/)Panels(\\|/)(ProcessDetailsPanel|ProcessesPanel|SystemMetricsPanel)\.h"
 
     Write-Host ""
     Write-Host "HTML report generated at: $CoverageDir\index.html" -ForegroundColor Green

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -110,7 +110,16 @@ $LLVM_COV show \
     -show-instantiations=false \
     -ignore-filename-regex="${COV_IGNORE_REGEX}"
 
-# Step 5: Generate summary
+# Step 5: Generate LCOV file for Codecov
+echo "==> Generating LCOV report..."
+$LLVM_COV export \
+    "${BUILD_DIR}/tests/TaskSmackTests" \
+    -instr-profile="${BUILD_DIR}/default.profdata" \
+    -format=lcov \
+    -ignore-filename-regex="${COV_IGNORE_REGEX}" \
+    > "${COVERAGE_DIR}/coverage.lcov"
+
+# Step 6: Generate summary
 echo "==> Coverage Summary:"
 $LLVM_COV report \
     "${BUILD_DIR}/tests/TaskSmackTests" \


### PR DESCRIPTION
Extend the `-ignore-filename-regex` used when generating LCOV files for Codecov to match the exclusions already applied by `coverage.sh`:

- `UI/Widgets.h` (header-only file, 0% covered)
- `App/Panels/ProcessDetailsPanel.h`
- `App/Panels/ProcessesPanel.h`
- `App/Panels/SystemMetricsPanel.h`

These files were excluded from the local HTML/text report but not from the LCOV data uploaded to Codecov, causing the Codecov number (~69%) to be lower than the local report (~87%).

## Files changed
- `.github/workflows/heavy-checks.yml` — Linux `llvm-cov export` step
- `tools/coverage.ps1` — Windows `show`, `export`, and `report` steps (all 3 occurrences)