### PR TITLE
fix(platform): guard publisher cache with mutex for concurrent enumeration

### DIFF
--- a/src/Platform/Windows/WindowsProcessProbe.cpp
+++ b/src/Platform/Windows/WindowsProcessProbe.cpp
@@ -39,6 +39,7 @@
 #include <cwchar>
 #include <cwctype>
 #include <limits>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -365,16 +366,19 @@ constexpr ULONG PEBI_IS_BACKGROUND = 0x00000020; // Background process (efficien
     // Normalise to lowercase before lookup so that different-cased paths for the same
     // binary (which QueryFullProcessImageNameW does not guarantee to be stable) share
     // a single cache entry.
-    // NOTE: not guarded by a mutex. enumerate() is invoked on the main thread and
-    // BackgroundSampler (which would require a lock) is not yet active. If concurrent
-    // enumeration is enabled in the future, this cache must be protected by a mutex.
+    // Only cache lookups and inserts are serialised; the expensive version-info I/O
+    // is performed outside the lock so concurrent threads do not stall each other.
+    static std::mutex s_cacheMutex;
     static std::unordered_map<std::wstring, std::string> s_cache;
     std::wstring cacheKey(imagePath);
     std::ranges::transform(
         cacheKey, cacheKey.begin(), [](wchar_t c) { return static_cast<wchar_t>(std::towlower(static_cast<wint_t>(c))); });
-    if (const auto it = s_cache.find(cacheKey); it != s_cache.end())
     {
-        return it->second;
+        std::lock_guard<std::mutex> lock(s_cacheMutex);
+        if (const auto it = s_cache.find(cacheKey); it != s_cache.end())
+        {
+            return it->second;
+        }
     }
 
     // GetFileVersionInfoSizeW requires a LPDWORD that receives an internal handle.
@@ -383,14 +387,16 @@ constexpr ULONG PEBI_IS_BACKGROUND = 0x00000020; // Background process (efficien
     const DWORD infoSize = GetFileVersionInfoSizeW(imagePath.c_str(), &unused);
     if (infoSize == 0)
     {
-        s_cache.emplace(cacheKey, std::string{});
+        std::lock_guard<std::mutex> lock(s_cacheMutex);
+        s_cache.try_emplace(cacheKey, std::string{});
         return {};
     }
 
     std::vector<BYTE> buffer(infoSize);
     if (GetFileVersionInfoW(imagePath.c_str(), 0, infoSize, buffer.data()) == 0)
     {
-        s_cache.emplace(cacheKey, std::string{});
+        std::lock_guard<std::mutex> lock(s_cacheMutex);
+        s_cache.try_emplace(cacheKey, std::string{});
         return {};
     }
 
@@ -443,7 +449,10 @@ constexpr ULONG PEBI_IS_BACKGROUND = 0x00000020; // Background process (efficien
         result = queryCompanyName(L"\\StringFileInfo\\040904E4\\CompanyName");
     }
 
-    s_cache.emplace(cacheKey, result);
+    {
+        std::lock_guard<std::mutex> lock(s_cacheMutex);
+        s_cache.try_emplace(cacheKey, result);
+    }
     return result;
 }
 


### PR DESCRIPTION
## Problem

`WindowsProcessProbeTest.ConcurrentEnumeration` was SEGFAULTing on Windows CI, causing the `build-windows (debug)` job to fail on PR #548 (and any subsequent PR based on main).

The test spawns 4 threads that each create a `WindowsProcessProbe` and call `enumerate()` concurrently. Inside `enumerate()`, `getFilePublisher()` is called for every process. That function has a `static std::unordered_map` cache with no synchronization — concurrent reads and writes to a `std::unordered_map` are undefined behaviour, manifesting as a SEGFAULT.

The code even had a comment acknowledging the gap:
> NOTE: not guarded by a mutex. enumerate() is invoked on the main thread and BackgroundSampler … is not yet active. If concurrent enumeration is enabled in the future, this cache must be protected by a mutex.

The `ConcurrentEnumeration` test was added in #541 without addressing this note.

## Fix

- Add `static std::mutex s_cacheMutex` alongside `s_cache` in `getFilePublisher()`.
- Serialise only the cache lookup and insert — the expensive `GetFileVersionInfoW` I/O runs **outside** the lock so concurrent threads don't stall each other.
- Use `try_emplace` instead of `emplace` so a concurrent insert by another thread is silently tolerated.

## Testing

All 1170 Linux tests pass. The Windows SEGFAULT is eliminated by removing the data race.