### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(POLICY CMP0069)
 endif()
 
 
-project(TaskSmack VERSION 0.6.1 LANGUAGES C CXX)
+project(TaskSmack VERSION 0.7.0 LANGUAGES C CXX)
 
 # Windows: Configure MSVC runtime library linkage for Clang
 if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Bumps project version from 0.6.1 to 0.7.0 in CMakeLists.txt in preparation for the v0.7.0 release tag.