### PR TITLE
Reduce Windows resize stalls with targeted tracing and coalesced titlebar sizing

### DIFF
--- a/src/App/Panels/ProcessesPanel.cpp
+++ b/src/App/Panels/ProcessesPanel.cpp
@@ -42,6 +42,7 @@ namespace
 
 constexpr float TREE_INDENT_WIDTH = 16.0F; // Indent width per tree level in pixels
 constexpr int MAX_TREE_DEPTH = 1000;       // Maximum tree depth to detect cycles or malformed data
+std::unordered_map<const ProcessesPanel*, float> INTERACTION_INTERVAL_HOLD_BY_PANEL;
 
 [[nodiscard]] std::chrono::milliseconds
 chooseAdaptiveProcessInterval(const std::chrono::milliseconds baseInterval, const bool isActiveTab, const bool interactionRedrawActive)
@@ -67,6 +68,8 @@ chooseAdaptiveProcessInterval(const std::chrono::milliseconds baseInterval, cons
     // Active tab, no interaction: use base interval
     return std::chrono::milliseconds(baseMs);
 }
+
+constexpr float INTERACTION_INTERVAL_HOLD_SECONDS = 0.40F;
 
 // Column-specific unit widths (based on longest unit that can appear)
 // Unit widths measured by longest unit string that column can display
@@ -306,6 +309,11 @@ ProcessesPanel::~ProcessesPanel()
         m_Sampler->stop();
         m_Sampler.reset();
     }
+    if (m_ProcessModel)
+    {
+        m_ProcessModel->setInteractionActive(false);
+    }
+    INTERACTION_INTERVAL_HOLD_BY_PANEL.erase(this);
     m_ProcessModel.reset();
 }
 
@@ -317,6 +325,7 @@ void ProcessesPanel::onAttach()
     const int intervalMs = UserConfig::get().settings().refreshIntervalMs;
     m_RefreshInterval = std::chrono::milliseconds(intervalMs);
     m_AppliedSamplerInterval = m_RefreshInterval;
+    INTERACTION_INTERVAL_HOLD_BY_PANEL[this] = 0.0F;
     m_ForceRefresh = false;
 
     // Create probe, extract capabilities/ticks/systemMemory, then transfer probe ownership
@@ -379,6 +388,7 @@ void ProcessesPanel::onDetach()
         m_Sampler->stop();
         m_Sampler.reset();
     }
+    INTERACTION_INTERVAL_HOLD_BY_PANEL.erase(this);
     m_ProcessModel.reset();
 }
 
@@ -414,15 +424,28 @@ void ProcessesPanel::onEvent(Core::Event& event)
         });
 }
 
-void ProcessesPanel::onUpdate([[maybe_unused]] float deltaTime)
+void ProcessesPanel::onUpdate(float deltaTime)
 {
     if (!m_ProcessModel || !m_Sampler)
     {
         return;
     }
 
-    const auto desiredInterval =
-        chooseAdaptiveProcessInterval(m_RefreshInterval, m_IsActiveTab, Core::Application::get().isInteractionRedrawActive());
+    float& interactionIntervalHoldSecondsRemaining = INTERACTION_INTERVAL_HOLD_BY_PANEL[this];
+    const bool interactionRedrawActive = Core::Application::get().isInteractionRedrawActive();
+    if (interactionRedrawActive)
+    {
+        interactionIntervalHoldSecondsRemaining = INTERACTION_INTERVAL_HOLD_SECONDS;
+    }
+    else if (interactionIntervalHoldSecondsRemaining > 0.0F)
+    {
+        const float clampedDeltaTime = std::max(0.0F, deltaTime);
+        interactionIntervalHoldSecondsRemaining = std::max(0.0F, interactionIntervalHoldSecondsRemaining - clampedDeltaTime);
+    }
+
+    const bool throttleForInteraction = interactionRedrawActive || (interactionIntervalHoldSecondsRemaining > 0.0F);
+    m_ProcessModel->setInteractionActive(throttleForInteraction);
+    const auto desiredInterval = chooseAdaptiveProcessInterval(m_RefreshInterval, m_IsActiveTab, throttleForInteraction);
     if (desiredInterval != m_AppliedSamplerInterval)
     {
         m_AppliedSamplerInterval = desiredInterval;

--- a/src/App/Panels/ProcessesPanel.cpp
+++ b/src/App/Panels/ProcessesPanel.cpp
@@ -42,9 +42,6 @@ namespace
 
 constexpr float TREE_INDENT_WIDTH = 16.0F; // Indent width per tree level in pixels
 constexpr int MAX_TREE_DEPTH = 1000;       // Maximum tree depth to detect cycles or malformed data
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-// Tracks per-panel interaction hold state keyed by panel instance.
-std::unordered_map<const ProcessesPanel*, float> INTERACTION_INTERVAL_HOLD_BY_PANEL;
 
 [[nodiscard]] std::chrono::milliseconds
 chooseAdaptiveProcessInterval(const std::chrono::milliseconds baseInterval, const bool isActiveTab, const bool interactionRedrawActive)
@@ -315,7 +312,7 @@ ProcessesPanel::~ProcessesPanel()
     {
         m_ProcessModel->setInteractionActive(false);
     }
-    INTERACTION_INTERVAL_HOLD_BY_PANEL.erase(this);
+    this->m_InteractionHoldSeconds = 0.0F;
     m_ProcessModel.reset();
 }
 
@@ -327,7 +324,7 @@ void ProcessesPanel::onAttach()
     const int intervalMs = UserConfig::get().settings().refreshIntervalMs;
     m_RefreshInterval = std::chrono::milliseconds(intervalMs);
     m_AppliedSamplerInterval = m_RefreshInterval;
-    INTERACTION_INTERVAL_HOLD_BY_PANEL[this] = 0.0F;
+    this->m_InteractionHoldSeconds = 0.0F;
     m_ForceRefresh = false;
 
     // Create probe, extract capabilities/ticks/systemMemory, then transfer probe ownership
@@ -390,7 +387,7 @@ void ProcessesPanel::onDetach()
         m_Sampler->stop();
         m_Sampler.reset();
     }
-    INTERACTION_INTERVAL_HOLD_BY_PANEL.erase(this);
+    this->m_InteractionHoldSeconds = 0.0F;
     m_ProcessModel.reset();
 }
 
@@ -433,19 +430,18 @@ void ProcessesPanel::onUpdate(float deltaTime)
         return;
     }
 
-    float& interactionIntervalHoldSecondsRemaining = INTERACTION_INTERVAL_HOLD_BY_PANEL[this];
     const bool interactionRedrawActive = Core::Application::get().isInteractionRedrawActive();
     if (interactionRedrawActive)
     {
-        interactionIntervalHoldSecondsRemaining = INTERACTION_INTERVAL_HOLD_SECONDS;
+        this->m_InteractionHoldSeconds = INTERACTION_INTERVAL_HOLD_SECONDS;
     }
-    else if (interactionIntervalHoldSecondsRemaining > 0.0F)
+    else if (this->m_InteractionHoldSeconds > 0.0F)
     {
         const float clampedDeltaTime = std::max(0.0F, deltaTime);
-        interactionIntervalHoldSecondsRemaining = std::max(0.0F, interactionIntervalHoldSecondsRemaining - clampedDeltaTime);
+        this->m_InteractionHoldSeconds = std::max(0.0F, this->m_InteractionHoldSeconds - clampedDeltaTime);
     }
 
-    const bool throttleForInteraction = interactionRedrawActive || (interactionIntervalHoldSecondsRemaining > 0.0F);
+    const bool throttleForInteraction = interactionRedrawActive || (this->m_InteractionHoldSeconds > 0.0F);
     m_ProcessModel->setInteractionActive(throttleForInteraction);
     const auto desiredInterval = chooseAdaptiveProcessInterval(m_RefreshInterval, m_IsActiveTab, throttleForInteraction);
     if (desiredInterval != m_AppliedSamplerInterval)

--- a/src/App/Panels/ProcessesPanel.cpp
+++ b/src/App/Panels/ProcessesPanel.cpp
@@ -42,6 +42,8 @@ namespace
 
 constexpr float TREE_INDENT_WIDTH = 16.0F; // Indent width per tree level in pixels
 constexpr int MAX_TREE_DEPTH = 1000;       // Maximum tree depth to detect cycles or malformed data
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+// Tracks per-panel interaction hold state keyed by panel instance.
 std::unordered_map<const ProcessesPanel*, float> INTERACTION_INTERVAL_HOLD_BY_PANEL;
 
 [[nodiscard]] std::chrono::milliseconds

--- a/src/App/Panels/ProcessesPanel.h
+++ b/src/App/Panels/ProcessesPanel.h
@@ -109,6 +109,7 @@ class ProcessesPanel : public Panel
     std::chrono::milliseconds m_AppliedSamplerInterval{Domain::Sampling::REFRESH_INTERVAL_DEFAULT_MS};
     bool m_ForceRefresh = false;
     bool m_IsActiveTab = false;
+    float m_InteractionHoldSeconds = 0.0F;
 
     // Snapshot version at last tree rebuild — used to detect new data from background sampler.
     std::uint64_t m_LastSnapshotVersion = std::numeric_limits<std::uint64_t>::max();

--- a/src/App/Panels/SystemMetricsPanel.cpp
+++ b/src/App/Panels/SystemMetricsPanel.cpp
@@ -151,13 +151,55 @@ SystemMetricsPanel::SystemMetricsPanel() : Panel("System")
 
 SystemMetricsPanel::~SystemMetricsPanel()
 {
+    stopGpuRefreshSampler();
     m_Model.reset();
+}
+
+void SystemMetricsPanel::startGpuRefreshSampler()
+{
+    stopGpuRefreshSampler();
+    if (!m_GPUModel)
+    {
+        return;
+    }
+
+    auto gpuModel = m_GPUModel;
+    m_GpuRefreshThread = std::jthread(
+        [this, gpuModel](const std::stop_token& stopToken)
+        {
+            while (!stopToken.stop_requested())
+            {
+                const auto start = std::chrono::steady_clock::now();
+                gpuModel->refresh();
+
+                const int intervalMs = std::max(m_GpuRefreshIntervalMs.load(std::memory_order_acquire), 1);
+                auto sleepRemaining = std::chrono::milliseconds(intervalMs) -
+                                      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+                while ((sleepRemaining > std::chrono::milliseconds::zero()) && !stopToken.stop_requested())
+                {
+                    constexpr auto sleepChunk = std::chrono::milliseconds(50);
+                    const auto nap = std::min(sleepChunk, sleepRemaining);
+                    std::this_thread::sleep_for(nap);
+                    sleepRemaining -= nap;
+                }
+            }
+        });
+}
+
+void SystemMetricsPanel::stopGpuRefreshSampler()
+{
+    if (m_GpuRefreshThread.joinable())
+    {
+        m_GpuRefreshThread.request_stop();
+        m_GpuRefreshThread.join();
+    }
 }
 
 void SystemMetricsPanel::onAttach()
 {
     auto& settings = UserConfig::get().settings();
     m_RefreshInterval = std::chrono::milliseconds(settings.refreshIntervalMs);
+    m_GpuRefreshIntervalMs.store(Domain::Numeric::narrowOr<int>(m_RefreshInterval.count(), 1000), std::memory_order_release);
     m_MaxHistorySeconds = Domain::Numeric::toDouble(settings.maxHistorySeconds);
     m_HistoryScrollSeconds = 0.0;
     m_RefreshAccumulatorSec = 0.0F;
@@ -178,6 +220,7 @@ void SystemMetricsPanel::onAttach()
     if (m_GPUModel)
     {
         m_GPUModel->refresh();
+        startGpuRefreshSampler();
     }
 
     m_TimestampsCache = m_Model->timestamps();
@@ -199,6 +242,7 @@ void SystemMetricsPanel::onAttach()
 
 void SystemMetricsPanel::onDetach()
 {
+    stopGpuRefreshSampler();
     m_GPUModel.reset();
     m_StorageModel.reset();
     m_Model.reset();
@@ -207,6 +251,7 @@ void SystemMetricsPanel::onDetach()
 void SystemMetricsPanel::setSamplingInterval(std::chrono::milliseconds interval)
 {
     m_RefreshInterval = interval;
+    m_GpuRefreshIntervalMs.store(Domain::Numeric::narrowOr<int>(std::max(interval.count(), 1LL), 1000), std::memory_order_release);
     m_RefreshAccumulatorSec = 0.0F;
     m_ForceRefresh = true;
 }
@@ -259,6 +304,7 @@ void SystemMetricsPanel::onUpdate(float deltaTime)
     using SecondsF = std::chrono::duration<float>;
     const auto effectiveInterval =
         chooseAdaptiveSystemInterval(m_RefreshInterval, m_IsActiveTab, Core::Application::get().isInteractionRedrawActive());
+    m_GpuRefreshIntervalMs.store(Domain::Numeric::narrowOr<int>(std::max(effectiveInterval.count(), 1LL), 1000), std::memory_order_release);
     const float intervalSec = std::chrono::duration_cast<SecondsF>(effectiveInterval).count();
     const bool intervalElapsed = (intervalSec > 0.0F) && (m_RefreshAccumulatorSec >= intervalSec);
 
@@ -271,11 +317,6 @@ void SystemMetricsPanel::onUpdate(float deltaTime)
         {
             m_StorageModel->setMaxHistorySeconds(m_MaxHistorySeconds);
             m_StorageModel->sample();
-        }
-
-        if (m_GPUModel)
-        {
-            m_GPUModel->refresh();
         }
 
         m_TimestampsCache = m_Model->timestamps();

--- a/src/App/Panels/SystemMetricsPanel.h
+++ b/src/App/Panels/SystemMetricsPanel.h
@@ -11,8 +11,10 @@
 
 #include <implot.h>
 
+#include <atomic>
 #include <chrono>
 #include <memory>
+#include <thread>
 #include <unordered_map>
 
 namespace App
@@ -77,6 +79,9 @@ class SystemMetricsPanel : public Panel
     }
 
   private:
+    void startGpuRefreshSampler();
+    void stopGpuRefreshSampler();
+
     void renderOverview();
     void renderCpuSection();
 
@@ -101,6 +106,8 @@ class SystemMetricsPanel : public Panel
     bool m_ForceRefresh = false;
     float m_LastDeltaSeconds = 0.0F;
     bool m_IsActiveTab = true; // System Overview is default tab
+    std::atomic<int> m_GpuRefreshIntervalMs{1000};
+    std::jthread m_GpuRefreshThread;
 
     struct SmoothedCpu
     {

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -13,6 +13,7 @@
 #include <imgui.h>
 #include <spdlog/spdlog.h>
 
+#include <cctype>
 #include <chrono>
 #include <string_view>
 

--- a/src/App/TitleBarLayer.cpp
+++ b/src/App/TitleBarLayer.cpp
@@ -13,6 +13,9 @@
 #include <imgui.h>
 #include <spdlog/spdlog.h>
 
+#include <chrono>
+#include <string_view>
+
 #include <stb_image.h>
 
 #ifdef _WIN32
@@ -37,6 +40,40 @@ auto TitleBarLayer::height() -> float
 
 namespace
 {
+[[nodiscard]] bool isResizePerfTracingEnabled() noexcept
+{
+    const char* value = SDL_getenv("TASKSMACK_TRACE_RESIZE_PERF");
+    if (value == nullptr)
+    {
+        return false;
+    }
+
+    const std::string_view text(value);
+    if (text.empty())
+    {
+        return false;
+    }
+
+    const auto ciEqual = [](const std::string_view a, const std::string_view b) noexcept
+    {
+        if (a.size() != b.size())
+        {
+            return false;
+        }
+
+        for (std::size_t i = 0; i < a.size(); ++i)
+        {
+            if (static_cast<char>(std::tolower(static_cast<unsigned char>(a[i]))) != b[i])
+            {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    return !ciEqual(text, "0") && !ciEqual(text, "false") && !ciEqual(text, "off") && !ciEqual(text, "no");
+}
+
 // Helper to check if point is inside bounds
 bool isInsideBounds(float x, float y, const TitleBarLayer::ButtonBounds& bounds)
 {
@@ -50,6 +87,8 @@ bool isInsideBounds(float x, float y, const TitleBarLayer::ButtonBounds& bounds)
 
 // Shared resize border thickness — must stay in sync between hit-test and cursor detection.
 constexpr float RESIZE_BORDER_THICKNESS = 8.0F;
+constexpr float RESIZE_SIZE_COMMIT_INTERVAL_SECONDS = 1.0F / 30.0F;
+constexpr float RESIZE_PENDING_IDLE_FLUSH_SECONDS = 1.0F / 60.0F;
 
 // Hit-test callback behavior is platform dependent:
 // - Windows: force NORMAL and use client-side drag/resize to avoid modal move/size redraw stalls.
@@ -483,6 +522,11 @@ void TitleBarLayer::beginWindowInteraction(const SDL_Event& event)
         m_LastAppliedWindowY = startY;
         m_LastAppliedWindowWidth = windowWidth;
         m_LastAppliedWindowHeight = windowHeight;
+        m_HasPendingResizeCommit = false;
+        m_PendingResizeWidth = windowWidth;
+        m_PendingResizeHeight = windowHeight;
+        m_LastResizeSizeCommitTime = Core::Application::getTime();
+        m_LastResizeDesiredChangeTime = m_LastResizeSizeCommitTime;
         m_CustomDragActive = false;
         return;
     }
@@ -532,9 +576,86 @@ void TitleBarLayer::updateWindowInteraction()
         return;
     }
 
+    using Clock = std::chrono::steady_clock;
+    constexpr double SLOW_TITLEBAR_UPDATE_MS = 250.0;
+    const bool traceEnabled = isResizePerfTracingEnabled();
+    const bool startedDrag = m_CustomDragActive;
+    const bool startedResize = m_CustomResizeActive;
+
+    double mouseStateMs = 0.0;
+    double restoreMs = 0.0;
+    double setPositionMs = 0.0;
+    double setSizeMs = 0.0;
+    double raiseResizeEventMs = 0.0;
+
+    const auto updateStart = traceEnabled ? Clock::now() : Clock::time_point{};
+    struct SlowUpdateTraceGuard
+    {
+        bool traceEnabled = false;
+        bool startedDrag = false;
+        bool startedResize = false;
+        const TitleBarLayer* self = nullptr;
+        double* mouseStateMs = nullptr;
+        double* restoreMs = nullptr;
+        double* setPositionMs = nullptr;
+        double* setSizeMs = nullptr;
+        double* raiseResizeEventMs = nullptr;
+        Clock::time_point updateStart{};
+
+        ~SlowUpdateTraceGuard()
+        {
+            if (!traceEnabled)
+            {
+                return;
+            }
+
+            const double totalMs = std::chrono::duration<double, std::milli>(Clock::now() - updateStart).count();
+            if (totalMs < SLOW_TITLEBAR_UPDATE_MS)
+            {
+                return;
+            }
+
+            const char* mode = startedDrag ? "drag" : (startedResize ? "resize" : "none");
+            spdlog::info("ResizePerfTitleBarSlowUpdate: mode={} edge={} total={:.3f} ms mouse={:.3f} ms restore={:.3f} ms setPos={:.3f} ms "
+                         "setSize={:.3f} ms raiseResizeEvent={:.3f} ms",
+                         mode,
+                         static_cast<int>(self->m_ActiveResizeEdge),
+                         totalMs,
+                         *mouseStateMs,
+                         *restoreMs,
+                         *setPositionMs,
+                         *setSizeMs,
+                         *raiseResizeEventMs);
+        }
+    };
+
+    const SlowUpdateTraceGuard traceScope{
+        .traceEnabled = traceEnabled,
+        .startedDrag = startedDrag,
+        .startedResize = startedResize,
+        .self = this,
+        .mouseStateMs = &mouseStateMs,
+        .restoreMs = &restoreMs,
+        .setPositionMs = &setPositionMs,
+        .setSizeMs = &setSizeMs,
+        .raiseResizeEventMs = &raiseResizeEventMs,
+        .updateStart = updateStart,
+    };
+
     float globalMouseXF = 0.0F;
     float globalMouseYF = 0.0F;
-    const SDL_MouseButtonFlags mouseButtons = SDL_GetGlobalMouseState(&globalMouseXF, &globalMouseYF);
+    SDL_MouseButtonFlags mouseButtons = 0U;
+    if (traceEnabled)
+    {
+        const auto opStart = Clock::now();
+        mouseButtons = SDL_GetGlobalMouseState(&globalMouseXF, &globalMouseYF);
+        mouseStateMs += std::chrono::duration<double, std::milli>(Clock::now() - opStart).count();
+    }
+    else
+    {
+        mouseButtons = SDL_GetGlobalMouseState(&globalMouseXF, &globalMouseYF);
+    }
+
     if ((mouseButtons & SDL_BUTTON_LMASK) == 0U)
     {
         endWindowInteraction();
@@ -562,11 +683,29 @@ void TitleBarLayer::updateWindowInteraction()
             // Threshold crossed — restore and rebase the drag origin.
             const float xProportion =
                 static_cast<float>(m_DragStartMouseGlobalX - m_MaximizedWindowX) / static_cast<float>(m_MaximizedWindowWidth);
-            window.restore();
+            if (traceEnabled)
+            {
+                const auto opStart = Clock::now();
+                window.restore();
+                restoreMs += std::chrono::duration<double, std::milli>(Clock::now() - opStart).count();
+            }
+            else
+            {
+                window.restore();
+            }
             const auto [restoredX, restoredY] = window.getPosition();
             const auto [restoredWidth, restoredHeight] = window.getSize();
             const int adjustedX = m_DragStartMouseGlobalX - static_cast<int>(xProportion * static_cast<float>(restoredWidth));
-            window.setPosition(adjustedX, restoredY);
+            if (traceEnabled)
+            {
+                const auto opStart = Clock::now();
+                window.setPosition(adjustedX, restoredY);
+                setPositionMs += std::chrono::duration<double, std::milli>(Clock::now() - opStart).count();
+            }
+            else
+            {
+                window.setPosition(adjustedX, restoredY);
+            }
             m_DragStartWindowX = adjustedX;
             m_DragStartWindowY = restoredY;
             m_LastAppliedWindowX = adjustedX;
@@ -581,7 +720,16 @@ void TitleBarLayer::updateWindowInteraction()
         const int targetY = m_DragStartWindowY + dy;
         if (targetX != m_LastAppliedWindowX || targetY != m_LastAppliedWindowY)
         {
-            window.setPosition(targetX, targetY);
+            if (traceEnabled)
+            {
+                const auto opStart = Clock::now();
+                window.setPosition(targetX, targetY);
+                setPositionMs += std::chrono::duration<double, std::milli>(Clock::now() - opStart).count();
+            }
+            else
+            {
+                window.setPosition(targetX, targetY);
+            }
             m_LastAppliedWindowX = targetX;
             m_LastAppliedWindowY = targetY;
         }
@@ -685,18 +833,92 @@ void TitleBarLayer::updateWindowInteraction()
 
         const bool positionChanged = (newX != m_LastAppliedWindowX) || (newY != m_LastAppliedWindowY);
         const bool sizeChanged = (newWidth != m_LastAppliedWindowWidth) || (newHeight != m_LastAppliedWindowHeight);
+        const float now = Core::Application::getTime();
+        bool sizeCommitApplied = false;
 
         if (positionChanged)
         {
-            window.setPosition(newX, newY);
+            if (traceEnabled)
+            {
+                const auto opStart = Clock::now();
+                window.setPosition(newX, newY);
+                setPositionMs += std::chrono::duration<double, std::milli>(Clock::now() - opStart).count();
+            }
+            else
+            {
+                window.setPosition(newX, newY);
+            }
             m_LastAppliedWindowX = newX;
             m_LastAppliedWindowY = newY;
         }
         if (sizeChanged)
         {
-            SDL_SetWindowSize(window.getHandle(), newWidth, newHeight);
-            m_LastAppliedWindowWidth = newWidth;
-            m_LastAppliedWindowHeight = newHeight;
+            const bool commitIntervalElapsed = (now - m_LastResizeSizeCommitTime) >= RESIZE_SIZE_COMMIT_INTERVAL_SECONDS;
+            const bool skipDuplicateSize = (newWidth == m_LastAppliedWindowWidth) && (newHeight == m_LastAppliedWindowHeight);
+            if (commitIntervalElapsed)
+            {
+                if (!skipDuplicateSize)
+                {
+                    if (traceEnabled)
+                    {
+                        const auto opStart = Clock::now();
+                        SDL_SetWindowSize(window.getHandle(), newWidth, newHeight);
+                        setSizeMs += std::chrono::duration<double, std::milli>(Clock::now() - opStart).count();
+                    }
+                    else
+                    {
+                        SDL_SetWindowSize(window.getHandle(), newWidth, newHeight);
+                    }
+                }
+                m_LastAppliedWindowWidth = newWidth;
+                m_LastAppliedWindowHeight = newHeight;
+                m_LastResizeSizeCommitTime = now;
+                m_LastResizeDesiredChangeTime = now;
+                m_HasPendingResizeCommit = false;
+                sizeCommitApplied = true;
+            }
+            else
+            {
+                m_HasPendingResizeCommit = true;
+                m_PendingResizeWidth = newWidth;
+                m_PendingResizeHeight = newHeight;
+                m_LastResizeDesiredChangeTime = now;
+            }
+        }
+        else if (m_HasPendingResizeCommit)
+        {
+            const bool idleElapsed = (now - m_LastResizeDesiredChangeTime) >= RESIZE_PENDING_IDLE_FLUSH_SECONDS;
+            if (idleElapsed)
+            {
+                const bool skipDuplicatePending =
+                    (m_PendingResizeWidth == m_LastAppliedWindowWidth) && (m_PendingResizeHeight == m_LastAppliedWindowHeight);
+                if (!skipDuplicatePending)
+                {
+                    if (traceEnabled)
+                    {
+                        const auto opStart = Clock::now();
+                        SDL_SetWindowSize(window.getHandle(), m_PendingResizeWidth, m_PendingResizeHeight);
+                        setSizeMs += std::chrono::duration<double, std::milli>(Clock::now() - opStart).count();
+                    }
+                    else
+                    {
+                        SDL_SetWindowSize(window.getHandle(), m_PendingResizeWidth, m_PendingResizeHeight);
+                    }
+                    m_LastAppliedWindowWidth = m_PendingResizeWidth;
+                    m_LastAppliedWindowHeight = m_PendingResizeHeight;
+                }
+                m_LastResizeSizeCommitTime = now;
+                m_HasPendingResizeCommit = false;
+                sizeCommitApplied = true;
+            }
+            else
+            {
+                return;
+            }
+        }
+
+        if (sizeCommitApplied)
+        {
             // Coalesce immediate resize events to avoid flooding the event bus
             // during edge/corner drags. SDL will still emit pixel-size events,
             // so this path only provides low-latency updates for interactive drag.
@@ -704,16 +926,25 @@ void TitleBarLayer::updateWindowInteraction()
             int pixelH = 0;
             SDL_GetWindowSizeInPixels(window.getHandle(), &pixelW, &pixelH);
             constexpr float MIN_RESIZE_EVENT_INTERVAL_SECONDS = 1.0F / 120.0F;
-            const float now = Core::Application::getTime();
+            const float resizeEventNow = Core::Application::getTime();
             const bool pixelSizeChanged = (pixelW != m_LastImmediateResizePixelW) || (pixelH != m_LastImmediateResizePixelH);
-            const bool intervalElapsed = (now - m_LastImmediateResizeEventTime) >= MIN_RESIZE_EVENT_INTERVAL_SECONDS;
+            const bool intervalElapsed = (resizeEventNow - m_LastImmediateResizeEventTime) >= MIN_RESIZE_EVENT_INTERVAL_SECONDS;
             if (pixelSizeChanged && intervalElapsed)
             {
                 m_LastImmediateResizePixelW = pixelW;
                 m_LastImmediateResizePixelH = pixelH;
-                m_LastImmediateResizeEventTime = now;
+                m_LastImmediateResizeEventTime = resizeEventNow;
                 Core::WindowResizedEvent resizeEvent(pixelW, pixelH);
-                Core::Application::get().raiseEvent(resizeEvent);
+                if (traceEnabled)
+                {
+                    const auto opStart = Clock::now();
+                    Core::Application::get().raiseEvent(resizeEvent);
+                    raiseResizeEventMs += std::chrono::duration<double, std::milli>(Clock::now() - opStart).count();
+                }
+                else
+                {
+                    Core::Application::get().raiseEvent(resizeEvent);
+                }
             }
         }
     }
@@ -721,6 +952,20 @@ void TitleBarLayer::updateWindowInteraction()
 
 void TitleBarLayer::endWindowInteraction()
 {
+    if (m_CustomResizeActive && m_HasPendingResizeCommit)
+    {
+        auto& window = Core::Application::get().getWindow();
+        SDL_Window* sdlWindow = window.getHandle();
+        if (sdlWindow != nullptr)
+        {
+            SDL_SetWindowSize(sdlWindow, m_PendingResizeWidth, m_PendingResizeHeight);
+            m_LastAppliedWindowWidth = m_PendingResizeWidth;
+            m_LastAppliedWindowHeight = m_PendingResizeHeight;
+            m_LastResizeSizeCommitTime = Core::Application::getTime();
+        }
+        m_HasPendingResizeCommit = false;
+    }
+
     m_CustomDragActive = false;
     m_CustomResizeActive = false;
     m_ActiveResizeEdge = ResizeEdge::None;

--- a/src/App/TitleBarLayer.h
+++ b/src/App/TitleBarLayer.h
@@ -138,6 +138,11 @@ class TitleBarLayer : public Core::Layer
     int m_LastAppliedWindowY = 0;
     int m_LastAppliedWindowWidth = 0;
     int m_LastAppliedWindowHeight = 0;
+    bool m_HasPendingResizeCommit = false;
+    int m_PendingResizeWidth = 0;
+    int m_PendingResizeHeight = 0;
+    float m_LastResizeSizeCommitTime = 0.0F;
+    float m_LastResizeDesiredChangeTime = 0.0F;
 
     bool m_PendingDragRestore = false;
     int m_MaximizedWindowX = 0;

--- a/src/Core/Application.cpp
+++ b/src/Core/Application.cpp
@@ -23,6 +23,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #ifndef _WIN32
 #include <sys/stat.h>
@@ -62,6 +63,8 @@ constexpr int MINIMIZED_FRAME_SLEEP_MS = 200;
 constexpr float INTERACTION_REDRAW_GRACE_SECONDS = 0.35F;
 constexpr const char* RESIZE_PERF_TRACE_ENV = "TASKSMACK_TRACE_RESIZE_PERF";
 constexpr float RESIZE_PERF_TRACE_LOG_INTERVAL_SECONDS = 0.5F;
+constexpr double RESIZE_PERF_TRACE_SLOW_PHASE_THRESHOLD_MS = 250.0;
+constexpr int RESIZE_PERF_TRACE_TOP_LAYER_COUNT = 3;
 
 [[nodiscard]] bool isEnvFlagEnabled(const char* value) noexcept
 {
@@ -565,6 +568,8 @@ void Application::run()
             double postRenderMs = 0.0;
             double swapMs = 0.0;
             renderFrame(computeDeltaTime(),
+                        tracingInteraction,
+                        true,
                         tracingInteraction ? &updateMs : nullptr,
                         tracingInteraction ? &renderMs : nullptr,
                         tracingInteraction ? &postRenderMs : nullptr,
@@ -599,6 +604,8 @@ void Application::run()
             double postRenderMs = 0.0;
             double swapMs = 0.0;
             renderFrame(computeDeltaTime(),
+                        tracingInteraction,
+                        false,
                         tracingInteraction ? &updateMs : nullptr,
                         tracingInteraction ? &renderMs : nullptr,
                         tracingInteraction ? &postRenderMs : nullptr,
@@ -627,14 +634,42 @@ void Application::run()
     spdlog::info("Exiting main loop");
 }
 
-void Application::renderFrame(float deltaTime, double* updateMs, double* renderMs, double* postRenderMs, double* swapMs)
+void Application::renderFrame(float deltaTime,
+                              bool tracingInteractionFrame,
+                              bool resizeTriggeredFrame,
+                              double* updateMs,
+                              double* renderMs,
+                              double* postRenderMs,
+                              double* swapMs)
 {
     const bool tracing = (updateMs != nullptr);
+
+    struct LayerPhaseDuration
+    {
+        std::string name;
+        double durationMs = 0.0;
+    };
+
+    std::vector<LayerPhaseDuration> updateLayerDurations;
+    std::vector<LayerPhaseDuration> postLayerDurations;
+    if (tracingInteractionFrame)
+    {
+        updateLayerDurations.reserve(m_LayerStack.size());
+        postLayerDurations.reserve(m_LayerStack.size());
+    }
+
     const auto updateStart = tracing ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
     // Update all layers
     for (const auto& layer : m_LayerStack)
     {
+        const auto layerStart = tracingInteractionFrame ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
         layer->onUpdate(deltaTime);
+        if (tracingInteractionFrame)
+        {
+            const auto layerEnd = std::chrono::steady_clock::now();
+            updateLayerDurations.emplace_back(LayerPhaseDuration{
+                .name = layer->getName(), .durationMs = std::chrono::duration<double, std::milli>(layerEnd - layerStart).count()});
+        }
     }
     const auto updateEnd = tracing ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
 
@@ -648,7 +683,14 @@ void Application::renderFrame(float deltaTime, double* updateMs, double* renderM
     // Post-render (for ImGui frame end, etc.)
     for (const auto& layer : m_LayerStack)
     {
+        const auto layerStart = tracingInteractionFrame ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
         layer->onPostRender();
+        if (tracingInteractionFrame)
+        {
+            const auto layerEnd = std::chrono::steady_clock::now();
+            postLayerDurations.emplace_back(LayerPhaseDuration{
+                .name = layer->getName(), .durationMs = std::chrono::duration<double, std::milli>(layerEnd - layerStart).count()});
+        }
     }
     const auto postRenderEnd = tracing ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
 
@@ -670,6 +712,55 @@ void Application::renderFrame(float deltaTime, double* updateMs, double* renderM
     if (swapMs != nullptr)
     {
         *swapMs = std::chrono::duration<double, std::milli>(swapEnd - postRenderEnd).count();
+    }
+
+    if (tracingInteractionFrame)
+    {
+        const double measuredUpdateMs = std::chrono::duration<double, std::milli>(updateEnd - updateStart).count();
+        const double measuredPostMs = std::chrono::duration<double, std::milli>(postRenderEnd - renderEnd).count();
+        const bool slowUpdate = measuredUpdateMs >= RESIZE_PERF_TRACE_SLOW_PHASE_THRESHOLD_MS;
+        const bool slowPost = measuredPostMs >= RESIZE_PERF_TRACE_SLOW_PHASE_THRESHOLD_MS;
+
+        if (slowUpdate || slowPost)
+        {
+            const auto logTopLayers = [](const std::vector<LayerPhaseDuration>& durations, const std::string_view phase)
+            {
+                if (durations.empty())
+                {
+                    return;
+                }
+
+                std::vector<LayerPhaseDuration> sorted = durations;
+                std::ranges::sort(sorted,
+                                  [](const LayerPhaseDuration& a, const LayerPhaseDuration& b) { return a.durationMs > b.durationMs; });
+
+                const auto count = std::min<std::size_t>(static_cast<std::size_t>(RESIZE_PERF_TRACE_TOP_LAYER_COUNT), sorted.size());
+                for (std::size_t i = 0; i < count; ++i)
+                {
+                    spdlog::info("ResizePerfSlowLayer[{}]: rank={} layer='{}' duration={:.3f} ms",
+                                 phase,
+                                 i + 1,
+                                 sorted[i].name,
+                                 sorted[i].durationMs);
+                }
+            };
+
+            spdlog::info("ResizePerfSlowFrame: resizeFrame={} update={:.3f} ms render={:.3f} ms post={:.3f} ms swap={:.3f} ms",
+                         resizeTriggeredFrame,
+                         measuredUpdateMs,
+                         std::chrono::duration<double, std::milli>(renderEnd - updateEnd).count(),
+                         measuredPostMs,
+                         std::chrono::duration<double, std::milli>(swapEnd - postRenderEnd).count());
+
+            if (slowUpdate)
+            {
+                logTopLayers(updateLayerDurations, "update");
+            }
+            if (slowPost)
+            {
+                logTopLayers(postLayerDurations, "post");
+            }
+        }
     }
 }
 

--- a/src/Core/Application.h
+++ b/src/Core/Application.h
@@ -89,8 +89,13 @@ class Application
 
     /// Run one update+render+swapBuffers cycle. Extracted so the main loop and
     /// the immediate-repaint-on-resize path share identical rendering logic.
-    void renderFrame(
-        float deltaTime, double* updateMs = nullptr, double* renderMs = nullptr, double* postRenderMs = nullptr, double* swapMs = nullptr);
+    void renderFrame(float deltaTime,
+                     bool tracingInteractionFrame,
+                     bool resizeTriggeredFrame,
+                     double* updateMs = nullptr,
+                     double* renderMs = nullptr,
+                     double* postRenderMs = nullptr,
+                     double* swapMs = nullptr);
 
     // Global application instance (managed via setInstance)
     // Note: Using std::unique_ptr allows main() to control initialization order

--- a/src/Domain/ProcessModel.cpp
+++ b/src/Domain/ProcessModel.cpp
@@ -105,191 +105,270 @@ void ProcessModel::updateFromCounters(const std::vector<Platform::ProcessCounter
 
 void ProcessModel::computeSnapshots(const std::vector<Platform::ProcessCounters>& counters, std::uint64_t totalCpuTime)
 {
-    std::unique_lock lock(m_Mutex); // NOLINT(misc-const-correctness) - lock guard pattern
-
-    const auto currentSampleTime = std::chrono::steady_clock::now();
-    if (!m_HasStartTime)
+    struct CachedGpuSnapshotFields
     {
-        m_StartTime = currentSampleTime;
-        m_HasStartTime = true;
-    }
-    double elapsedSeconds = 0.0;
-    std::uint64_t timeDeltaUs = 0;
-    if (m_HasPrevSampleTime)
-    {
-        const auto delta = currentSampleTime - m_PrevSampleTime;
-        elapsedSeconds = std::chrono::duration<double>(delta).count();
-        timeDeltaUs = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(delta).count());
+        double gpuUtilPercent = 0.0;
+        std::uint64_t gpuMemoryBytes = 0;
+        double gpuEncoderUtil = 0.0;
+        double gpuDecoderUtil = 0.0;
+        std::vector<std::string> gpuEngines;
+        std::vector<ProcessSnapshot::PerGPUUsage> perGpuUsage;
+        std::string gpuDevices;
+    };
 
-        // Suppress delta-based rates for implausibly short intervals. The seed call
-        // in onAttach() fires just before the BackgroundSampler thread starts; the
-        // thread's first callback may arrive only a few ms later (thread-startup
-        // latency), making elapsedSeconds tiny and producing enormous byte/sec and
-        // pageFaults/sec spikes. Any elapsed time below half the minimum configurable
-        // refresh interval is treated as "no previous data" for rate purposes.
-        // Note: we zero out elapsed/timeDelta here so computeSnapshot() emits zero
-        // rates; we do NOT prevent the history push below (handle counts etc. don't
-        // depend on elapsed time and must still be recorded every cycle).
-        constexpr double MIN_ELAPSED_FOR_RATES = static_cast<double>(Sampling::REFRESH_INTERVAL_MIN_MS) / 2000.0; // half of 100ms = 0.05s
-        if (elapsedSeconds < MIN_ELAPSED_FOR_RATES)
-        {
-            elapsedSeconds = 0.0;
-            timeDeltaUs = 0;
-        }
-    }
-    const bool hasElapsedForHistory = m_HasPrevSampleTime;
-    m_PrevSampleTime = currentSampleTime;
-    m_HasPrevSampleTime = true;
+    constexpr auto INTERACTION_GPU_MERGE_MIN_INTERVAL = std::chrono::milliseconds(1500);
 
-    std::uint64_t totalCpuDelta = 0;
-    if (m_PrevTotalCpuTime > 0 && totalCpuTime > m_PrevTotalCpuTime)
-    {
-        totalCpuDelta = totalCpuTime - m_PrevTotalCpuTime;
-    }
-
-    // Steal capacity from the previous snapshot vector to avoid a malloc each refresh.
-    // m_Snapshots is already under the write lock so this is safe.
     std::vector<ProcessSnapshot> newSnapshots;
-    std::swap(newSnapshots, m_Snapshots); // steal old allocation
-    newSnapshots.clear();                 // drop elements, keep capacity
-    newSnapshots.reserve(counters.size());
+    std::unordered_map<std::int32_t, CachedGpuSnapshotFields> cachedGpuByPid;
+    std::shared_ptr<GPUModel> gpuModel;
+    bool shouldMergeGpuData = false;
 
-    // Bump the generation counter once per refresh.  At the end of the loop we
-    // prune any PerProcessState entry that was NOT touched this refresh (i.e.
-    // its generation is still the previous value) in a single erase_if pass.
-    ++m_CurrentGeneration;
-
-    double aggNetSent = 0.0;
-    double aggNetRecv = 0.0;
-    double aggPageFaults = 0.0;
-    double aggThreads = 0.0;
-    double aggHandles = 0.0;
-    double aggPower = 0.0;
-
-    for (const auto& current : counters)
     {
-        const std::uint64_t key = makeUniqueKey(current.pid, current.startTimeTicks);
+        std::unique_lock lock(m_Mutex); // NOLINT(misc-const-correctness) - lock guard pattern
 
-        // Single map operation replaces three separate find/insert calls for
-        // m_PrevCounters, m_NetworkBaselines, and m_PeakRss.
-        // try_emplace returns {iterator, inserted}: inserted==true means a brand-new
-        // process; inserted==false means we have state from the previous refresh.
-        auto [it, inserted] = m_PerProcessState.try_emplace(key);
-        PerProcessState& state = it->second;
-        state.generation = m_CurrentGeneration;
-
-        // --- previous CPU counters (for delta calculation) ---
-        const Platform::ProcessCounters* previous = inserted ? nullptr : &state.counters;
-
-        // --- network baseline ---
-        // For new processes: initialise to current counters so the very first rate
-        // is 0 rather than a spike from pre-existing cumulative TCP counters.
-        // For existing processes: keep the original baseline untouched.
-        if (inserted)
+        const auto currentSampleTime = std::chrono::steady_clock::now();
+        const bool interactionActive = m_InteractionActive.load(std::memory_order_acquire);
+        if (!m_HasStartTime)
         {
-            state.networkBaseline.netSentBytes = current.netSentBytes;
-            state.networkBaseline.netReceivedBytes = current.netReceivedBytes;
-            state.networkBaseline.firstSeenTime = currentSampleTime;
+            m_StartTime = currentSampleTime;
+            m_HasStartTime = true;
         }
-
-        // --- peak RSS ---
-        if (m_Capabilities.hasPeakRss && current.peakRssBytes > 0)
+        double elapsedSeconds = 0.0;
+        std::uint64_t timeDeltaUs = 0;
+        if (m_HasPrevSampleTime)
         {
-            state.peakRss = current.peakRssBytes;
-        }
-        else
-        {
-            state.peakRss = inserted ? current.rssBytes : std::max(state.peakRss, current.rssBytes);
-        }
+            const auto delta = currentSampleTime - m_PrevSampleTime;
+            elapsedSeconds = std::chrono::duration<double>(delta).count();
+            timeDeltaUs = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(delta).count());
 
-        auto snapshot =
-            computeSnapshot(current, previous, totalCpuDelta, m_SystemTotalMemory, m_TicksPerSecond, elapsedSeconds, timeDeltaUs);
-        snapshot.peakMemoryBytes = state.peakRss;
-
-        // =======================================================================
-        // Network Rate Calculation (Baseline Approach)
-        // =======================================================================
-        // Formula: rate = (currentCounters - baselineCounters) / timeSinceFirstSeen
-        //
-        // This gives us average bytes/sec since we started monitoring this process.
-        // See ProcessModel.h for detailed explanation of why we use this approach
-        // instead of delta-based rates (TL;DR: Windows TCP EStats connection churn).
-        //
-        // We require a minimum time elapsed (0.5s) before computing rates to avoid
-        // division by tiny time values on first sample causing huge rate spikes.
-        // We also apply a sanity check ceiling (100 Gbps) as a safety net.
-        //
-        // Note: A more accurate approach (ETW, eBPF, etc.) could enable instantaneous
-        // rate calculation similar to I/O rates below. See ProcessModel.h for details.
-        // =======================================================================
-        constexpr double MIN_TIME_FOR_RATE = 0.5;          // seconds
-        constexpr double MAX_SANE_RATE = 12'500'000'000.0; // 100 Gbps in bytes/sec
-        const double timeSinceFirstSeen = std::chrono::duration<double>(currentSampleTime - state.networkBaseline.firstSeenTime).count();
-        if (timeSinceFirstSeen >= MIN_TIME_FOR_RATE)
-        {
-            // Only compute rate if current >= baseline (counter should never decrease
-            // for the same process, but handle it gracefully if it does)
-            if (current.netSentBytes >= state.networkBaseline.netSentBytes)
+            // Suppress delta-based rates for implausibly short intervals. The seed call
+            // in onAttach() fires just before the BackgroundSampler thread starts; the
+            // thread's first callback may arrive only a few ms later (thread-startup
+            // latency), making elapsedSeconds tiny and producing enormous byte/sec and
+            // pageFaults/sec spikes. Any elapsed time below half the minimum configurable
+            // refresh interval is treated as "no previous data" for rate purposes.
+            // Note: we zero out elapsed/timeDelta here so computeSnapshot() emits zero
+            // rates; we do NOT prevent the history push below (handle counts etc. don't
+            // depend on elapsed time and must still be recorded every cycle).
+            constexpr double MIN_ELAPSED_FOR_RATES = static_cast<double>(Sampling::REFRESH_INTERVAL_MIN_MS) / 2000.0;
+            if (elapsedSeconds < MIN_ELAPSED_FOR_RATES)
             {
-                const std::uint64_t sentDelta = current.netSentBytes - state.networkBaseline.netSentBytes;
-                const double rate = Numeric::toDouble(sentDelta) / timeSinceFirstSeen;
-                snapshot.netSentBytesPerSec = (rate <= MAX_SANE_RATE) ? rate : 0.0;
-            }
-            if (current.netReceivedBytes >= state.networkBaseline.netReceivedBytes)
-            {
-                const std::uint64_t recvDelta = current.netReceivedBytes - state.networkBaseline.netReceivedBytes;
-                const double rate = Numeric::toDouble(recvDelta) / timeSinceFirstSeen;
-                snapshot.netReceivedBytesPerSec = (rate <= MAX_SANE_RATE) ? rate : 0.0;
+                elapsedSeconds = 0.0;
+                timeDeltaUs = 0;
             }
         }
+        const bool hasElapsedForHistory = m_HasPrevSampleTime;
+        m_PrevSampleTime = currentSampleTime;
+        m_HasPrevSampleTime = true;
 
-        newSnapshots.push_back(std::move(snapshot));
+        std::uint64_t totalCpuDelta = 0;
+        if (m_PrevTotalCpuTime > 0 && totalCpuTime > m_PrevTotalCpuTime)
+        {
+            totalCpuDelta = totalCpuTime - m_PrevTotalCpuTime;
+        }
 
-        const ProcessSnapshot& snapRef = newSnapshots.back();
-        aggNetSent += snapRef.netSentBytesPerSec;
-        aggNetRecv += snapRef.netReceivedBytesPerSec;
-        aggPageFaults += snapRef.pageFaultsPerSec;
-        aggThreads += static_cast<double>(snapRef.threadCount);
-        aggHandles += static_cast<double>(snapRef.handleCount);
-        aggPower += snapRef.powerWatts;
+        // Steal capacity from the previous snapshot vector to avoid a malloc each refresh.
+        // m_Snapshots is already under the write lock so this is safe.
+        std::swap(newSnapshots, m_Snapshots); // steal old allocation
+        if (interactionActive)
+        {
+            cachedGpuByPid.reserve(newSnapshots.size());
+            for (const auto& previousSnapshot : newSnapshots)
+            {
+                if ((previousSnapshot.gpuMemoryBytes == 0) && (previousSnapshot.gpuUtilPercent <= 0.0) &&
+                    previousSnapshot.gpuDevices.empty() && previousSnapshot.perGpuUsage.empty())
+                {
+                    continue;
+                }
 
-        // Store current counters so next refresh can compute deltas.
-        state.counters = current;
+                cachedGpuByPid.emplace(previousSnapshot.pid,
+                                       CachedGpuSnapshotFields{previousSnapshot.gpuUtilPercent,
+                                                               previousSnapshot.gpuMemoryBytes,
+                                                               previousSnapshot.gpuEncoderUtil,
+                                                               previousSnapshot.gpuDecoderUtil,
+                                                               previousSnapshot.gpuEngines,
+                                                               previousSnapshot.perGpuUsage,
+                                                               previousSnapshot.gpuDevices});
+            }
+        }
+        newSnapshots.clear(); // drop elements, keep capacity
+        newSnapshots.reserve(counters.size());
+
+        // Bump the generation counter once per refresh.  At the end of the loop we
+        // prune any PerProcessState entry that was NOT touched this refresh (i.e.
+        // its generation is still the previous value) in a single erase_if pass.
+        ++m_CurrentGeneration;
+
+        double aggNetSent = 0.0;
+        double aggNetRecv = 0.0;
+        double aggPageFaults = 0.0;
+        double aggThreads = 0.0;
+        double aggHandles = 0.0;
+        double aggPower = 0.0;
+
+        for (const auto& current : counters)
+        {
+            const std::uint64_t key = makeUniqueKey(current.pid, current.startTimeTicks);
+
+            // Single map operation replaces three separate find/insert calls for
+            // m_PrevCounters, m_NetworkBaselines, and m_PeakRss.
+            // try_emplace returns {iterator, inserted}: inserted==true means a brand-new
+            // process; inserted==false means we have state from the previous refresh.
+            auto [it, inserted] = m_PerProcessState.try_emplace(key);
+            PerProcessState& state = it->second;
+            state.generation = m_CurrentGeneration;
+
+            // --- previous CPU counters (for delta calculation) ---
+            const Platform::ProcessCounters* previous = inserted ? nullptr : &state.counters;
+
+            // --- network baseline ---
+            // For new processes: initialise to current counters so the very first rate
+            // is 0 rather than a spike from pre-existing cumulative TCP counters.
+            // For existing processes: keep the original baseline untouched.
+            if (inserted)
+            {
+                state.networkBaseline.netSentBytes = current.netSentBytes;
+                state.networkBaseline.netReceivedBytes = current.netReceivedBytes;
+                state.networkBaseline.firstSeenTime = currentSampleTime;
+            }
+
+            // --- peak RSS ---
+            if (m_Capabilities.hasPeakRss && current.peakRssBytes > 0)
+            {
+                state.peakRss = current.peakRssBytes;
+            }
+            else
+            {
+                state.peakRss = inserted ? current.rssBytes : std::max(state.peakRss, current.rssBytes);
+            }
+
+            auto snapshot =
+                computeSnapshot(current, previous, totalCpuDelta, m_SystemTotalMemory, m_TicksPerSecond, elapsedSeconds, timeDeltaUs);
+            snapshot.peakMemoryBytes = state.peakRss;
+
+            // =======================================================================
+            // Network Rate Calculation (Baseline Approach)
+            // =======================================================================
+            // Formula: rate = (currentCounters - baselineCounters) / timeSinceFirstSeen
+            //
+            // This gives us average bytes/sec since we started monitoring this process.
+            // See ProcessModel.h for detailed explanation of why we use this approach
+            // instead of delta-based rates (TL;DR: Windows TCP EStats connection churn).
+            //
+            // We require a minimum time elapsed (0.5s) before computing rates to avoid
+            // division by tiny time values on first sample causing huge rate spikes.
+            // We also apply a sanity check ceiling (100 Gbps) as a safety net.
+            //
+            // Note: A more accurate approach (ETW, eBPF, etc.) could enable instantaneous
+            // rate calculation similar to I/O rates below. See ProcessModel.h for details.
+            // =======================================================================
+            constexpr double MIN_TIME_FOR_RATE = 0.5;          // seconds
+            constexpr double MAX_SANE_RATE = 12'500'000'000.0; // 100 Gbps in bytes/sec
+            const double timeSinceFirstSeen =
+                std::chrono::duration<double>(currentSampleTime - state.networkBaseline.firstSeenTime).count();
+            if (timeSinceFirstSeen >= MIN_TIME_FOR_RATE)
+            {
+                // Only compute rate if current >= baseline (counter should never decrease
+                // for the same process, but handle it gracefully if it does)
+                if (current.netSentBytes >= state.networkBaseline.netSentBytes)
+                {
+                    const std::uint64_t sentDelta = current.netSentBytes - state.networkBaseline.netSentBytes;
+                    const double rate = Numeric::toDouble(sentDelta) / timeSinceFirstSeen;
+                    snapshot.netSentBytesPerSec = (rate <= MAX_SANE_RATE) ? rate : 0.0;
+                }
+                if (current.netReceivedBytes >= state.networkBaseline.netReceivedBytes)
+                {
+                    const std::uint64_t recvDelta = current.netReceivedBytes - state.networkBaseline.netReceivedBytes;
+                    const double rate = Numeric::toDouble(recvDelta) / timeSinceFirstSeen;
+                    snapshot.netReceivedBytesPerSec = (rate <= MAX_SANE_RATE) ? rate : 0.0;
+                }
+            }
+
+            newSnapshots.push_back(std::move(snapshot));
+
+            const ProcessSnapshot& snapRef = newSnapshots.back();
+            aggNetSent += snapRef.netSentBytesPerSec;
+            aggNetRecv += snapRef.netReceivedBytesPerSec;
+            aggPageFaults += snapRef.pageFaultsPerSec;
+            aggThreads += static_cast<double>(snapRef.threadCount);
+            aggHandles += static_cast<double>(snapRef.handleCount);
+            aggPower += snapRef.powerWatts;
+
+            // Store current counters so next refresh can compute deltas.
+            state.counters = current;
+        }
+
+        // Prune dead processes: a single erase_if on one map instead of the previous
+        // two separate erase_if calls on m_PrevCounters and m_PeakRss plus the full
+        // rebuild of m_NetworkBaselines.
+        std::erase_if(m_PerProcessState, [gen = m_CurrentGeneration](const auto& entry) { return entry.second.generation != gen; });
+
+        m_PrevTotalCpuTime = totalCpuTime;
+        gpuModel = m_GPUModel;
+        if (gpuModel != nullptr)
+        {
+            if (!interactionActive)
+            {
+                shouldMergeGpuData = true;
+            }
+            else if (!m_HasLastGpuMergeTime || ((currentSampleTime - m_LastGpuMergeTime) >= INTERACTION_GPU_MERGE_MIN_INTERVAL))
+            {
+                shouldMergeGpuData = true;
+            }
+        }
+
+        if (hasElapsedForHistory)
+        {
+            // Use absolute time (since epoch) to match SystemModel's timestamp format
+            const double nowSeconds = std::chrono::duration<double>(currentSampleTime.time_since_epoch()).count();
+            m_Timestamps.push_back(nowSeconds);
+            m_SystemNetSentHistory.push_back(aggNetSent);
+            m_SystemNetRecvHistory.push_back(aggNetRecv);
+            m_SystemPageFaultsHistory.push_back(aggPageFaults);
+            m_SystemThreadCountHistory.push_back(aggThreads);
+            m_SystemHandleCountHistory.push_back(aggHandles);
+            m_SystemPowerHistory.push_back(aggPower);
+            trimHistory();
+        }
     }
 
-    m_Snapshots = std::move(newSnapshots);
-    ++m_SnapshotVersion;
-
-    // Merge per-process GPU data if GPUModel is available. Must happen before
-    // publishing the new version so that the UI never observes a version whose
-    // snapshots are still missing GPU fields.
-    if (m_GPUModel != nullptr)
+    // GPU aggregation can be expensive (PDH queries/string work). Keep it outside
+    // the ProcessModel write lock so UI readers are not blocked during resize.
+    if (shouldMergeGpuData && (gpuModel != nullptr))
     {
-        mergeGPUData();
+        mergeGPUData(newSnapshots, gpuModel);
+    }
+    else if (!cachedGpuByPid.empty())
+    {
+        for (auto& snapshot : newSnapshots)
+        {
+            const auto it = cachedGpuByPid.find(snapshot.pid);
+            if (it == cachedGpuByPid.end())
+            {
+                continue;
+            }
+
+            const CachedGpuSnapshotFields& cached = it->second;
+            snapshot.gpuUtilPercent = cached.gpuUtilPercent;
+            snapshot.gpuMemoryBytes = cached.gpuMemoryBytes;
+            snapshot.gpuEncoderUtil = cached.gpuEncoderUtil;
+            snapshot.gpuDecoderUtil = cached.gpuDecoderUtil;
+            snapshot.gpuEngines = cached.gpuEngines;
+            snapshot.perGpuUsage = cached.perGpuUsage;
+            snapshot.gpuDevices = cached.gpuDevices;
+        }
     }
 
-    // Publish only after all snapshot mutations (including GPU merge) are done.
-    m_PublishedSnapshotVersion.store(m_SnapshotVersion, std::memory_order_release);
-
-    // Prune dead processes: a single erase_if on one map instead of the previous
-    // two separate erase_if calls on m_PrevCounters and m_PeakRss plus the full
-    // rebuild of m_NetworkBaselines.
-    std::erase_if(m_PerProcessState, [gen = m_CurrentGeneration](const auto& entry) { return entry.second.generation != gen; });
-
-    m_PrevTotalCpuTime = totalCpuTime;
-
-    if (hasElapsedForHistory)
     {
-        // Use absolute time (since epoch) to match SystemModel's timestamp format
-        const double nowSeconds = std::chrono::duration<double>(currentSampleTime.time_since_epoch()).count();
-        m_Timestamps.push_back(nowSeconds);
-        m_SystemNetSentHistory.push_back(aggNetSent);
-        m_SystemNetRecvHistory.push_back(aggNetRecv);
-        m_SystemPageFaultsHistory.push_back(aggPageFaults);
-        m_SystemThreadCountHistory.push_back(aggThreads);
-        m_SystemHandleCountHistory.push_back(aggHandles);
-        m_SystemPowerHistory.push_back(aggPower);
-        trimHistory();
+        std::unique_lock lock(m_Mutex); // NOLINT(misc-const-correctness) - lock guard pattern
+        m_Snapshots = std::move(newSnapshots);
+        ++m_SnapshotVersion;
+        m_PublishedSnapshotVersion.store(m_SnapshotVersion, std::memory_order_release);
+        if (shouldMergeGpuData)
+        {
+            m_LastGpuMergeTime = std::chrono::steady_clock::now();
+            m_HasLastGpuMergeTime = true;
+        }
     }
 }
 
@@ -393,10 +472,20 @@ void ProcessModel::setGPUModel(std::shared_ptr<GPUModel> gpuModel)
     m_GPUModel = std::move(gpuModel);
 }
 
-void ProcessModel::mergeGPUData()
+void ProcessModel::setInteractionActive(const bool active) noexcept
 {
+    m_InteractionActive.store(active, std::memory_order_release);
+}
+
+void ProcessModel::mergeGPUData(std::vector<ProcessSnapshot>& snapshots, const std::shared_ptr<GPUModel>& gpuModel)
+{
+    if (gpuModel == nullptr)
+    {
+        return;
+    }
+
     // Query per-process GPU counters from GPUModel
-    auto gpuCounters = m_GPUModel->readProcessGPUCounters();
+    auto gpuCounters = gpuModel->readProcessGPUCounters();
     if (gpuCounters.empty())
     {
         return;
@@ -406,8 +495,7 @@ void ProcessModel::mergeGPUData()
     // PDH returns LUID-based IDs (e.g., "GPU_0x00000000_0x0000F78E")
     // DXGI provides both index-based IDs ("GPU0") and LUID-based IDs
     std::unordered_map<std::string, std::string> gpuIdToName;
-    auto gpuSnaps = m_GPUModel->snapshots();
-    spdlog::debug("ProcessModel::mergeGPUData: Got {} GPU snapshots for name lookup", gpuSnaps.size());
+    auto gpuSnaps = gpuModel->snapshots();
     for (const auto& gpuSnap : gpuSnaps)
     {
         // Map both ID formats to the same name
@@ -416,7 +504,6 @@ void ProcessModel::mergeGPUData()
         {
             gpuIdToName[gpuSnap.luidId] = gpuSnap.name;
         }
-        spdlog::debug("ProcessModel::mergeGPUData: GPU ID '{}' / LUID '{}' -> name '{}'", gpuSnap.gpuId, gpuSnap.luidId, gpuSnap.name);
     }
 
     // Build a lookup map: PID -> GPU counters (aggregated across GPUs)
@@ -432,12 +519,6 @@ void ProcessModel::mergeGPUData()
         std::vector<std::string> gpuNames; // Friendly names instead of UUIDs
     };
     std::unordered_map<std::int32_t, AggregatedGPU> pidToGPU;
-
-    // Log the first counter's GPU ID for debugging
-    if (!gpuCounters.empty())
-    {
-        spdlog::debug("ProcessModel::mergeGPUData: First per-process counter gpuId='{}'", gpuCounters[0].gpuId);
-    }
 
     for (const auto& gc : gpuCounters)
     {
@@ -483,7 +564,7 @@ void ProcessModel::mergeGPUData()
 
     // Merge into snapshots
     int mergedCount = 0;
-    for (auto& snapshot : m_Snapshots)
+    for (auto& snapshot : snapshots)
     {
         auto it = pidToGPU.find(snapshot.pid);
         if (it != pidToGPU.end())
@@ -521,19 +602,10 @@ void ProcessModel::mergeGPUData()
                 }
             }
             snapshot.gpuDevices = std::move(gpuDevices);
-
-            // Log GPU-using processes for debugging
-            spdlog::debug("ProcessModel: PID {} ({}) using GPU: {:.1f}%, {} bytes, devices='{}', engines={}",
-                          snapshot.pid,
-                          snapshot.name,
-                          snapshot.gpuUtilPercent,
-                          snapshot.gpuMemoryBytes,
-                          snapshot.gpuDevices,
-                          snapshot.gpuEngines.size());
         }
     }
 
-    spdlog::debug("ProcessModel: Merged GPU data for {} processes", mergedCount);
+    spdlog::debug("ProcessModel::mergeGPUData: merged GPU data for {} processes", mergedCount);
 }
 
 ProcessSnapshot ProcessModel::computeSnapshot(const Platform::ProcessCounters& current,

--- a/src/Domain/ProcessModel.cpp
+++ b/src/Domain/ProcessModel.cpp
@@ -119,7 +119,7 @@ void ProcessModel::computeSnapshots(const std::vector<Platform::ProcessCounters>
     constexpr auto INTERACTION_GPU_MERGE_MIN_INTERVAL = std::chrono::milliseconds(1500);
 
     std::vector<ProcessSnapshot> newSnapshots;
-    std::unordered_map<std::int32_t, CachedGpuSnapshotFields> cachedGpuByPid;
+    std::unordered_map<std::uint64_t, CachedGpuSnapshotFields> cachedGpuByUniqueKey;
     std::shared_ptr<GPUModel> gpuModel;
     bool shouldMergeGpuData = false;
 
@@ -167,13 +167,13 @@ void ProcessModel::computeSnapshots(const std::vector<Platform::ProcessCounters>
             totalCpuDelta = totalCpuTime - m_PrevTotalCpuTime;
         }
 
-        // Steal capacity from the previous snapshot vector to avoid a malloc each refresh.
-        // m_Snapshots is already under the write lock so this is safe.
-        std::swap(newSnapshots, m_Snapshots); // steal old allocation
+        // Keep m_Snapshots published and readable until the replacement snapshot vector
+        // is fully prepared and ready to publish.
+        newSnapshots.reserve(std::max(counters.size(), m_Snapshots.size()));
         if (interactionActive)
         {
-            cachedGpuByPid.reserve(newSnapshots.size());
-            for (const auto& previousSnapshot : newSnapshots)
+            cachedGpuByUniqueKey.reserve(m_Snapshots.size());
+            for (const auto& previousSnapshot : m_Snapshots)
             {
                 if ((previousSnapshot.gpuMemoryBytes == 0) && (previousSnapshot.gpuUtilPercent <= 0.0) &&
                     previousSnapshot.gpuDevices.empty() && previousSnapshot.perGpuUsage.empty())
@@ -181,18 +181,17 @@ void ProcessModel::computeSnapshots(const std::vector<Platform::ProcessCounters>
                     continue;
                 }
 
-                cachedGpuByPid.emplace(previousSnapshot.pid,
-                                       CachedGpuSnapshotFields{previousSnapshot.gpuUtilPercent,
-                                                               previousSnapshot.gpuMemoryBytes,
-                                                               previousSnapshot.gpuEncoderUtil,
-                                                               previousSnapshot.gpuDecoderUtil,
-                                                               previousSnapshot.gpuEngines,
-                                                               previousSnapshot.perGpuUsage,
-                                                               previousSnapshot.gpuDevices});
+                cachedGpuByUniqueKey.emplace(previousSnapshot.uniqueKey,
+                                             CachedGpuSnapshotFields{previousSnapshot.gpuUtilPercent,
+                                                                     previousSnapshot.gpuMemoryBytes,
+                                                                     previousSnapshot.gpuEncoderUtil,
+                                                                     previousSnapshot.gpuDecoderUtil,
+                                                                     previousSnapshot.gpuEngines,
+                                                                     previousSnapshot.perGpuUsage,
+                                                                     previousSnapshot.gpuDevices});
             }
         }
-        newSnapshots.clear(); // drop elements, keep capacity
-        newSnapshots.reserve(counters.size());
+        newSnapshots.clear();
 
         // Bump the generation counter once per refresh.  At the end of the loop we
         // prune any PerProcessState entry that was NOT touched this refresh (i.e.
@@ -338,12 +337,12 @@ void ProcessModel::computeSnapshots(const std::vector<Platform::ProcessCounters>
     {
         mergeGPUData(newSnapshots, gpuModel);
     }
-    else if (!cachedGpuByPid.empty())
+    else if (!cachedGpuByUniqueKey.empty())
     {
         for (auto& snapshot : newSnapshots)
         {
-            const auto it = cachedGpuByPid.find(snapshot.pid);
-            if (it == cachedGpuByPid.end())
+            const auto it = cachedGpuByUniqueKey.find(snapshot.uniqueKey);
+            if (it == cachedGpuByUniqueKey.end())
             {
                 continue;
             }

--- a/src/Domain/ProcessModel.h
+++ b/src/Domain/ProcessModel.h
@@ -78,6 +78,10 @@ class ProcessModel
     /// When set, refresh() automatically queries GPU counters and merges them.
     void setGPUModel(std::shared_ptr<GPUModel> gpuModel);
 
+    /// Hint whether interactive resize/move redraw is currently active.
+    /// Allows throttling expensive GPU merge work during interactions.
+    void setInteractionActive(bool active) noexcept;
+
   private:
     std::unique_ptr<Platform::IProcessProbe> m_Probe;
     std::shared_ptr<GPUModel> m_GPUModel; // For per-process GPU data
@@ -162,6 +166,9 @@ class ProcessModel
     std::vector<ProcessSnapshot> m_Snapshots;
     std::uint64_t m_SnapshotVersion = 0;
     std::atomic<std::uint64_t> m_PublishedSnapshotVersion{0};
+    std::atomic<bool> m_InteractionActive{false};
+    std::chrono::steady_clock::time_point m_LastGpuMergeTime{};
+    bool m_HasLastGpuMergeTime = false;
 
     // Thread safety
     mutable std::shared_mutex m_Mutex;
@@ -169,7 +176,7 @@ class ProcessModel
     // Helpers
     void computeSnapshots(const std::vector<Platform::ProcessCounters>& counters, std::uint64_t totalCpuTime);
 
-    void mergeGPUData(); // Merge GPU counters from m_GPUModel into m_Snapshots
+    static void mergeGPUData(std::vector<ProcessSnapshot>& snapshots, const std::shared_ptr<GPUModel>& gpuModel);
 
     [[nodiscard]] static ProcessSnapshot computeSnapshot(const Platform::ProcessCounters& current,
                                                          const Platform::ProcessCounters* previous,


### PR DESCRIPTION
## Summary
This PR addresses severe Windows resize stalls by combining instrumentation-driven diagnosis with targeted mitigation in the custom title bar resize path.

Key changes:
- Added slow-frame layer attribution for resize tracing in the application loop.
- Added TitleBar sub-step timing to isolate blocking operations during interactive resize.
- Confirmed `SDL_SetWindowSize` in `TitleBarLayer` custom resize path as dominant blocker.
- Implemented coalesced resize commits during active edge/corner resize.
- Added pending-size flush on interaction end, duplicate-size skip, and idle flush behavior.
- Kept process/system-side optimizations from the profiling branch (ProcessModel merge/throttle, SystemMetrics GPU sampler off-main-thread, interaction hysteresis wiring).

## Why
Resize traces showed multi-second `update` spikes. New instrumentation demonstrated these spikes were overwhelmingly attributable to `TitleBarLayer::updateWindowInteraction`, specifically `SDL_SetWindowSize` calls made at high frequency during custom resize.

## Validation
Built and profiled with `TASKSMACK_TRACE_RESIZE_PERF=1` on `win-profile`.

Observed progression:
- Before titlebar mitigation: frequent multi-second update outliers, many `>=1000ms` events.
- After first coalescing pass: major reduction but occasional rare outlier remained.
- After duplicate-skip + idle-flush refinement: latest run showed:
  - `ResizePerfTitleBarSlowUpdate` count: `0`
  - `interaction-progress` update stats: `count=27`, `max=13.348ms`, `p95=12.040ms`, `ge1000=0`

## Notes for reviewers
- Instrumentation logs are emitted only when resize perf tracing is enabled (`TASKSMACK_TRACE_RESIZE_PERF`).
- Mitigation preserves final size correctness by flushing pending resize on interaction end.

## Files changed
- `src/Core/Application.h`
- `src/Core/Application.cpp`
- `src/App/TitleBarLayer.h`
- `src/App/TitleBarLayer.cpp`
- `src/App/Panels/ProcessesPanel.cpp`
- `src/App/Panels/SystemMetricsPanel.h`
- `src/App/Panels/SystemMetricsPanel.cpp`
- `src/Domain/ProcessModel.h`
- `src/Domain/ProcessModel.cpp`

## Verification run in this branch
- `cmake --build --preset win-profile`
