### PR TITLE
fix(ci): tolerate restricted PR creation in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -105,12 +105,17 @@ jobs:
           git commit -m "Update CHANGELOG.md for ${{ github.ref_name }}"
           git push origin "$BRANCH"
           if [ "$PR_EXISTS" = false ]; then
-            gh pr create \
+            if ! gh pr create \
               --base main \
               --head "$BRANCH" \
               --title "Update CHANGELOG.md for ${{ github.ref_name }}" \
               --body "Auto-generated changelog for the ${{ github.ref_name }} release via git-cliff." \
-              --label "documentation"
+              --label "documentation"; then
+              echo "Unable to create PR from workflow token."
+              echo "Create it manually: https://github.com/${{ github.repository }}/pull/new/$BRANCH"
+              # Do not fail release-related automation if PR creation is restricted by repo settings.
+              exit 0
+            fi
           else
             echo "PR for $BRANCH already exists — branch updated."
           fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -105,17 +105,24 @@ jobs:
           git commit -m "Update CHANGELOG.md for ${{ github.ref_name }}"
           git push origin "$BRANCH"
           if [ "$PR_EXISTS" = false ]; then
+            PR_CREATE_ERROR_FILE=$(mktemp)
             if ! gh pr create \
               --base main \
               --head "$BRANCH" \
               --title "Update CHANGELOG.md for ${{ github.ref_name }}" \
               --body "Auto-generated changelog for the ${{ github.ref_name }} release via git-cliff." \
-              --label "documentation"; then
-              echo "Unable to create PR from workflow token."
-              echo "Create it manually: https://github.com/${{ github.repository }}/pull/new/$BRANCH"
-              # Do not fail release-related automation if PR creation is restricted by repo settings.
-              exit 0
+              --label "documentation" 2>"$PR_CREATE_ERROR_FILE"; then
+              if grep -Eq 'not permitted to create or approve pull requests|Resource not accessible by integration|createPullRequest' "$PR_CREATE_ERROR_FILE"; then
+                echo "Unable to create PR from workflow token."
+                echo "Create it manually: https://github.com/${{ github.repository }}/pull/new/$BRANCH"
+                exit 0
+              fi
+
+              cat "$PR_CREATE_ERROR_FILE" >&2
+              rm -f "$PR_CREATE_ERROR_FILE"
+              exit 1
             fi
+            rm -f "$PR_CREATE_ERROR_FILE"
           else
             echo "PR for $BRANCH already exists — branch updated."
           fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -106,6 +106,9 @@ jobs:
           git push origin "$BRANCH"
           if [ "$PR_EXISTS" = false ]; then
             PR_CREATE_ERROR_FILE=$(mktemp)
+            # Guarantee temp file cleanup on all exits (success, error, and restricted-token fallback)
+            # shellcheck disable=SC2064
+            trap "rm -f \"$PR_CREATE_ERROR_FILE\"" EXIT
             if ! gh pr create \
               --base main \
               --head "$BRANCH" \
@@ -114,15 +117,15 @@ jobs:
               --label "documentation" 2>"$PR_CREATE_ERROR_FILE"; then
               if grep -Eq 'not permitted to create or approve pull requests|Resource not accessible by integration|createPullRequest' "$PR_CREATE_ERROR_FILE"; then
                 echo "Unable to create PR from workflow token."
-                echo "Create it manually: https://github.com/${{ github.repository }}/pull/new/$BRANCH"
+                # Encode slashes in branch name so the compare URL works correctly
+                ENCODED_BRANCH="${BRANCH//\//%2F}"
+                echo "Create it manually: https://github.com/${{ github.repository }}/compare/main...${ENCODED_BRANCH}?expand=1"
                 exit 0
               fi
 
               cat "$PR_CREATE_ERROR_FILE" >&2
-              rm -f "$PR_CREATE_ERROR_FILE"
               exit 1
             fi
-            rm -f "$PR_CREATE_ERROR_FILE"
           else
             echo "PR for $BRANCH already exists — branch updated."
           fi


### PR DESCRIPTION
The changelog workflow currently fails if repository settings block GitHub Actions from creating pull requests (createPullRequest).

This change makes PR creation best-effort:
- If gh pr create succeeds, behavior is unchanged.
- If it fails due token restrictions, the workflow prints a manual PR URL and exits successfully, so release-related automation is not marked failed.

This prevents false-negative workflow failures while preserving branch-protection-compliant changelog updates.