### PR TITLE
fix(release): set CPack maintainer metadata and bump to 0.7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(POLICY CMP0069)
 endif()
 
 
-project(TaskSmack VERSION 0.7.0 LANGUAGES C CXX)
+project(TaskSmack VERSION 0.7.1 LANGUAGES C CXX)
 
 # Windows: Configure MSVC runtime library linkage for Clang
 if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -843,8 +843,8 @@ set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${PROJECT_NAME} - TaskSmack")
 set(CPACK_PACKAGE_DESCRIPTION "TaskSmack - Modern cross-platform system monitor")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/mgradwohl/tasksmack")
-set(CPACK_PACKAGE_VENDOR "")
-set(CPACK_PACKAGE_CONTACT "")
+set(CPACK_PACKAGE_VENDOR "TaskSmack Contributors")
+set(CPACK_PACKAGE_CONTACT "mgradwohl@users.noreply.github.com")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
 set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/assets/icons/tasksmack.ico")


### PR DESCRIPTION
## Summary
- set non-empty CPack package vendor/contact metadata
- ensure Debian maintainer resolves from contact metadata for DEB packaging
- bump project version to 0.7.1

## Why
The v0.7.0 release workflow failed in Linux packaging because CPackDeb requires maintainer/contact metadata (CPACK_PACKAGE_CONTACT or CPACK_DEBIAN_PACKAGE_MAINTAINER).

## Validation
- Confirmed release run failure: CPackDeb: Debian package requires a maintainer
- Metadata is now set in CMakeLists.txt.

After merge, create/push tag 0.7.1 to publish a complete release.