### PR TITLE
fix(logging): suppress info/debug log output in release builds

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,6 +133,11 @@ auto runApp() -> int
 #ifndef NDEBUG
     spdlog::set_level(spdlog::level::debug);
     spdlog::flush_on(spdlog::level::debug);
+#else
+    // Suppress info/debug log output in release builds. The compile-time
+    // SPDLOG_ACTIVE_LEVEL guard only silences the SPDLOG_* macros; direct
+    // spdlog::info() calls are always compiled in and respect the runtime level.
+    spdlog::set_level(spdlog::level::warn);
 #endif
 
     spdlog::info("{} v{} ({} build)", tasksmack::Version::PROJECT_NAME, tasksmack::Version::STRING, tasksmack::Version::BUILD_TYPE);


### PR DESCRIPTION
## Problem

`spdlog::info()` calls were appearing in optimized/release binaries (e.g. `[info] TaskSmack v0.7.1 (Release build)`, `[info] Loaded config from ...`).

## Root Cause

The existing `SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_WARN` compile definition (set in `CMakeLists.txt` for `Release` configs) only silences the `SPDLOG_INFO()`/`SPDLOG_DEBUG()` macro family at compile time. The codebase uses `spdlog::info()` / `spdlog::debug()` direct function calls, which are always compiled in and respect only the **runtime** log level — which defaults to `info` on all builds.

## Fix

Add an `#else` branch to the existing `#ifndef NDEBUG` block in `main.cpp` (where the logger is configured, before the first log call) to call `spdlog::set_level(spdlog::level::warn)` in all `Release`/`Optimized` builds. This runs before any `spdlog::info()` calls, so no info/debug output appears in production binaries.

```cpp
#ifndef NDEBUG
    spdlog::set_level(spdlog::level::debug);
    spdlog::flush_on(spdlog::level::debug);
#else
    // Suppress info/debug log output in release builds. The compile-time
    // SPDLOG_ACTIVE_LEVEL guard only silences the SPDLOG_* macros; direct
    // spdlog::info() calls are always compiled in and respect the runtime level.
    spdlog::set_level(spdlog::level::warn);
#endif
```

## Testing

- Optimized binary: `timeout 4 ./build/optimized/bin/TaskSmack | grep '\[info\]'` → no output
- 1178/1178 debug tests pass

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have run `clang-format` on my changes
- [x] I have run `pre-commit run --all-files`
- [x] All new and existing tests pass
