### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(POLICY CMP0069)
 endif()
 
 
-project(TaskSmack VERSION 0.7.1 LANGUAGES C CXX)
+project(TaskSmack VERSION 0.8.0 LANGUAGES C CXX)
 
 # Windows: Configure MSVC runtime library linkage for Clang
 if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
## Summary
- Bump TaskSmack to version 0.8.0 on a branch off `main`.

## Release flow
- Merge this PR into `main` first.
- Then create exactly one strict semver tag `v0.8.0` from the resulting `main` commit so the changelog workflow runs once.

## Notes
- `CHANGELOG.md` is intentionally left for the tag-triggered workflow.
