### PR TITLE
Fix live redraw during custom window move/resize + add border and resize cursors

### DIFF
--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -491,29 +491,23 @@ void TitleBarLayer::beginWindowInteraction(const SDL_Event& event)
     {
         if (isMaximized)
         {
-            // Restore the window before starting the drag so the title bar can be
-            // dragged out of the maximized state (mirrors native caption behavior).
-            // Reposition so the cursor stays at the same horizontal proportion in
-            // the restored title bar as it was in the maximized window.
+            // Don't restore yet — defer restore until the pointer has actually moved
+            // past the drag threshold so a bare click doesn't unmaximize the window.
             const auto [maxX, maxY] = window.getPosition();
-            const float xProportion = (static_cast<float>(globalMouseX) - static_cast<float>(maxX)) / static_cast<float>(windowWidth);
-            window.restore();
-            const auto [restoredX, restoredY] = window.getPosition();
-            const auto [restoredWidth, restoredHeight] = window.getSize();
-            // Place the window so the cursor is at the proportionally same spot.
-            const int adjustedX = globalMouseX - static_cast<int>(xProportion * static_cast<float>(restoredWidth));
-            window.setPosition(adjustedX, restoredY);
+            m_PendingDragRestore = true;
+            m_MaximizedWindowX = maxX;
+            m_MaximizedWindowWidth = windowWidth;
             m_CustomDragActive = true;
             m_DragStartMouseGlobalX = globalMouseX;
             m_DragStartMouseGlobalY = globalMouseY;
-            m_DragStartWindowX = adjustedX;
-            m_DragStartWindowY = restoredY;
-            m_LastAppliedWindowX = adjustedX;
-            m_LastAppliedWindowY = restoredY;
+            // Placeholder positions replaced once restore actually happens.
+            m_DragStartWindowX = maxX;
+            m_DragStartWindowY = maxY;
+            m_LastAppliedWindowX = maxX;
+            m_LastAppliedWindowY = maxY;
             m_CustomResizeActive = false;
             m_ActiveResizeEdge = ResizeEdge::None;
-            // Silence unused variable warning when restoredHeight is unreferenced.
-            (void) restoredHeight;
+            (void) maxY;
         }
         else
         {
@@ -555,6 +549,34 @@ void TitleBarLayer::updateWindowInteraction()
     {
         const int dx = globalMouseX - m_DragStartMouseGlobalX;
         const int dy = globalMouseY - m_DragStartMouseGlobalY;
+
+        if (m_PendingDragRestore)
+        {
+            // Defer restore until mouse has moved at least DRAG_THRESHOLD pixels in
+            // any direction so a bare click on the title bar does not unmaximize.
+            constexpr int DRAG_THRESHOLD = 5;
+            if (dx > -DRAG_THRESHOLD && dx < DRAG_THRESHOLD && dy > -DRAG_THRESHOLD && dy < DRAG_THRESHOLD)
+            {
+                return;
+            }
+            // Threshold crossed — restore and rebase the drag origin.
+            const float xProportion =
+                static_cast<float>(m_DragStartMouseGlobalX - m_MaximizedWindowX) / static_cast<float>(m_MaximizedWindowWidth);
+            window.restore();
+            const auto [restoredX, restoredY] = window.getPosition();
+            const auto [restoredWidth, restoredHeight] = window.getSize();
+            const int adjustedX = m_DragStartMouseGlobalX - static_cast<int>(xProportion * static_cast<float>(restoredWidth));
+            window.setPosition(adjustedX, restoredY);
+            m_DragStartWindowX = adjustedX;
+            m_DragStartWindowY = restoredY;
+            m_LastAppliedWindowX = adjustedX;
+            m_LastAppliedWindowY = restoredY;
+            m_PendingDragRestore = false;
+            (void) restoredX;
+            (void) restoredHeight;
+            return;
+        }
+
         const int targetX = m_DragStartWindowX + dx;
         const int targetY = m_DragStartWindowY + dy;
         if (targetX != m_LastAppliedWindowX || targetY != m_LastAppliedWindowY)
@@ -693,6 +715,7 @@ void TitleBarLayer::endWindowInteraction()
     m_CustomDragActive = false;
     m_CustomResizeActive = false;
     m_ActiveResizeEdge = ResizeEdge::None;
+    m_PendingDragRestore = false;
     m_HasCursorSample = false;
 }
 
@@ -847,7 +870,6 @@ void TitleBarLayer::updateResizeCursor()
     // must reapply on every call to keep the resize cursor visible while
     // hovering an edge.
     applyCursorForEdge(edge);
-    m_HoverResizeEdge = edge;
 }
 
 void TitleBarLayer::onRender()

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -485,6 +485,8 @@ void TitleBarLayer::updateWindowInteraction()
     {
         constexpr int MIN_WINDOW_WIDTH = Core::WINDOW_MIN_DIMENSION;
         constexpr int MIN_WINDOW_HEIGHT = Core::WINDOW_MIN_DIMENSION;
+        constexpr int MAX_WINDOW_WIDTH = Core::WINDOW_MAX_DIMENSION;
+        constexpr int MAX_WINDOW_HEIGHT = Core::WINDOW_MAX_DIMENSION;
 
         const int dx = globalMouseX - m_ResizeStartMouseGlobalX;
         const int dy = globalMouseY - m_ResizeStartMouseGlobalY;
@@ -544,6 +546,11 @@ void TitleBarLayer::updateWindowInteraction()
             newWidth = MIN_WINDOW_WIDTH;
         }
 
+        if (newWidth > MAX_WINDOW_WIDTH)
+        {
+            newWidth = MAX_WINDOW_WIDTH;
+        }
+
         if (newHeight < MIN_WINDOW_HEIGHT)
         {
             if (m_ActiveResizeEdge == ResizeEdge::Top || m_ActiveResizeEdge == ResizeEdge::TopLeft ||
@@ -552,6 +559,11 @@ void TitleBarLayer::updateWindowInteraction()
                 newY = m_ResizeStartWindowY + (m_ResizeStartWindowHeight - MIN_WINDOW_HEIGHT);
             }
             newHeight = MIN_WINDOW_HEIGHT;
+        }
+
+        if (newHeight > MAX_WINDOW_HEIGHT)
+        {
+            newHeight = MAX_WINDOW_HEIGHT;
         }
 
         const bool positionChanged = (newX != m_LastAppliedWindowX) || (newY != m_LastAppliedWindowY);
@@ -706,10 +718,14 @@ void TitleBarLayer::updateResizeCursor()
         if (insideWindow)
         {
             edge = detectResizeEdge(localX, localY, windowWidth, windowHeight, isMaximized);
+#ifdef _WIN32
+            // On Windows the custom resize path owns all resizing; suppress the
+            // cursor over title-bar controls to match the hit-test exemptions.
             if (edge != ResizeEdge::None && isPointInControlArea(localX, localY))
             {
                 edge = ResizeEdge::None;
             }
+#endif
         }
     }
 

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -317,7 +317,17 @@ void TitleBarLayer::onSDLEvent(SDL_Event* event)
 #ifdef _WIN32
     if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN && event->button.button == SDL_BUTTON_LEFT)
     {
-        beginWindowInteraction(*event);
+        if (event->button.clicks == 2)
+        {
+            // Double-click on the title bar: cancel any drag started by the first
+            // click and toggle maximize / restore (mirrors OS caption double-click).
+            endWindowInteraction();
+            handleTitleBarDoubleClick(*event);
+        }
+        else
+        {
+            beginWindowInteraction(*event);
+        }
     }
     else if ((event->type == SDL_EVENT_MOUSE_BUTTON_UP && event->button.button == SDL_BUTTON_LEFT) ||
              event->type == SDL_EVENT_WINDOW_FOCUS_LOST)
@@ -380,6 +390,51 @@ auto TitleBarLayer::detectResizeEdge(float x, float y, int windowWidth, int wind
     return ResizeEdge::None;
 }
 
+void TitleBarLayer::handleTitleBarDoubleClick(const SDL_Event& event)
+{
+    auto& window = Core::Application::get().getWindow();
+    SDL_Window* sdlWindow = window.getHandle();
+    if (sdlWindow == nullptr)
+    {
+        return;
+    }
+
+    const SDL_WindowID thisWindowId = SDL_GetWindowID(sdlWindow);
+    if (event.button.windowID != thisWindowId)
+    {
+        return;
+    }
+
+    const float mouseX = event.button.x;
+    const float mouseY = event.button.y;
+
+    // Only act on double-clicks in the title bar, not on a control or resize edge.
+    if (isPointInControlArea(mouseX, mouseY))
+    {
+        return;
+    }
+    if (mouseY > height())
+    {
+        return;
+    }
+    const auto [windowWidth, windowHeight] = window.getSize();
+    const bool isMaximized = window.isMaximized();
+    if (detectResizeEdge(mouseX, mouseY, windowWidth, windowHeight, isMaximized) != ResizeEdge::None)
+    {
+        return;
+    }
+
+    // Toggle maximize / restore.
+    if (isMaximized)
+    {
+        window.restore();
+    }
+    else
+    {
+        window.maximize();
+    }
+}
+
 void TitleBarLayer::beginWindowInteraction(const SDL_Event& event)
 {
     auto& window = Core::Application::get().getWindow();
@@ -431,18 +486,47 @@ void TitleBarLayer::beginWindowInteraction(const SDL_Event& event)
         return;
     }
 
-    if (!isMaximized && mouseY <= height())
+    if (mouseY <= height())
     {
-        const auto [startX, startY] = window.getPosition();
-        m_CustomDragActive = true;
-        m_DragStartMouseGlobalX = globalMouseX;
-        m_DragStartMouseGlobalY = globalMouseY;
-        m_DragStartWindowX = startX;
-        m_DragStartWindowY = startY;
-        m_LastAppliedWindowX = startX;
-        m_LastAppliedWindowY = startY;
-        m_CustomResizeActive = false;
-        m_ActiveResizeEdge = ResizeEdge::None;
+        if (isMaximized)
+        {
+            // Restore the window before starting the drag so the title bar can be
+            // dragged out of the maximized state (mirrors native caption behavior).
+            // Reposition so the cursor stays at the same horizontal proportion in
+            // the restored title bar as it was in the maximized window.
+            const auto [maxX, maxY] = window.getPosition();
+            const float xProportion = (static_cast<float>(globalMouseX) - static_cast<float>(maxX)) / static_cast<float>(windowWidth);
+            window.restore();
+            const auto [restoredX, restoredY] = window.getPosition();
+            const auto [restoredWidth, restoredHeight] = window.getSize();
+            // Place the window so the cursor is at the proportionally same spot.
+            const int adjustedX = globalMouseX - static_cast<int>(xProportion * static_cast<float>(restoredWidth));
+            window.setPosition(adjustedX, restoredY);
+            m_CustomDragActive = true;
+            m_DragStartMouseGlobalX = globalMouseX;
+            m_DragStartMouseGlobalY = globalMouseY;
+            m_DragStartWindowX = adjustedX;
+            m_DragStartWindowY = restoredY;
+            m_LastAppliedWindowX = adjustedX;
+            m_LastAppliedWindowY = restoredY;
+            m_CustomResizeActive = false;
+            m_ActiveResizeEdge = ResizeEdge::None;
+            // Silence unused variable warning when restoredHeight is unreferenced.
+            (void) restoredHeight;
+        }
+        else
+        {
+            const auto [startX, startY] = window.getPosition();
+            m_CustomDragActive = true;
+            m_DragStartMouseGlobalX = globalMouseX;
+            m_DragStartMouseGlobalY = globalMouseY;
+            m_DragStartWindowX = startX;
+            m_DragStartWindowY = startY;
+            m_LastAppliedWindowX = startX;
+            m_LastAppliedWindowY = startY;
+            m_CustomResizeActive = false;
+            m_ActiveResizeEdge = ResizeEdge::None;
+        }
     }
 }
 
@@ -548,6 +632,11 @@ void TitleBarLayer::updateWindowInteraction()
 
         if (newWidth > MAX_WINDOW_WIDTH)
         {
+            if (m_ActiveResizeEdge == ResizeEdge::Left || m_ActiveResizeEdge == ResizeEdge::TopLeft ||
+                m_ActiveResizeEdge == ResizeEdge::BottomLeft)
+            {
+                newX = m_ResizeStartWindowX + (m_ResizeStartWindowWidth - MAX_WINDOW_WIDTH);
+            }
             newWidth = MAX_WINDOW_WIDTH;
         }
 
@@ -563,6 +652,11 @@ void TitleBarLayer::updateWindowInteraction()
 
         if (newHeight > MAX_WINDOW_HEIGHT)
         {
+            if (m_ActiveResizeEdge == ResizeEdge::Top || m_ActiveResizeEdge == ResizeEdge::TopLeft ||
+                m_ActiveResizeEdge == ResizeEdge::TopRight)
+            {
+                newY = m_ResizeStartWindowY + (m_ResizeStartWindowHeight - MAX_WINDOW_HEIGHT);
+            }
             newHeight = MAX_WINDOW_HEIGHT;
         }
 

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -50,101 +50,12 @@ bool isInsideBounds(float x, float y, const TitleBarLayer::ButtonBounds& bounds)
 // Hit test callback for SDL - determines if a point is draggable
 SDL_HitTestResult hitTestCallback(SDL_Window* sdlWindow, const SDL_Point* area, void* data)
 {
-    auto* layer = static_cast<TitleBarLayer*>(data);
-    if (layer == nullptr || area == nullptr)
-    {
-        return SDL_HITTEST_NORMAL;
-    }
-
-    // SDL hit test coordinates are in LOGICAL (window) coordinates
-    // ImGui also uses logical coordinates for positioning (SDL backend handles DPI)
-    // Button bounds from renderTitleBar() are in logical coordinates
-    // So we use coordinates WITHOUT scaling
-    const auto x = static_cast<float>(area->x);
-    const auto y = static_cast<float>(area->y);
-
-    // Title bar height is in logical coordinates
-    const float titleBarHeight = TitleBarLayer::height();
-
-    // Get window size in LOGICAL coordinates for consistency
-    int windowWidth = 0;
-    int windowHeight = 0;
-    if (!SDL_GetWindowSize(sdlWindow, &windowWidth, &windowHeight))
-    {
-        spdlog::error("SDL_GetWindowSize failed in hitTestCallback: {}", SDL_GetError());
-        return SDL_HITTEST_NORMAL;
-    }
-
-    // Check if window is maximized - no resize borders when maximized
-    const bool isMaximized = ((SDL_GetWindowFlags(sdlWindow) & SDL_WINDOW_MAXIMIZED) != 0);
-
-    // Check window resize edges first (8px border in logical coordinates)
-    // Skip resize edge detection when maximized
-    constexpr float resizeBorder = 8.0F;
-
-    if (!isMaximized)
-    {
-        // Bottom corners and edges
-        if (y >= static_cast<float>(windowHeight) - resizeBorder)
-        {
-            if (x < resizeBorder)
-            {
-                return SDL_HITTEST_RESIZE_BOTTOMLEFT;
-            }
-            if (x >= static_cast<float>(windowWidth) - resizeBorder)
-            {
-                return SDL_HITTEST_RESIZE_BOTTOMRIGHT;
-            }
-            return SDL_HITTEST_RESIZE_BOTTOM;
-        }
-
-        // Side edges
-        if (x < resizeBorder)
-        {
-            if (y < resizeBorder)
-            {
-                return SDL_HITTEST_RESIZE_TOPLEFT;
-            }
-            return SDL_HITTEST_RESIZE_LEFT;
-        }
-        if (x >= static_cast<float>(windowWidth) - resizeBorder)
-        {
-            if (y < resizeBorder)
-            {
-                return SDL_HITTEST_RESIZE_TOPRIGHT;
-            }
-            return SDL_HITTEST_RESIZE_RIGHT;
-        }
-
-        // Top edge (but only if not in button area)
-        if (y < resizeBorder)
-        {
-            // Don't resize if clicking in the button area on the right
-            const auto& helpBounds = layer->getHelpBounds();
-            if (helpBounds.maxX > helpBounds.minX && x >= helpBounds.minX)
-            {
-                return SDL_HITTEST_NORMAL; // Let ImGui handle buttons
-            }
-            return SDL_HITTEST_RESIZE_TOP;
-        }
-    }
-
-    // Not in title bar area - let ImGui handle it normally
-    if (y > titleBarHeight)
-    {
-        return SDL_HITTEST_NORMAL;
-    }
-
-    // In title bar area - check if on any button or the icon
-    if (isInsideBounds(x, y, layer->getIconBounds()) || isInsideBounds(x, y, layer->getHelpBounds()) ||
-        isInsideBounds(x, y, layer->getSettingsBounds()) || isInsideBounds(x, y, layer->getMinimizeBounds()) ||
-        isInsideBounds(x, y, layer->getMaximizeBounds()) || isInsideBounds(x, y, layer->getCloseBounds()))
-    {
-        return SDL_HITTEST_NORMAL; // Let ImGui handle button/icon clicks
-    }
-
-    // In title bar but not on a button - this area is draggable
-    return SDL_HITTEST_DRAGGABLE;
+    (void) sdlWindow;
+    (void) area;
+    (void) data;
+    // Always return NORMAL so SDL does not enter native modal move/resize loops
+    // that pause rendering. Drag/resize is handled in TitleBarLayer::onSDLEvent.
+    return SDL_HITTEST_NORMAL;
 }
 
 } // namespace
@@ -236,6 +147,7 @@ void TitleBarLayer::onAttach()
 
     // Set up hit test for window dragging
     setupHitTest();
+    createSystemCursors();
 }
 
 void TitleBarLayer::onDetach()
@@ -248,13 +160,16 @@ void TitleBarLayer::onDetach()
         m_IconTexture = 0;
     }
 
+    destroySystemCursors();
+
     // Remove hit test callback
     Core::Application::get().getWindow().setHitTestCallback(nullptr, nullptr);
 }
 
 void TitleBarLayer::onUpdate([[maybe_unused]] float deltaTime)
 {
-    // No update logic needed
+    updateWindowInteraction();
+    updateResizeCursor();
 }
 
 void TitleBarLayer::onSDLEvent(SDL_Event* event)
@@ -309,6 +224,396 @@ void TitleBarLayer::onSDLEvent(SDL_Event* event)
             m_ShowSystemMenu = true;
         }
     }
+
+    if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN && event->button.button == SDL_BUTTON_LEFT)
+    {
+        beginWindowInteraction(*event);
+    }
+    else if ((event->type == SDL_EVENT_MOUSE_BUTTON_UP && event->button.button == SDL_BUTTON_LEFT) ||
+             event->type == SDL_EVENT_WINDOW_FOCUS_LOST)
+    {
+        endWindowInteraction();
+    }
+}
+
+auto TitleBarLayer::isPointInControlArea(float x, float y) const -> bool
+{
+    return isInsideBounds(x, y, m_IconBounds) || isInsideBounds(x, y, m_HelpBounds) || isInsideBounds(x, y, m_SettingsBounds) ||
+           isInsideBounds(x, y, m_MinimizeBounds) || isInsideBounds(x, y, m_MaximizeBounds) || isInsideBounds(x, y, m_CloseBounds);
+}
+
+auto TitleBarLayer::detectResizeEdge(float x, float y, int windowWidth, int windowHeight, bool isMaximized) -> ResizeEdge
+{
+    if (isMaximized)
+    {
+        return ResizeEdge::None;
+    }
+
+    constexpr float RESIZE_BORDER = 8.0F;
+    const bool nearLeft = x < RESIZE_BORDER;
+    const bool nearRight = x >= (static_cast<float>(windowWidth) - RESIZE_BORDER);
+    const bool nearTop = y < RESIZE_BORDER;
+    const bool nearBottom = y >= (static_cast<float>(windowHeight) - RESIZE_BORDER);
+
+    if (nearTop && nearLeft)
+    {
+        return ResizeEdge::TopLeft;
+    }
+    if (nearTop && nearRight)
+    {
+        return ResizeEdge::TopRight;
+    }
+    if (nearBottom && nearLeft)
+    {
+        return ResizeEdge::BottomLeft;
+    }
+    if (nearBottom && nearRight)
+    {
+        return ResizeEdge::BottomRight;
+    }
+    if (nearLeft)
+    {
+        return ResizeEdge::Left;
+    }
+    if (nearRight)
+    {
+        return ResizeEdge::Right;
+    }
+    if (nearTop)
+    {
+        return ResizeEdge::Top;
+    }
+    if (nearBottom)
+    {
+        return ResizeEdge::Bottom;
+    }
+    return ResizeEdge::None;
+}
+
+void TitleBarLayer::beginWindowInteraction(const SDL_Event& event)
+{
+    auto& window = Core::Application::get().getWindow();
+    SDL_Window* sdlWindow = window.getHandle();
+    if (sdlWindow == nullptr)
+    {
+        return;
+    }
+
+    const SDL_WindowID thisWindowId = SDL_GetWindowID(sdlWindow);
+    if (event.button.windowID != thisWindowId)
+    {
+        return;
+    }
+
+    const float mouseX = event.button.x;
+    const float mouseY = event.button.y;
+    const auto [windowWidth, windowHeight] = window.getSize();
+    const bool isMaximized = window.isMaximized();
+
+    if (isPointInControlArea(mouseX, mouseY))
+    {
+        return;
+    }
+
+    const ResizeEdge edge = detectResizeEdge(mouseX, mouseY, windowWidth, windowHeight, isMaximized);
+    float globalMouseXF = 0.0F;
+    float globalMouseYF = 0.0F;
+    SDL_GetGlobalMouseState(&globalMouseXF, &globalMouseYF);
+    const int globalMouseX = static_cast<int>(globalMouseXF);
+    const int globalMouseY = static_cast<int>(globalMouseYF);
+
+    if (edge != ResizeEdge::None)
+    {
+        const auto [startX, startY] = window.getPosition();
+        m_CustomResizeActive = true;
+        m_ActiveResizeEdge = edge;
+        m_ResizeStartMouseGlobalX = globalMouseX;
+        m_ResizeStartMouseGlobalY = globalMouseY;
+        m_ResizeStartWindowX = startX;
+        m_ResizeStartWindowY = startY;
+        m_ResizeStartWindowWidth = windowWidth;
+        m_ResizeStartWindowHeight = windowHeight;
+        m_LastAppliedWindowX = startX;
+        m_LastAppliedWindowY = startY;
+        m_LastAppliedWindowWidth = windowWidth;
+        m_LastAppliedWindowHeight = windowHeight;
+        m_CustomDragActive = false;
+        return;
+    }
+
+    if (!isMaximized && mouseY <= height())
+    {
+        const auto [startX, startY] = window.getPosition();
+        m_CustomDragActive = true;
+        m_DragStartMouseGlobalX = globalMouseX;
+        m_DragStartMouseGlobalY = globalMouseY;
+        m_DragStartWindowX = startX;
+        m_DragStartWindowY = startY;
+        m_LastAppliedWindowX = startX;
+        m_LastAppliedWindowY = startY;
+        m_CustomResizeActive = false;
+        m_ActiveResizeEdge = ResizeEdge::None;
+    }
+}
+
+void TitleBarLayer::updateWindowInteraction()
+{
+    if (!m_CustomDragActive && !m_CustomResizeActive)
+    {
+        return;
+    }
+
+    float globalMouseXF = 0.0F;
+    float globalMouseYF = 0.0F;
+    const SDL_MouseButtonFlags mouseButtons = SDL_GetGlobalMouseState(&globalMouseXF, &globalMouseYF);
+    if ((mouseButtons & SDL_BUTTON_LMASK) == 0U)
+    {
+        endWindowInteraction();
+        return;
+    }
+
+    const int globalMouseX = static_cast<int>(globalMouseXF);
+    const int globalMouseY = static_cast<int>(globalMouseYF);
+    auto& window = Core::Application::get().getWindow();
+
+    if (m_CustomDragActive)
+    {
+        const int dx = globalMouseX - m_DragStartMouseGlobalX;
+        const int dy = globalMouseY - m_DragStartMouseGlobalY;
+        const int targetX = m_DragStartWindowX + dx;
+        const int targetY = m_DragStartWindowY + dy;
+        if (targetX != m_LastAppliedWindowX || targetY != m_LastAppliedWindowY)
+        {
+            window.setPosition(targetX, targetY);
+            m_LastAppliedWindowX = targetX;
+            m_LastAppliedWindowY = targetY;
+        }
+        return;
+    }
+
+    if (m_CustomResizeActive)
+    {
+        constexpr int MIN_WINDOW_WIDTH = 320;
+        constexpr int MIN_WINDOW_HEIGHT = 240;
+
+        const int dx = globalMouseX - m_ResizeStartMouseGlobalX;
+        const int dy = globalMouseY - m_ResizeStartMouseGlobalY;
+
+        int newX = m_ResizeStartWindowX;
+        int newY = m_ResizeStartWindowY;
+        int newWidth = m_ResizeStartWindowWidth;
+        int newHeight = m_ResizeStartWindowHeight;
+
+        switch (m_ActiveResizeEdge)
+        {
+        case ResizeEdge::Left:
+            newX = m_ResizeStartWindowX + dx;
+            newWidth = m_ResizeStartWindowWidth - dx;
+            break;
+        case ResizeEdge::Right:
+            newWidth = m_ResizeStartWindowWidth + dx;
+            break;
+        case ResizeEdge::Top:
+            newY = m_ResizeStartWindowY + dy;
+            newHeight = m_ResizeStartWindowHeight - dy;
+            break;
+        case ResizeEdge::Bottom:
+            newHeight = m_ResizeStartWindowHeight + dy;
+            break;
+        case ResizeEdge::TopLeft:
+            newX = m_ResizeStartWindowX + dx;
+            newWidth = m_ResizeStartWindowWidth - dx;
+            newY = m_ResizeStartWindowY + dy;
+            newHeight = m_ResizeStartWindowHeight - dy;
+            break;
+        case ResizeEdge::TopRight:
+            newWidth = m_ResizeStartWindowWidth + dx;
+            newY = m_ResizeStartWindowY + dy;
+            newHeight = m_ResizeStartWindowHeight - dy;
+            break;
+        case ResizeEdge::BottomLeft:
+            newX = m_ResizeStartWindowX + dx;
+            newWidth = m_ResizeStartWindowWidth - dx;
+            newHeight = m_ResizeStartWindowHeight + dy;
+            break;
+        case ResizeEdge::BottomRight:
+            newWidth = m_ResizeStartWindowWidth + dx;
+            newHeight = m_ResizeStartWindowHeight + dy;
+            break;
+        case ResizeEdge::None:
+            break;
+        }
+
+        if (newWidth < MIN_WINDOW_WIDTH)
+        {
+            if (m_ActiveResizeEdge == ResizeEdge::Left || m_ActiveResizeEdge == ResizeEdge::TopLeft ||
+                m_ActiveResizeEdge == ResizeEdge::BottomLeft)
+            {
+                newX = m_ResizeStartWindowX + (m_ResizeStartWindowWidth - MIN_WINDOW_WIDTH);
+            }
+            newWidth = MIN_WINDOW_WIDTH;
+        }
+
+        if (newHeight < MIN_WINDOW_HEIGHT)
+        {
+            if (m_ActiveResizeEdge == ResizeEdge::Top || m_ActiveResizeEdge == ResizeEdge::TopLeft ||
+                m_ActiveResizeEdge == ResizeEdge::TopRight)
+            {
+                newY = m_ResizeStartWindowY + (m_ResizeStartWindowHeight - MIN_WINDOW_HEIGHT);
+            }
+            newHeight = MIN_WINDOW_HEIGHT;
+        }
+
+        const bool positionChanged = (newX != m_LastAppliedWindowX) || (newY != m_LastAppliedWindowY);
+        const bool sizeChanged = (newWidth != m_LastAppliedWindowWidth) || (newHeight != m_LastAppliedWindowHeight);
+
+        if (positionChanged)
+        {
+            window.setPosition(newX, newY);
+            m_LastAppliedWindowX = newX;
+            m_LastAppliedWindowY = newY;
+        }
+        if (sizeChanged)
+        {
+            SDL_SetWindowSize(window.getHandle(), newWidth, newHeight);
+            m_LastAppliedWindowWidth = newWidth;
+            m_LastAppliedWindowHeight = newHeight;
+        }
+    }
+}
+
+void TitleBarLayer::endWindowInteraction()
+{
+    m_CustomDragActive = false;
+    m_CustomResizeActive = false;
+    m_ActiveResizeEdge = ResizeEdge::None;
+}
+
+void TitleBarLayer::createSystemCursors()
+{
+    m_DefaultCursor = SDL_GetDefaultCursor();
+    m_NsResizeCursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NS_RESIZE);
+    m_EwResizeCursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_EW_RESIZE);
+    m_NeswResizeCursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NESW_RESIZE);
+    m_NwseResizeCursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NWSE_RESIZE);
+}
+
+void TitleBarLayer::destroySystemCursors()
+{
+    if (m_DefaultCursor != nullptr)
+    {
+        SDL_SetCursor(m_DefaultCursor);
+    }
+
+    if (m_NsResizeCursor != nullptr)
+    {
+        SDL_DestroyCursor(m_NsResizeCursor);
+        m_NsResizeCursor = nullptr;
+    }
+    if (m_EwResizeCursor != nullptr)
+    {
+        SDL_DestroyCursor(m_EwResizeCursor);
+        m_EwResizeCursor = nullptr;
+    }
+    if (m_NeswResizeCursor != nullptr)
+    {
+        SDL_DestroyCursor(m_NeswResizeCursor);
+        m_NeswResizeCursor = nullptr;
+    }
+    if (m_NwseResizeCursor != nullptr)
+    {
+        SDL_DestroyCursor(m_NwseResizeCursor);
+        m_NwseResizeCursor = nullptr;
+    }
+}
+
+void TitleBarLayer::applyCursorForEdge(const ResizeEdge edge)
+{
+    SDL_Cursor* cursor = m_DefaultCursor;
+
+    switch (edge)
+    {
+    case ResizeEdge::Top:
+    case ResizeEdge::Bottom:
+        cursor = m_NsResizeCursor;
+        break;
+    case ResizeEdge::Left:
+    case ResizeEdge::Right:
+        cursor = m_EwResizeCursor;
+        break;
+    case ResizeEdge::TopLeft:
+    case ResizeEdge::BottomRight:
+        cursor = m_NwseResizeCursor;
+        break;
+    case ResizeEdge::TopRight:
+    case ResizeEdge::BottomLeft:
+        cursor = m_NeswResizeCursor;
+        break;
+    case ResizeEdge::None:
+        cursor = m_DefaultCursor;
+        break;
+    }
+
+    if (cursor != nullptr)
+    {
+        SDL_SetCursor(cursor);
+    }
+}
+
+void TitleBarLayer::updateResizeCursor()
+{
+    auto& window = Core::Application::get().getWindow();
+    SDL_Window* sdlWindow = window.getHandle();
+    if (sdlWindow == nullptr)
+    {
+        return;
+    }
+
+    ResizeEdge edge = ResizeEdge::None;
+
+    if (m_CustomResizeActive)
+    {
+        edge = m_ActiveResizeEdge;
+    }
+    else
+    {
+        float globalMouseXF = 0.0F;
+        float globalMouseYF = 0.0F;
+        SDL_GetGlobalMouseState(&globalMouseXF, &globalMouseYF);
+        const int mouseGlobalX = static_cast<int>(globalMouseXF);
+        const int mouseGlobalY = static_cast<int>(globalMouseYF);
+
+        if (m_HasCursorSample && mouseGlobalX == m_LastCursorMouseGlobalX && mouseGlobalY == m_LastCursorMouseGlobalY)
+        {
+            return;
+        }
+
+        m_LastCursorMouseGlobalX = mouseGlobalX;
+        m_LastCursorMouseGlobalY = mouseGlobalY;
+        m_HasCursorSample = true;
+
+        const auto [windowX, windowY] = window.getPosition();
+        const auto [windowWidth, windowHeight] = window.getSize();
+        const float localX = globalMouseXF - static_cast<float>(windowX);
+        const float localY = globalMouseYF - static_cast<float>(windowY);
+
+        const bool insideWindow =
+            (localX >= 0.0F && localY >= 0.0F && localX < static_cast<float>(windowWidth) && localY < static_cast<float>(windowHeight));
+        if (insideWindow)
+        {
+            edge = detectResizeEdge(localX, localY, windowWidth, windowHeight, window.isMaximized());
+            if (edge != ResizeEdge::None && isPointInControlArea(localX, localY))
+            {
+                edge = ResizeEdge::None;
+            }
+        }
+    }
+
+    if (edge != m_HoverResizeEdge)
+    {
+        applyCursorForEdge(edge);
+        m_HoverResizeEdge = edge;
+    }
 }
 
 void TitleBarLayer::onRender()
@@ -325,7 +630,7 @@ void TitleBarLayer::renderTitleBar()
 {
     const auto& scheme = UI::Theme::get().scheme();
     auto& window = Core::Application::get().getWindow();
-    const auto [windowWidth, _] = window.getSize();
+    const auto [windowWidth, windowHeight] = window.getSize();
 
     const float titleBarHeight = height();
     // Set up window for title bar - no padding, no scrolling, fixed position
@@ -518,6 +823,19 @@ void TitleBarLayer::renderTitleBar()
     renderSystemMenu();
 
     ImGui::End();
+
+    if (!window.isMaximized())
+    {
+        constexpr float BORDER_THICKNESS = 1.0F;
+        ImDrawList* drawList = ImGui::GetForegroundDrawList();
+        drawList->AddRect(ImVec2(0.0F, 0.0F),
+                          ImVec2(static_cast<float>(windowWidth), static_cast<float>(windowHeight)),
+                          ImGui::ColorConvertFloat4ToU32(scheme.border),
+                          0.0F,
+                          ImDrawFlags_None,
+                          BORDER_THICKNESS);
+    }
+
     ImGui::PopStyleColor(); // WindowBg
     ImGui::PopStyleVar(2);  // WindowPadding, WindowBorderSize
 }

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -47,6 +47,9 @@ bool isInsideBounds(float x, float y, const TitleBarLayer::ButtonBounds& bounds)
     return x >= bounds.minX && x <= bounds.maxX && y >= bounds.minY && y <= bounds.maxY;
 }
 
+// Shared resize border thickness — must stay in sync between hit-test and cursor detection.
+constexpr float kResizeBorderThickness = 8.0F;
+
 // Hit-test callback behavior is platform dependent:
 // - Windows: force NORMAL and use client-side drag/resize to avoid modal move/size redraw stalls.
 // - Non-Windows: keep native draggable/resize hit-test behavior for compositor-friendly moves/resizes.
@@ -79,41 +82,39 @@ SDL_HitTestResult hitTestCallback(SDL_Window* sdlWindow, const SDL_Point* area, 
     }
 
     const bool isMaximized = ((SDL_GetWindowFlags(sdlWindow) & SDL_WINDOW_MAXIMIZED) != 0);
-    constexpr float resizeBorder = 8.0F;
-
     if (!isMaximized)
     {
-        if (y >= static_cast<float>(windowHeight) - resizeBorder)
+        if (y >= static_cast<float>(windowHeight) - kResizeBorderThickness)
         {
-            if (x < resizeBorder)
+            if (x < kResizeBorderThickness)
             {
                 return SDL_HITTEST_RESIZE_BOTTOMLEFT;
             }
-            if (x >= static_cast<float>(windowWidth) - resizeBorder)
+            if (x >= static_cast<float>(windowWidth) - kResizeBorderThickness)
             {
                 return SDL_HITTEST_RESIZE_BOTTOMRIGHT;
             }
             return SDL_HITTEST_RESIZE_BOTTOM;
         }
 
-        if (x < resizeBorder)
+        if (x < kResizeBorderThickness)
         {
-            if (y < resizeBorder)
+            if (y < kResizeBorderThickness)
             {
                 return SDL_HITTEST_RESIZE_TOPLEFT;
             }
             return SDL_HITTEST_RESIZE_LEFT;
         }
-        if (x >= static_cast<float>(windowWidth) - resizeBorder)
+        if (x >= static_cast<float>(windowWidth) - kResizeBorderThickness)
         {
-            if (y < resizeBorder)
+            if (y < kResizeBorderThickness)
             {
                 return SDL_HITTEST_RESIZE_TOPRIGHT;
             }
             return SDL_HITTEST_RESIZE_RIGHT;
         }
 
-        if (y < resizeBorder)
+        if (y < kResizeBorderThickness)
         {
             const auto& helpBounds = layer->getHelpBounds();
             if (helpBounds.maxX > helpBounds.minX && x >= helpBounds.minX)
@@ -253,6 +254,10 @@ void TitleBarLayer::onUpdate([[maybe_unused]] float deltaTime)
 #ifdef _WIN32
     updateWindowInteraction();
 #endif
+}
+
+void TitleBarLayer::onPostRender()
+{
     updateResizeCursor();
 }
 
@@ -335,11 +340,10 @@ auto TitleBarLayer::detectResizeEdge(float x, float y, int windowWidth, int wind
         return ResizeEdge::None;
     }
 
-    constexpr float RESIZE_BORDER = 8.0F;
-    const bool nearLeft = x < RESIZE_BORDER;
-    const bool nearRight = x >= (static_cast<float>(windowWidth) - RESIZE_BORDER);
-    const bool nearTop = y < RESIZE_BORDER;
-    const bool nearBottom = y >= (static_cast<float>(windowHeight) - RESIZE_BORDER);
+    const bool nearLeft = x < kResizeBorderThickness;
+    const bool nearRight = x >= (static_cast<float>(windowWidth) - kResizeBorderThickness);
+    const bool nearTop = y < kResizeBorderThickness;
+    const bool nearBottom = y >= (static_cast<float>(windowHeight) - kResizeBorderThickness);
 
     if (nearTop && nearLeft)
     {
@@ -479,8 +483,8 @@ void TitleBarLayer::updateWindowInteraction()
 
     if (m_CustomResizeActive)
     {
-        constexpr int MIN_WINDOW_WIDTH = 320;
-        constexpr int MIN_WINDOW_HEIGHT = 240;
+        constexpr int MIN_WINDOW_WIDTH = Core::WINDOW_MIN_DIMENSION;
+        constexpr int MIN_WINDOW_HEIGHT = Core::WINDOW_MIN_DIMENSION;
 
         const int dx = globalMouseX - m_ResizeStartMouseGlobalX;
         const int dy = globalMouseY - m_ResizeStartMouseGlobalY;
@@ -641,6 +645,10 @@ void TitleBarLayer::applyCursorForEdge(const ResizeEdge edge)
         break;
     }
 
+    if (cursor == nullptr)
+    {
+        cursor = m_DefaultCursor;
+    }
     if (cursor != nullptr)
     {
         SDL_SetCursor(cursor);

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -48,7 +48,7 @@ bool isInsideBounds(float x, float y, const TitleBarLayer::ButtonBounds& bounds)
 }
 
 // Shared resize border thickness — must stay in sync between hit-test and cursor detection.
-constexpr float kResizeBorderThickness = 8.0F;
+constexpr float RESIZE_BORDER_THICKNESS = 8.0F;
 
 // Hit-test callback behavior is platform dependent:
 // - Windows: force NORMAL and use client-side drag/resize to avoid modal move/size redraw stalls.
@@ -84,37 +84,37 @@ SDL_HitTestResult hitTestCallback(SDL_Window* sdlWindow, const SDL_Point* area, 
     const bool isMaximized = ((SDL_GetWindowFlags(sdlWindow) & SDL_WINDOW_MAXIMIZED) != 0);
     if (!isMaximized)
     {
-        if (y >= static_cast<float>(windowHeight) - kResizeBorderThickness)
+        if (y >= static_cast<float>(windowHeight) - RESIZE_BORDER_THICKNESS)
         {
-            if (x < kResizeBorderThickness)
+            if (x < RESIZE_BORDER_THICKNESS)
             {
                 return SDL_HITTEST_RESIZE_BOTTOMLEFT;
             }
-            if (x >= static_cast<float>(windowWidth) - kResizeBorderThickness)
+            if (x >= static_cast<float>(windowWidth) - RESIZE_BORDER_THICKNESS)
             {
                 return SDL_HITTEST_RESIZE_BOTTOMRIGHT;
             }
             return SDL_HITTEST_RESIZE_BOTTOM;
         }
 
-        if (x < kResizeBorderThickness)
+        if (x < RESIZE_BORDER_THICKNESS)
         {
-            if (y < kResizeBorderThickness)
+            if (y < RESIZE_BORDER_THICKNESS)
             {
                 return SDL_HITTEST_RESIZE_TOPLEFT;
             }
             return SDL_HITTEST_RESIZE_LEFT;
         }
-        if (x >= static_cast<float>(windowWidth) - kResizeBorderThickness)
+        if (x >= static_cast<float>(windowWidth) - RESIZE_BORDER_THICKNESS)
         {
-            if (y < kResizeBorderThickness)
+            if (y < RESIZE_BORDER_THICKNESS)
             {
                 return SDL_HITTEST_RESIZE_TOPRIGHT;
             }
             return SDL_HITTEST_RESIZE_RIGHT;
         }
 
-        if (y < kResizeBorderThickness)
+        if (y < RESIZE_BORDER_THICKNESS)
         {
             const auto& helpBounds = layer->getHelpBounds();
             if (helpBounds.maxX > helpBounds.minX && x >= helpBounds.minX)
@@ -350,10 +350,10 @@ auto TitleBarLayer::detectResizeEdge(float x, float y, int windowWidth, int wind
         return ResizeEdge::None;
     }
 
-    const bool nearLeft = x < kResizeBorderThickness;
-    const bool nearRight = x >= (static_cast<float>(windowWidth) - kResizeBorderThickness);
-    const bool nearTop = y < kResizeBorderThickness;
-    const bool nearBottom = y >= (static_cast<float>(windowHeight) - kResizeBorderThickness);
+    const bool nearLeft = x < RESIZE_BORDER_THICKNESS;
+    const bool nearRight = x >= (static_cast<float>(windowWidth) - RESIZE_BORDER_THICKNESS);
+    const bool nearTop = y < RESIZE_BORDER_THICKNESS;
+    const bool nearBottom = y >= (static_cast<float>(windowHeight) - RESIZE_BORDER_THICKNESS);
 
     if (nearTop && nearLeft)
     {

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -803,7 +803,10 @@ void TitleBarLayer::updateResizeCursor()
         return;
     }
 
-    ResizeEdge edge = ResizeEdge::None;
+    // Seed from the cache so the state-unchanged fast-path still reaches the
+    // cursor-apply step at the end (ImGui may reset the cursor each frame).
+    const ResizeEdge prevEdge = m_CachedHoverEdge;
+    ResizeEdge edge = m_CachedHoverEdge;
 
     if (m_CustomResizeActive)
     {
@@ -821,55 +824,65 @@ void TitleBarLayer::updateResizeCursor()
         const auto [windowWidth, windowHeight] = window.getSize();
         const bool isMaximized = window.isMaximized();
 
-        if (m_HasCursorSample && mouseGlobalX == m_LastCursorMouseGlobalX && mouseGlobalY == m_LastCursorMouseGlobalY &&
-            windowX == m_LastCursorWindowX && windowY == m_LastCursorWindowY && windowWidth == m_LastCursorWindowWidth &&
-            windowHeight == m_LastCursorWindowHeight && isMaximized == m_LastCursorWindowMaximized)
+        const bool stateUnchanged = m_HasCursorSample && mouseGlobalX == m_LastCursorMouseGlobalX &&
+                                    mouseGlobalY == m_LastCursorMouseGlobalY && windowX == m_LastCursorWindowX &&
+                                    windowY == m_LastCursorWindowY && windowWidth == m_LastCursorWindowWidth &&
+                                    windowHeight == m_LastCursorWindowHeight && isMaximized == m_LastCursorWindowMaximized;
+
+        if (!stateUnchanged)
         {
-            return;
-        }
+            m_LastCursorMouseGlobalX = mouseGlobalX;
+            m_LastCursorMouseGlobalY = mouseGlobalY;
+            m_LastCursorWindowX = windowX;
+            m_LastCursorWindowY = windowY;
+            m_LastCursorWindowWidth = windowWidth;
+            m_LastCursorWindowHeight = windowHeight;
+            m_LastCursorWindowMaximized = isMaximized;
+            m_HasCursorSample = true;
 
-        m_LastCursorMouseGlobalX = mouseGlobalX;
-        m_LastCursorMouseGlobalY = mouseGlobalY;
-        m_LastCursorWindowX = windowX;
-        m_LastCursorWindowY = windowY;
-        m_LastCursorWindowWidth = windowWidth;
-        m_LastCursorWindowHeight = windowHeight;
-        m_LastCursorWindowMaximized = isMaximized;
-        m_HasCursorSample = true;
+            const float localX = globalMouseXF - static_cast<float>(windowX);
+            const float localY = globalMouseYF - static_cast<float>(windowY);
 
-        const float localX = globalMouseXF - static_cast<float>(windowX);
-        const float localY = globalMouseYF - static_cast<float>(windowY);
-
-        const bool insideWindow =
-            (localX >= 0.0F && localY >= 0.0F && localX < static_cast<float>(windowWidth) && localY < static_cast<float>(windowHeight));
-        if (insideWindow)
-        {
-            edge = detectResizeEdge(localX, localY, windowWidth, windowHeight, isMaximized);
-            // Suppress the resize cursor over title-bar controls on all platforms:
-            // Windows routes these through the custom resize path, and on non-Windows
-            // the hit-test callback returns NORMAL for control areas, so the cursor
-            // must match the action regardless of platform.
-            if (edge != ResizeEdge::None && isPointInControlArea(localX, localY))
+            const bool insideWindow =
+                (localX >= 0.0F && localY >= 0.0F && localX < static_cast<float>(windowWidth) && localY < static_cast<float>(windowHeight));
+            edge = ResizeEdge::None;
+            if (insideWindow)
             {
-                edge = ResizeEdge::None;
-            }
+                edge = detectResizeEdge(localX, localY, windowWidth, windowHeight, isMaximized);
+                // Suppress the resize cursor over title-bar controls on all platforms:
+                // Windows routes these through the custom resize path, and on non-Windows
+                // the hit-test callback returns NORMAL for control areas, so the cursor
+                // must match the action regardless of platform.
+                if (edge != ResizeEdge::None && isPointInControlArea(localX, localY))
+                {
+                    edge = ResizeEdge::None;
+                }
 #ifndef _WIN32
-            // On non-Windows, hitTestCallback returns NORMAL for the top-edge
-            // band right of helpBounds.minX (so the WM doesn't intercept clicks
-            // on that region). Suppress the resize cursor there to match.
-            if (edge == ResizeEdge::Top && m_HelpBounds.maxX > m_HelpBounds.minX && localX >= m_HelpBounds.minX)
-            {
-                edge = ResizeEdge::None;
-            }
+                // On non-Windows, hitTestCallback returns NORMAL for the top-edge
+                // band right of helpBounds.minX (so the WM doesn't intercept clicks
+                // on that region). Suppress the resize cursor there to match.
+                if (edge == ResizeEdge::Top && m_HelpBounds.maxX > m_HelpBounds.minX && localX >= m_HelpBounds.minX)
+                {
+                    edge = ResizeEdge::None;
+                }
 #endif
+            }
+            m_CachedHoverEdge = edge;
         }
+        // State unchanged: edge == m_CachedHoverEdge, falls through to apply.
     }
 
-    // Always apply the cursor each frame: the SDL/ImGui backend
-    // (ImGui_ImplSDL3_NewFrame) may reset the cursor between frames, so we
-    // must reapply on every call to keep the resize cursor visible while
-    // hovering an edge.
-    applyCursorForEdge(edge);
+    // Set a resize cursor while on a border. Restore the default only when
+    // leaving one so ImGui-provided cursors (text inputs, splitters, etc.) are
+    // not overridden while the pointer is away from window borders.
+    if (edge != ResizeEdge::None)
+    {
+        applyCursorForEdge(edge);
+    }
+    else if (prevEdge != ResizeEdge::None)
+    {
+        applyCursorForEdge(ResizeEdge::None);
+    }
 }
 
 void TitleBarLayer::onRender()

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -3,6 +3,7 @@
 #include "Core/Application.h"
 #include "Core/ApplicationEvents.h"
 #include "Core/Layer.h"
+#include "Core/WindowEvents.h"
 #include "UI/AssetPath.h"
 #include "UI/IconsFontAwesome6.h"
 #include "UI/Theme.h"
@@ -674,6 +675,15 @@ void TitleBarLayer::updateWindowInteraction()
             SDL_SetWindowSize(window.getHandle(), newWidth, newHeight);
             m_LastAppliedWindowWidth = newWidth;
             m_LastAppliedWindowHeight = newHeight;
+            // Immediately raise a resize event so UILayer updates the GL viewport
+            // for this frame. Without this, the viewport lags one frame behind
+            // the window until SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED is processed
+            // in the next event-poll iteration.
+            int pixelW = 0;
+            int pixelH = 0;
+            SDL_GetWindowSizeInPixels(window.getHandle(), &pixelW, &pixelH);
+            Core::WindowResizedEvent resizeEvent(pixelW, pixelH);
+            Core::Application::get().raiseEvent(resizeEvent);
         }
     }
 }
@@ -820,14 +830,24 @@ void TitleBarLayer::updateResizeCursor()
             {
                 edge = ResizeEdge::None;
             }
+#ifndef _WIN32
+            // On non-Windows, hitTestCallback returns NORMAL for the top-edge
+            // band right of helpBounds.minX (so the WM doesn't intercept clicks
+            // on that region). Suppress the resize cursor there to match.
+            if (edge == ResizeEdge::Top && m_HelpBounds.maxX > m_HelpBounds.minX && localX >= m_HelpBounds.minX)
+            {
+                edge = ResizeEdge::None;
+            }
+#endif
         }
     }
 
-    if (edge != m_HoverResizeEdge)
-    {
-        applyCursorForEdge(edge);
-        m_HoverResizeEdge = edge;
-    }
+    // Always apply the cursor each frame: the SDL/ImGui backend
+    // (ImGui_ImplSDL3_NewFrame) may reset the cursor between frames, so we
+    // must reapply on every call to keep the resize cursor visible while
+    // hovering an edge.
+    applyCursorForEdge(edge);
+    m_HoverResizeEdge = edge;
 }
 
 void TitleBarLayer::onRender()

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -47,15 +47,97 @@ bool isInsideBounds(float x, float y, const TitleBarLayer::ButtonBounds& bounds)
     return x >= bounds.minX && x <= bounds.maxX && y >= bounds.minY && y <= bounds.maxY;
 }
 
-// Hit test callback for SDL - determines if a point is draggable
+// Hit-test callback behavior is platform dependent:
+// - Windows: force NORMAL and use client-side drag/resize to avoid modal move/size redraw stalls.
+// - Non-Windows: keep native draggable/resize hit-test behavior for compositor-friendly moves/resizes.
 SDL_HitTestResult hitTestCallback(SDL_Window* sdlWindow, const SDL_Point* area, void* data)
 {
+#ifdef _WIN32
     (void) sdlWindow;
     (void) area;
     (void) data;
     // Always return NORMAL so SDL does not enter native modal move/resize loops
     // that pause rendering. Drag/resize is handled in TitleBarLayer::onSDLEvent.
     return SDL_HITTEST_NORMAL;
+#else
+    auto* layer = static_cast<TitleBarLayer*>(data);
+    if (layer == nullptr || area == nullptr)
+    {
+        return SDL_HITTEST_NORMAL;
+    }
+
+    const float x = static_cast<float>(area->x);
+    const float y = static_cast<float>(area->y);
+    const float titleBarHeight = TitleBarLayer::height();
+
+    int windowWidth = 0;
+    int windowHeight = 0;
+    if (!SDL_GetWindowSize(sdlWindow, &windowWidth, &windowHeight))
+    {
+        spdlog::error("SDL_GetWindowSize failed in hitTestCallback: {}", SDL_GetError());
+        return SDL_HITTEST_NORMAL;
+    }
+
+    const bool isMaximized = ((SDL_GetWindowFlags(sdlWindow) & SDL_WINDOW_MAXIMIZED) != 0);
+    constexpr float resizeBorder = 8.0F;
+
+    if (!isMaximized)
+    {
+        if (y >= static_cast<float>(windowHeight) - resizeBorder)
+        {
+            if (x < resizeBorder)
+            {
+                return SDL_HITTEST_RESIZE_BOTTOMLEFT;
+            }
+            if (x >= static_cast<float>(windowWidth) - resizeBorder)
+            {
+                return SDL_HITTEST_RESIZE_BOTTOMRIGHT;
+            }
+            return SDL_HITTEST_RESIZE_BOTTOM;
+        }
+
+        if (x < resizeBorder)
+        {
+            if (y < resizeBorder)
+            {
+                return SDL_HITTEST_RESIZE_TOPLEFT;
+            }
+            return SDL_HITTEST_RESIZE_LEFT;
+        }
+        if (x >= static_cast<float>(windowWidth) - resizeBorder)
+        {
+            if (y < resizeBorder)
+            {
+                return SDL_HITTEST_RESIZE_TOPRIGHT;
+            }
+            return SDL_HITTEST_RESIZE_RIGHT;
+        }
+
+        if (y < resizeBorder)
+        {
+            const auto& helpBounds = layer->getHelpBounds();
+            if (helpBounds.maxX > helpBounds.minX && x >= helpBounds.minX)
+            {
+                return SDL_HITTEST_NORMAL;
+            }
+            return SDL_HITTEST_RESIZE_TOP;
+        }
+    }
+
+    if (y > titleBarHeight)
+    {
+        return SDL_HITTEST_NORMAL;
+    }
+
+    if (isInsideBounds(x, y, layer->getIconBounds()) || isInsideBounds(x, y, layer->getHelpBounds()) ||
+        isInsideBounds(x, y, layer->getSettingsBounds()) || isInsideBounds(x, y, layer->getMinimizeBounds()) ||
+        isInsideBounds(x, y, layer->getMaximizeBounds()) || isInsideBounds(x, y, layer->getCloseBounds()))
+    {
+        return SDL_HITTEST_NORMAL;
+    }
+
+    return SDL_HITTEST_DRAGGABLE;
+#endif
 }
 
 } // namespace
@@ -168,7 +250,9 @@ void TitleBarLayer::onDetach()
 
 void TitleBarLayer::onUpdate([[maybe_unused]] float deltaTime)
 {
+#ifdef _WIN32
     updateWindowInteraction();
+#endif
     updateResizeCursor();
 }
 
@@ -225,6 +309,7 @@ void TitleBarLayer::onSDLEvent(SDL_Event* event)
         }
     }
 
+#ifdef _WIN32
     if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN && event->button.button == SDL_BUTTON_LEFT)
     {
         beginWindowInteraction(*event);
@@ -234,6 +319,7 @@ void TitleBarLayer::onSDLEvent(SDL_Event* event)
     {
         endWindowInteraction();
     }
+#endif
 }
 
 auto TitleBarLayer::isPointInControlArea(float x, float y) const -> bool
@@ -487,6 +573,7 @@ void TitleBarLayer::endWindowInteraction()
     m_CustomDragActive = false;
     m_CustomResizeActive = false;
     m_ActiveResizeEdge = ResizeEdge::None;
+    m_HasCursorSample = false;
 }
 
 void TitleBarLayer::createSystemCursors()
@@ -583,17 +670,26 @@ void TitleBarLayer::updateResizeCursor()
         const int mouseGlobalX = static_cast<int>(globalMouseXF);
         const int mouseGlobalY = static_cast<int>(globalMouseYF);
 
-        if (m_HasCursorSample && mouseGlobalX == m_LastCursorMouseGlobalX && mouseGlobalY == m_LastCursorMouseGlobalY)
+        const auto [windowX, windowY] = window.getPosition();
+        const auto [windowWidth, windowHeight] = window.getSize();
+        const bool isMaximized = window.isMaximized();
+
+        if (m_HasCursorSample && mouseGlobalX == m_LastCursorMouseGlobalX && mouseGlobalY == m_LastCursorMouseGlobalY &&
+            windowX == m_LastCursorWindowX && windowY == m_LastCursorWindowY && windowWidth == m_LastCursorWindowWidth &&
+            windowHeight == m_LastCursorWindowHeight && isMaximized == m_LastCursorWindowMaximized)
         {
             return;
         }
 
         m_LastCursorMouseGlobalX = mouseGlobalX;
         m_LastCursorMouseGlobalY = mouseGlobalY;
+        m_LastCursorWindowX = windowX;
+        m_LastCursorWindowY = windowY;
+        m_LastCursorWindowWidth = windowWidth;
+        m_LastCursorWindowHeight = windowHeight;
+        m_LastCursorWindowMaximized = isMaximized;
         m_HasCursorSample = true;
 
-        const auto [windowX, windowY] = window.getPosition();
-        const auto [windowWidth, windowHeight] = window.getSize();
         const float localX = globalMouseXF - static_cast<float>(windowX);
         const float localY = globalMouseYF - static_cast<float>(windowY);
 
@@ -601,7 +697,7 @@ void TitleBarLayer::updateResizeCursor()
             (localX >= 0.0F && localY >= 0.0F && localX < static_cast<float>(windowWidth) && localY < static_cast<float>(windowHeight));
         if (insideWindow)
         {
-            edge = detectResizeEdge(localX, localY, windowWidth, windowHeight, window.isMaximized());
+            edge = detectResizeEdge(localX, localY, windowWidth, windowHeight, isMaximized);
             if (edge != ResizeEdge::None && isPointInControlArea(localX, localY))
             {
                 edge = ResizeEdge::None;

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -812,14 +812,14 @@ void TitleBarLayer::updateResizeCursor()
         if (insideWindow)
         {
             edge = detectResizeEdge(localX, localY, windowWidth, windowHeight, isMaximized);
-#ifdef _WIN32
-            // On Windows the custom resize path owns all resizing; suppress the
-            // cursor over title-bar controls to match the hit-test exemptions.
+            // Suppress the resize cursor over title-bar controls on all platforms:
+            // Windows routes these through the custom resize path, and on non-Windows
+            // the hit-test callback returns NORMAL for control areas, so the cursor
+            // must match the action regardless of platform.
             if (edge != ResizeEdge::None && isPointInControlArea(localX, localY))
             {
                 edge = ResizeEdge::None;
             }
-#endif
         }
     }
 

--- a/src/App/TitleBarLayer.h
+++ b/src/App/TitleBarLayer.h
@@ -86,6 +86,7 @@ class TitleBarLayer : public Core::Layer
     };
 
     void beginWindowInteraction(const SDL_Event& event);
+    void handleTitleBarDoubleClick(const SDL_Event& event);
     void updateWindowInteraction();
     void endWindowInteraction();
 

--- a/src/App/TitleBarLayer.h
+++ b/src/App/TitleBarLayer.h
@@ -31,6 +31,7 @@ class TitleBarLayer : public Core::Layer
     void onDetach() override;
     void onUpdate(float deltaTime) override;
     void onRender() override;
+    void onPostRender() override;
     void onSDLEvent(SDL_Event* event) override;
 
     /// Get the title bar height (for content offset) - matches ImGui tab bar height

--- a/src/App/TitleBarLayer.h
+++ b/src/App/TitleBarLayer.h
@@ -2,6 +2,10 @@
 
 #include "Core/Layer.h"
 
+#include <cstdint>
+
+struct SDL_Cursor;
+
 namespace App
 {
 
@@ -67,6 +71,31 @@ class TitleBarLayer : public Core::Layer
     }
 
   private:
+    enum class ResizeEdge : std::uint8_t
+    {
+        None,
+        Left,
+        Right,
+        Top,
+        Bottom,
+        TopLeft,
+        TopRight,
+        BottomLeft,
+        BottomRight,
+    };
+
+    void beginWindowInteraction(const SDL_Event& event);
+    void updateWindowInteraction();
+    void endWindowInteraction();
+
+    void createSystemCursors();
+    void destroySystemCursors();
+    void updateResizeCursor();
+    void applyCursorForEdge(ResizeEdge edge);
+
+    [[nodiscard]] static auto detectResizeEdge(float x, float y, int windowWidth, int windowHeight, bool isMaximized) -> ResizeEdge;
+    [[nodiscard]] auto isPointInControlArea(float x, float y) const -> bool;
+
     void renderTitleBar();
     void renderSystemMenu();
     void setupHitTest();
@@ -86,6 +115,38 @@ class TitleBarLayer : public Core::Layer
     ButtonBounds m_MaximizeBounds{};
     ButtonBounds m_CloseBounds{};
     ButtonBounds m_IconBounds{};
+
+    bool m_CustomDragActive = false;
+    bool m_CustomResizeActive = false;
+    ResizeEdge m_ActiveResizeEdge = ResizeEdge::None;
+
+    int m_DragStartMouseGlobalX = 0;
+    int m_DragStartMouseGlobalY = 0;
+    int m_DragStartWindowX = 0;
+    int m_DragStartWindowY = 0;
+
+    int m_ResizeStartMouseGlobalX = 0;
+    int m_ResizeStartMouseGlobalY = 0;
+    int m_ResizeStartWindowX = 0;
+    int m_ResizeStartWindowY = 0;
+    int m_ResizeStartWindowWidth = 0;
+    int m_ResizeStartWindowHeight = 0;
+
+    int m_LastAppliedWindowX = 0;
+    int m_LastAppliedWindowY = 0;
+    int m_LastAppliedWindowWidth = 0;
+    int m_LastAppliedWindowHeight = 0;
+
+    ResizeEdge m_HoverResizeEdge = ResizeEdge::None;
+    int m_LastCursorMouseGlobalX = 0;
+    int m_LastCursorMouseGlobalY = 0;
+    bool m_HasCursorSample = false;
+
+    SDL_Cursor* m_DefaultCursor = nullptr;
+    SDL_Cursor* m_NsResizeCursor = nullptr;
+    SDL_Cursor* m_EwResizeCursor = nullptr;
+    SDL_Cursor* m_NeswResizeCursor = nullptr;
+    SDL_Cursor* m_NwseResizeCursor = nullptr;
 };
 
 } // namespace App

--- a/src/App/TitleBarLayer.h
+++ b/src/App/TitleBarLayer.h
@@ -140,6 +140,11 @@ class TitleBarLayer : public Core::Layer
     ResizeEdge m_HoverResizeEdge = ResizeEdge::None;
     int m_LastCursorMouseGlobalX = 0;
     int m_LastCursorMouseGlobalY = 0;
+    int m_LastCursorWindowX = 0;
+    int m_LastCursorWindowY = 0;
+    int m_LastCursorWindowWidth = 0;
+    int m_LastCursorWindowHeight = 0;
+    bool m_LastCursorWindowMaximized = false;
     bool m_HasCursorSample = false;
 
     SDL_Cursor* m_DefaultCursor = nullptr;

--- a/src/App/TitleBarLayer.h
+++ b/src/App/TitleBarLayer.h
@@ -143,6 +143,7 @@ class TitleBarLayer : public Core::Layer
     int m_MaximizedWindowX = 0;
     int m_MaximizedWindowWidth = 0;
 
+    ResizeEdge m_CachedHoverEdge = ResizeEdge::None;
     int m_LastCursorMouseGlobalX = 0;
     int m_LastCursorMouseGlobalY = 0;
     int m_LastCursorWindowX = 0;

--- a/src/App/TitleBarLayer.h
+++ b/src/App/TitleBarLayer.h
@@ -139,7 +139,10 @@ class TitleBarLayer : public Core::Layer
     int m_LastAppliedWindowWidth = 0;
     int m_LastAppliedWindowHeight = 0;
 
-    ResizeEdge m_HoverResizeEdge = ResizeEdge::None;
+    bool m_PendingDragRestore = false;
+    int m_MaximizedWindowX = 0;
+    int m_MaximizedWindowWidth = 0;
+
     int m_LastCursorMouseGlobalX = 0;
     int m_LastCursorMouseGlobalY = 0;
     int m_LastCursorWindowX = 0;

--- a/src/App/UserConfig.cpp
+++ b/src/App/UserConfig.cpp
@@ -1,6 +1,7 @@
 #include "UserConfig.h"
 
 #include "App/UserConfigHelpers.h"
+#include "Core/Window.h"
 #include "Domain/Numeric.h"
 #include "Domain/SamplingConfig.h"
 #include "ProcessColumnConfig.h"
@@ -315,8 +316,10 @@ void UserConfig::load()
         // Note: panels visibility is no longer used (removed in favor of tabbed UI)
 
         // Window state
-        UserConfigHelpers::loadAndNarrowIntWithClamp(config, "window", "width", m_Settings.windowWidth, 800, 200, 16'384);
-        UserConfigHelpers::loadAndNarrowIntWithClamp(config, "window", "height", m_Settings.windowHeight, 600, 200, 16'384);
+        UserConfigHelpers::loadAndNarrowIntWithClamp(
+            config, "window", "width", m_Settings.windowWidth, 800, Core::WINDOW_MIN_DIMENSION, Core::WINDOW_MAX_DIMENSION);
+        UserConfigHelpers::loadAndNarrowIntWithClamp(
+            config, "window", "height", m_Settings.windowHeight, 600, Core::WINDOW_MIN_DIMENSION, Core::WINDOW_MAX_DIMENSION);
         if (auto val = config["window"]["x"].value<std::int64_t>())
         {
             // Use default x position of 100 if narrowOr fails

--- a/src/Core/Application.cpp
+++ b/src/Core/Application.cpp
@@ -41,6 +41,12 @@ constexpr int IDLE_FRAME_SLEEP_MS = 50;
 // is extended to ~5 fps. Any event (e.g. SDL_EVENT_WINDOW_RESTORED) wakes
 // immediately, so restore latency is unaffected.
 constexpr int MINIMIZED_FRAME_SLEEP_MS = 200;
+
+// During interactive move/resize, event delivery can be bursty depending on
+// compositor/window-manager behavior. Keep redraw active for a short grace
+// window after each relevant window event so the framebuffer stays responsive
+// without forcing continuous high-rate rendering when idle.
+constexpr float INTERACTION_REDRAW_GRACE_SECONDS = 0.35F;
 } // namespace
 
 Application::Application(ApplicationSpecification spec) : m_Spec(std::move(spec))
@@ -162,6 +168,8 @@ void Application::run()
         return deltaTime;
     };
 
+    float forceInteractionRedrawUntil = 0.0F;
+
     spdlog::info("Entering main loop");
 
     while (m_Running)
@@ -199,6 +207,7 @@ void Application::run()
                 WindowResizedEvent resizeEvent(sdlEvent.window.data1, sdlEvent.window.data2);
                 raiseEvent(resizeEvent);
                 needsResizeRedraw = true;
+                forceInteractionRedrawUntil = getTime() + INTERACTION_REDRAW_GRACE_SECONDS;
             }
             else if (sdlEvent.type == SDL_EVENT_WINDOW_RESIZED || sdlEvent.type == SDL_EVENT_WINDOW_EXPOSED)
             {
@@ -208,7 +217,12 @@ void Application::run()
                     WindowResizedEvent resizeEvent(pixelW, pixelH);
                     raiseEvent(resizeEvent);
                     needsResizeRedraw = true;
+                    forceInteractionRedrawUntil = getTime() + INTERACTION_REDRAW_GRACE_SECONDS;
                 }
+            }
+            else if (sdlEvent.type == SDL_EVENT_WINDOW_MOVED)
+            {
+                forceInteractionRedrawUntil = getTime() + INTERACTION_REDRAW_GRACE_SECONDS;
             }
         }
 
@@ -218,18 +232,16 @@ void Application::run()
             break;
         }
 
-#ifdef _WIN32
-        // Keep interactive resize visually responsive on Windows without reintroducing
-        // per-event rendering stalls: render at most once per drained event batch.
+        // Keep interactive move/resize visually responsive across platforms
+        // without reintroducing per-event rendering stalls: render at most once
+        // per drained event batch.
         bool didImmediateResizeRedraw = false;
-        if (needsResizeRedraw && !m_Window->isMinimized())
+        const bool forceInteractionRedraw = getTime() < forceInteractionRedrawUntil;
+        if ((needsResizeRedraw || forceInteractionRedraw) && !m_Window->isMinimized())
         {
             renderFrame(computeDeltaTime());
             didImmediateResizeRedraw = true;
         }
-#else
-        constexpr bool didImmediateResizeRedraw = false;
-#endif
 
         // When the event queue is empty, sleep briefly before rendering the next frame.
         // This caps the idle render rate to ~20 fps, reducing CPU/GPU usage when the
@@ -238,6 +250,11 @@ void Application::run()
         // Use a longer sleep while minimized — nothing is visible, so 5 fps is ample.
         if (!hadEvents)
         {
+            const bool keepInteractionRedrawActive = getTime() < forceInteractionRedrawUntil;
+            if (keepInteractionRedrawActive)
+            {
+                continue;
+            }
             const int sleepMs = m_Window->isMinimized() ? MINIMIZED_FRAME_SLEEP_MS : IDLE_FRAME_SLEEP_MS;
             SDL_WaitEventTimeout(nullptr, sleepMs);
         }

--- a/src/Core/Application.cpp
+++ b/src/Core/Application.cpp
@@ -154,12 +154,21 @@ void Application::run()
 
     float lastTime = getTime();
 
+    const auto computeDeltaTime = [&lastTime]() -> float
+    {
+        const float currentTime = getTime();
+        const float deltaTime = std::min(currentTime - lastTime, MAX_DELTA_TIME);
+        lastTime = currentTime;
+        return deltaTime;
+    };
+
     spdlog::info("Entering main loop");
 
     while (m_Running)
     {
         // Process SDL events
         bool hadEvents = false;
+        bool needsResizeRedraw = false;
         SDL_Event sdlEvent;
         while (SDL_PollEvent(&sdlEvent))
         {
@@ -181,16 +190,25 @@ void Application::run()
                 }
             }
 
-            // Notify layers of framebuffer pixel size changes (user drag-resize or DPI change).
-            // We do NOT render here — calling renderFrame() inside the event loop causes one
-            // vsync stall (~16 ms at 60 Hz) per resize event. When events batch up during an
-            // active drag, that serialises many vsync waits and makes resize extremely sluggish.
-            // UILayer::onEvent(WindowResizedEvent) keeps glViewport in sync; the unconditional
-            // renderFrame() below presents the correct framebuffer each iteration.
+            // Drive viewport updates from resize-related events.
+            // On Windows, interactive border drag can surface WINDOW_RESIZED/EXPOSED before
+            // (or instead of) WINDOW_PIXEL_SIZE_CHANGED in some paths. Handle all relevant
+            // variants and use physical pixel size when explicit dimensions are unavailable.
             if (sdlEvent.type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED)
             {
                 WindowResizedEvent resizeEvent(sdlEvent.window.data1, sdlEvent.window.data2);
                 raiseEvent(resizeEvent);
+                needsResizeRedraw = true;
+            }
+            else if (sdlEvent.type == SDL_EVENT_WINDOW_RESIZED || sdlEvent.type == SDL_EVENT_WINDOW_EXPOSED)
+            {
+                const auto [pixelW, pixelH] = m_Window->getSizeInPixels();
+                if (pixelW > 0 && pixelH > 0)
+                {
+                    WindowResizedEvent resizeEvent(pixelW, pixelH);
+                    raiseEvent(resizeEvent);
+                    needsResizeRedraw = true;
+                }
             }
         }
 
@@ -199,6 +217,19 @@ void Application::run()
             stop();
             break;
         }
+
+#ifdef _WIN32
+        // Keep interactive resize visually responsive on Windows without reintroducing
+        // per-event rendering stalls: render at most once per drained event batch.
+        bool didImmediateResizeRedraw = false;
+        if (needsResizeRedraw && !m_Window->isMinimized())
+        {
+            renderFrame(computeDeltaTime());
+            didImmediateResizeRedraw = true;
+        }
+#else
+        constexpr bool didImmediateResizeRedraw = false;
+#endif
 
         // When the event queue is empty, sleep briefly before rendering the next frame.
         // This caps the idle render rate to ~20 fps, reducing CPU/GPU usage when the
@@ -211,11 +242,10 @@ void Application::run()
             SDL_WaitEventTimeout(nullptr, sleepMs);
         }
 
-        const float currentTime = getTime();
-        const float deltaTime = std::min(currentTime - lastTime, MAX_DELTA_TIME);
-        lastTime = currentTime;
-
-        renderFrame(deltaTime);
+        if (!didImmediateResizeRedraw)
+        {
+            renderFrame(computeDeltaTime());
+        }
     }
 
     spdlog::info("Exiting main loop");

--- a/src/Core/Application.cpp
+++ b/src/Core/Application.cpp
@@ -243,20 +243,20 @@ void Application::run()
             didImmediateResizeRedraw = true;
         }
 
-        // When the event queue is empty, sleep briefly before rendering the next frame.
-        // This caps the idle render rate to ~20 fps, reducing CPU/GPU usage when the
-        // display hasn't changed. Any SDL event (mouse move, key press, focus, resize)
-        // wakes the sleep immediately, so interactive frame rate is unaffected.
-        // Use a longer sleep while minimized — nothing is visible, so 5 fps is ample.
+        // When the event queue is empty, decide whether to sleep or render immediately:
+        // - Inside the grace period: skip the sleep and fall through to renderFrame so the
+        //   display stays current during burst gaps between resize/move events.
+        // - Outside the grace period: sleep briefly (~20 fps idle, 5 fps minimized) to
+        //   reduce CPU/GPU usage when the display hasn't changed. Any SDL event wakes the
+        //   sleep immediately, keeping interactive frame rate unaffected.
         if (!hadEvents)
         {
             const bool keepInteractionRedrawActive = getTime() < forceInteractionRedrawUntil;
-            if (keepInteractionRedrawActive)
+            if (!keepInteractionRedrawActive)
             {
-                continue;
+                const int sleepMs = m_Window->isMinimized() ? MINIMIZED_FRAME_SLEEP_MS : IDLE_FRAME_SLEEP_MS;
+                SDL_WaitEventTimeout(nullptr, sleepMs);
             }
-            const int sleepMs = m_Window->isMinimized() ? MINIMIZED_FRAME_SLEEP_MS : IDLE_FRAME_SLEEP_MS;
-            SDL_WaitEventTimeout(nullptr, sleepMs);
         }
 
         if (!didImmediateResizeRedraw)

--- a/src/Core/Window.cpp
+++ b/src/Core/Window.cpp
@@ -24,7 +24,7 @@ namespace
 {
 [[nodiscard]] int clampWindowDimension(const int value) noexcept
 {
-    return std::clamp(value, 1, 16384);
+    return std::clamp(value, WINDOW_MIN_DIMENSION, WINDOW_MAX_DIMENSION);
 }
 
 [[nodiscard]] std::string_view glString(GLenum name)

--- a/src/Core/Window.h
+++ b/src/Core/Window.h
@@ -12,6 +12,10 @@ namespace Core
 /// Must match the clamp bounds in main.cpp and UserConfig.cpp.
 constexpr int WINDOW_MIN_DIMENSION = 200;
 
+/// Maximum window dimension (width or height) in pixels.
+/// Must match the clamp bounds in main.cpp and UserConfig.cpp.
+constexpr int WINDOW_MAX_DIMENSION = 16'384;
+
 struct WindowSpecification
 {
     std::string Title = "Window";

--- a/src/Core/Window.h
+++ b/src/Core/Window.h
@@ -9,11 +9,13 @@ namespace Core
 {
 
 /// Minimum window dimension (width or height) in pixels.
-/// Must match the clamp bounds in main.cpp and UserConfig.cpp.
+/// Use at all window-size clamp sites (main.cpp, UserConfig.cpp, custom resize) to
+/// maintain a single source of truth.
 constexpr int WINDOW_MIN_DIMENSION = 200;
 
 /// Maximum window dimension (width or height) in pixels.
-/// Must match the clamp bounds in main.cpp and UserConfig.cpp.
+/// Use at all window-size clamp sites (main.cpp, UserConfig.cpp, custom resize) to
+/// maintain a single source of truth.
 constexpr int WINDOW_MAX_DIMENSION = 16'384;
 
 struct WindowSpecification

--- a/src/Core/Window.h
+++ b/src/Core/Window.h
@@ -8,6 +8,10 @@
 namespace Core
 {
 
+/// Minimum window dimension (width or height) in pixels.
+/// Must match the clamp bounds in main.cpp and UserConfig.cpp.
+constexpr int WINDOW_MIN_DIMENSION = 200;
+
 struct WindowSpecification
 {
     std::string Title = "Window";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,7 @@ auto runApp() -> int
     // Suppress info/debug log output in release builds. The compile-time
     // SPDLOG_ACTIVE_LEVEL guard only silences the SPDLOG_* macros; direct
     // spdlog::info() calls are always compiled in and respect the runtime level.
-    spdlog::set_level(spdlog::level::warn);
+    spdlog::set_level(spdlog::level::off);
 #endif
 
     spdlog::info("{} v{} ({} build)", tasksmack::Version::PROJECT_NAME, tasksmack::Version::STRING, tasksmack::Version::BUILD_TYPE);
@@ -152,8 +152,8 @@ auto runApp() -> int
     // Create application and transfer ownership to the singleton
     Core::ApplicationSpecification appSpec;
     appSpec.Name = "TaskSmack";
-    appSpec.Width = std::clamp(settings.windowWidth, 200, 16'384);
-    appSpec.Height = std::clamp(settings.windowHeight, 200, 16'384);
+    appSpec.Width = std::clamp(settings.windowWidth, Core::WINDOW_MIN_DIMENSION, Core::WINDOW_MAX_DIMENSION);
+    appSpec.Height = std::clamp(settings.windowHeight, Core::WINDOW_MIN_DIMENSION, Core::WINDOW_MAX_DIMENSION);
     appSpec.VSync = true;
 
     auto app = std::make_unique<Core::Application>(appSpec);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,10 +134,11 @@ auto runApp() -> int
     spdlog::set_level(spdlog::level::debug);
     spdlog::flush_on(spdlog::level::debug);
 #else
-    // Suppress info/debug log output in release builds. The compile-time
-    // SPDLOG_ACTIVE_LEVEL guard only silences the SPDLOG_* macros; direct
-    // spdlog::info() calls are always compiled in and respect the runtime level.
-    spdlog::set_level(spdlog::level::off);
+    // In release builds, silence info/debug noise while preserving warnings,
+    // errors, and critical failures so production issues remain diagnosable.
+    // The compile-time SPDLOG_ACTIVE_LEVEL guard only silences the SPDLOG_*
+    // macros; direct spdlog::info() calls respect this runtime level.
+    spdlog::set_level(spdlog::level::warn);
 #endif
 
     spdlog::info("{} v{} ({} build)", tasksmack::Version::PROJECT_NAME, tasksmack::Version::STRING, tasksmack::Version::BUILD_TYPE);

--- a/tests/Core/test_Window.cpp
+++ b/tests/Core/test_Window.cpp
@@ -129,12 +129,12 @@ TEST_F(WindowTest, SetSizeClampsToExpectedBounds)
         Window window(WindowSpecification{.Title = "WindowClampTest", .Width = 640, .Height = 480, .VSync = false, .Borderless = true});
 
         window.setSize(0, -10);
-        EXPECT_EQ(window.getWidth(), 1);
-        EXPECT_EQ(window.getHeight(), 1);
+        EXPECT_EQ(window.getWidth(), WINDOW_MIN_DIMENSION);
+        EXPECT_EQ(window.getHeight(), WINDOW_MIN_DIMENSION);
 
         window.setSize(20000, 50000);
-        EXPECT_EQ(window.getWidth(), 16384);
-        EXPECT_EQ(window.getHeight(), 16384);
+        EXPECT_EQ(window.getWidth(), WINDOW_MAX_DIMENSION);
+        EXPECT_EQ(window.getHeight(), WINDOW_MAX_DIMENSION);
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
## Summary
- Keep rendering active during interactive move/resize instead of pausing in native modal loops
- Add custom window border rendering for borderless window mode
- Add resize cursor feedback on borders/corners
- Improve hot-path performance in interaction handling by avoiding redundant window/cursor updates

## Key Changes
- Core loop:
  - Added interaction redraw grace behavior for resize/move events
  - Avoid idle sleep while interaction redraw is active
- Title bar / custom chrome:
  - Disabled native hit-test modal move/resize path and implemented app-managed drag/resize
  - Added edge/corner detection and cursor mapping (NS/EW/NESW/NWSE)
  - Added 1px themed border draw in non-maximized state
  - Added state caching to reduce redundant position/size/cursor calls

## Validation Performed
- Windows optimized build passes
- Manual validation on Windows confirms:
  - redraw during title-bar drag
  - redraw during corner/border resize
  - resize cursor behavior
  - border rendering

## Linux Validation Requested
Please validate on Linux for:
- live redraw during drag/resize
- cursor feedback on edges/corners
- any compositor-specific behavior differences
