### PR TITLE
Adjust PR checks cadence to weekly for heavy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,6 @@ jobs:
     with:
       os: ubuntu-24.04
       build_type: debug
-      llvm-version: '22'
 
   build-linux-release:
     needs: [detect-docs-only, validate-environment]
@@ -127,7 +126,6 @@ jobs:
     with:
       os: ubuntu-24.04
       build_type: release
-      llvm-version: '22'
 
   build-windows-debug:
     needs: [detect-docs-only, validate-environment-windows]
@@ -161,7 +159,7 @@ jobs:
         run: ./tools/md-link-audit.sh
 
   static-analysis:
-    needs: [detect-docs-only, validate-environment, build-linux-debug]
+    needs: [detect-docs-only, validate-environment]
     if: (github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true') && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ['dev/**']
   pull_request:
     branches: [main, 'dev/**']
+  schedule:
+    # Run weekly on Sundays at 09:00 UTC
+    - cron: '0 9 * * 0'
   workflow_dispatch:
 
 concurrency:
@@ -104,34 +107,48 @@ jobs:
         shell: pwsh
         run: ./tools/check-prereqs.ps1
 
-  build-linux:
+  build-linux-debug:
     needs: [detect-docs-only, validate-environment]
     if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true'
-    strategy:
-      fail-fast: true
-      matrix:
-        build_type: [debug, release]
     permissions:
       contents: read
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       os: ubuntu-24.04
-      build_type: ${{ matrix.build_type }}
+      build_type: debug
       llvm-version: '22'
 
-  build-windows:
+  build-linux-release:
+    needs: [detect-docs-only, validate-environment]
+    if: (github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true') && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-build-test.yml
+    with:
+      os: ubuntu-24.04
+      build_type: release
+      llvm-version: '22'
+
+  build-windows-debug:
     needs: [detect-docs-only, validate-environment-windows]
     if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true'
-    strategy:
-      fail-fast: true
-      matrix:
-        build_type: [debug, release]
     permissions:
       contents: read
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       os: windows-latest
-      build_type: ${{ matrix.build_type }}
+      build_type: debug
+      llvm-semver-version: '22.1.0'
+
+  build-windows-release:
+    needs: [detect-docs-only, validate-environment-windows]
+    if: (github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true') && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-build-test.yml
+    with:
+      os: windows-latest
+      build_type: release
       llvm-semver-version: '22.1.0'
 
   docs-hygiene:
@@ -146,8 +163,8 @@ jobs:
         run: ./tools/md-link-audit.sh
 
   static-analysis:
-    needs: [detect-docs-only, validate-environment, build-linux]
-    if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true'
+    needs: [detect-docs-only, validate-environment, build-linux-debug]
+    if: (github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true') && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
@@ -198,7 +215,7 @@ jobs:
           retention-days: 14
 
   include-analysis:
-    needs: [detect-docs-only, validate-environment, build-linux]
+    needs: [detect-docs-only, validate-environment, build-linux-debug]
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
   build-linux-debug:
     needs: [detect-docs-only, validate-environment]
-    if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true'
+    if: (github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true') && github.event_name != 'schedule'
     permissions:
       contents: read
     uses: ./.github/workflows/reusable-build-test.yml
@@ -131,14 +131,13 @@ jobs:
 
   build-windows-debug:
     needs: [detect-docs-only, validate-environment-windows]
-    if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true'
+    if: (github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs_only != 'true') && github.event_name != 'schedule'
     permissions:
       contents: read
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       os: windows-latest
       build_type: debug
-      llvm-semver-version: '22.1.0'
 
   build-windows-release:
     needs: [detect-docs-only, validate-environment-windows]
@@ -149,7 +148,6 @@ jobs:
     with:
       os: windows-latest
       build_type: release
-      llvm-semver-version: '22.1.0'
 
   docs-hygiene:
     runs-on: ubuntu-24.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,11 +3,9 @@ name: CodeQL Security Analysis
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
-    # Run weekly on Mondays at 10:00 UTC
-    - cron: '0 10 * * 1'
+    # Run weekly on Sundays at 10:00 UTC
+    - cron: '0 10 * * 0'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -14,11 +14,9 @@ name: OSV Dependency Scan
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   schedule:
-    # Run weekly on Mondays at 06:00 UTC (offset from CodeQL at 10:00 UTC)
-    - cron: '0 6 * * 1'
+    # Run weekly on Sundays at 06:00 UTC (offset from CodeQL at 10:00 UTC)
+    - cron: '0 6 * * 0'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Move Linux/Windows release build+test in CI off pull requests to weekly Sunday schedule and manual dispatch.
- Keep debug build+test on PRs by splitting CI reusable workflow jobs into explicit debug/release jobs.
- Move CI clang-tidy static-analysis off PRs to weekly Sunday schedule/manual.
- Remove pull_request triggers from CodeQL and OSV workflows; keep push to main + weekly Sunday + manual.

## Why
- Reduce PR cycle time while preserving fast signal from required debug builds.
- Keep heavier security and release-oriented checks running regularly without blocking day-to-day PR flow.

## Validation
- Workflow YAML validation passed in pre-commit hooks.
- No diagnostics errors in updated workflow files.
- Confirmed release/tag automation remains intact:
  - release workflow still triggers on semver tag push.
  - changelog workflow still triggers on semver tag push.
  - release workflow does not depend on CI job names changed in this PR.

## Follow-up already completed outside this PR
- Main branch ruleset required checks were updated to the new debug contexts only:
  - build-linux-debug / Build & Test (ubuntu-24.04 debug)
  - build-windows-debug / Build & Test (windows-latest debug)
