### PR TITLE
Optimize profiling workflow and process hot paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,15 @@
 *.profdata
 /profiles/
 coverage-output.txt
+/perf-data/*.etl
+/perf-data/*.etl.NGENPDB/
+/perf-data/etw-*.log
+/perf-data/etw-*.txt
+/perf-data/etw-*.json
+/perf-data/pgo-hot*.txt
+/perf-data/pgo-hot*.json
+/perf-data/SymCache/
+*.pdb
 
 # Test results and sanitizer outputs
 test-results.xml

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -163,7 +163,7 @@
             "inherits": "linux-base",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer",
+                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer",
                 "TASKSMACK_BUILD_BENCHMARKS": "ON"
             }
         },
@@ -279,7 +279,7 @@
             "binaryDir": "${sourceDir}/build/win-profile",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer",
+                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer",
                 "TASKSMACK_BUILD_BENCHMARKS": "ON"
             }
         },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -535,14 +535,35 @@ xcrun xctrace record --template 'Time Profiler' --launch -- ./build/profile/bin/
 ### Windows (ETW/VTune)
 
 ```powershell
-# Build with profiling preset
-cmake --preset win-profile
-cmake --build --preset win-profile
+# Default ETW capture uses the optimized build for production-like timings
+cmake --preset win-optimized
+cmake --build --preset win-optimized
 
-# Use Windows Performance Analyzer (WPA) or Intel VTune
-# For VTune:
+# Capture a real app trace (self-elevates for WPR, defaults to win-optimized)
+pwsh tools/profile-etw.ps1 app
+
+# Capture a targeted benchmark trace (defaults to win-benchmark)
+pwsh tools/profile-etw.ps1 bench -BenchmarkFilter 'BM_(ProcessProbe_Enumerate|ProcessModel_Refresh|SystemProbe_Sample|SystemModel_Refresh|GPUProbe_ReadCounters|GPUModel_Refresh)$'
+
+# Use win-profile explicitly when you want a frame-pointer/symbol-rich follow-up build
+pwsh tools/profile-etw.ps1 app -Preset win-profile
+
+# Analyze an ETW trace and print top TaskSmack modules/functions
+pwsh tools/analyze-etw.ps1 -TracePath .\perf-data\etw-app-<timestamp>.etl
+
+# Optional VTune workflow if installed
 vtune -collect hotspots -- .\build\win-profile\bin\TaskSmack.exe
 ```
+
+`tools/profile-etw.ps1` writes traces and logs under `perf-data/` and stops the trace
+automatically when the app exits. `tools/analyze-etw.ps1` exports both module-level and
+function-level `xperf` reports, then prints the top TaskSmack-specific hotspots.
+
+Notes:
+- `wpr`, `xperf`, and `wpa` ship with the Windows Performance Toolkit. If they are not on `PATH`, install the Windows Performance Toolkit.
+- ETW capture requires elevation; the helper script relaunches itself as Administrator by default and fails clearly if the elevated child does not produce the expected artifacts.
+- `wpr -cancel` returns a non-zero exit code when no trace is active; the helper scripts treat that as non-fatal.
+- Prefer `win-optimized` for real app scenario capture and `win-benchmark` for benchmark capture. Use `win-profile` only when you specifically want a symbol-rich build for deeper attribution.
 
 ### Compile-Time Profiling (-ftime-trace)
 

--- a/src/App/Panels/ProcessesPanel.cpp
+++ b/src/App/Panels/ProcessesPanel.cpp
@@ -123,17 +123,67 @@ void renderRightAlignedText(std::string_view text)
 {
     const auto parts = UI::Format::splitPercentForAlignment(percent);
 
-    constexpr std::size_t MAX_WHOLE_DIGITS = 3;                                                 // "100"
-    const std::size_t wholeDigits = parts.wholePart.empty() ? 0 : (parts.wholePart.size() - 1); // Exclude trailing '.'
-    const std::size_t leftPad = (wholeDigits < MAX_WHOLE_DIGITS) ? (MAX_WHOLE_DIGITS - wholeDigits) : 0;
-
     std::string out;
-    out.reserve(leftPad + parts.wholePart.size() + 2);
-    out.append(leftPad, ' ');
+    out.reserve(parts.wholePart.size() + 2);
     out.append(parts.wholePart.data(), parts.wholePart.size());
     out.push_back(parts.decimalDigit);
     out.append(UI::Format::AlignedPercentParts::unitPart.data(), UI::Format::AlignedPercentParts::unitPart.size());
     return out;
+}
+
+void renderRightAlignedPercentText(std::string_view text,
+                                   const std::array<float, 101>& wholeWithDotWidths,
+                                   float decimalDigitWidth,
+                                   float unitPercentWidth)
+{
+    if (text.empty() || text == "-")
+    {
+        renderRightAlignedText(text);
+        return;
+    }
+
+    const std::size_t dotPos = text.find('.');
+    if (dotPos == std::string_view::npos || (dotPos + 1) >= text.size())
+    {
+        renderRightAlignedText(text);
+        return;
+    }
+
+    const std::string_view wholePart = text.substr(0, dotPos + 1); // includes trailing '.'
+    const std::string_view decimalPart = text.substr(dotPos + 1, 1);
+    const std::string_view unitPart = (dotPos + 2 < text.size()) ? text.substr(dotPos + 2) : std::string_view{"%"};
+
+    std::int32_t wholeValue = -1;
+    const std::string_view wholeDigits = text.substr(0, dotPos);
+    const auto parseResult = std::from_chars(wholeDigits.data(), wholeDigits.data() + wholeDigits.size(), wholeValue);
+
+    float wholeWidth = 0.0F;
+    if (parseResult.ec == std::errc{} && parseResult.ptr == (wholeDigits.data() + wholeDigits.size()) && wholeValue >= 0 &&
+        wholeValue <= 100)
+    {
+        wholeWidth = wholeWithDotWidths[static_cast<std::size_t>(wholeValue)];
+    }
+    else
+    {
+        wholeWidth = ImGui::CalcTextSize(wholePart.data(), wholePart.data() + wholePart.size()).x;
+    }
+
+    const float cellStartX = ImGui::GetCursorPosX();
+    const float availWidth = ImGui::GetContentRegionAvail().x;
+    const float cellEndX = cellStartX + availWidth;
+
+    const float unitRegionStart = cellEndX - unitPercentWidth;
+    const float decimalRegionStart = unitRegionStart - decimalDigitWidth;
+    const float wholeStartX = decimalRegionStart - wholeWidth;
+
+    ImGui::SetCursorPosX(std::max(cellStartX, wholeStartX));
+    ImGui::TextUnformatted(wholePart.data(), wholePart.data() + wholePart.size());
+
+    ImGui::SetCursorPosX(decimalRegionStart);
+    ImGui::TextUnformatted(decimalPart.data(), decimalPart.data() + decimalPart.size());
+
+    ImGui::SetCursorPosX(unitRegionStart);
+    ImGui::TextUnformatted(unitPart.data(), unitPart.data() + unitPart.size());
 }
 
 [[nodiscard]] auto formatAlignedBytesString(double bytes, UI::Format::ByteUnit unit) -> std::string
@@ -201,6 +251,12 @@ void ProcessesPanel::TextSizeCache::populate()
     unitBytesPerSecWidth = ImGui::CalcTextSize(UNIT_BYTES_PER_SEC.data(), UNIT_BYTES_PER_SEC.data() + UNIT_BYTES_PER_SEC.size()).x;
     unitPowerWidth = ImGui::CalcTextSize(UNIT_POWER.data(), UNIT_POWER.data() + UNIT_POWER.size()).x;
     singleDigitWidth = ImGui::CalcTextSize("0").x;
+    for (std::size_t i = 0; i < percentWholeWithDotWidths.size(); ++i)
+    {
+        std::string wholeWithDot = std::to_string(i);
+        wholeWithDot.push_back('.');
+        percentWholeWithDotWidths[i] = ImGui::CalcTextSize(wholeWithDot.c_str()).x;
+    }
 
     // Cache static label widths
     treeViewLabelWidth = ImGui::CalcTextSize(TREE_VIEW_LABEL.data(), TREE_VIEW_LABEL.data() + TREE_VIEW_LABEL.size()).x;
@@ -1123,11 +1179,17 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
             break;
 
         case ProcessColumn::CpuPercent:
-            renderRightAlignedText(fmt.cpuPercent);
+            renderRightAlignedPercentText(fmt.cpuPercent,
+                                          m_TextSizeCache.percentWholeWithDotWidths,
+                                          m_TextSizeCache.singleDigitWidth,
+                                          m_TextSizeCache.unitPercentWidth);
             break;
 
         case ProcessColumn::MemPercent:
-            renderRightAlignedText(fmt.memPercent);
+            renderRightAlignedPercentText(fmt.memPercent,
+                                          m_TextSizeCache.percentWholeWithDotWidths,
+                                          m_TextSizeCache.singleDigitWidth,
+                                          m_TextSizeCache.unitPercentWidth);
             break;
 
         case ProcessColumn::Virtual:
@@ -1273,7 +1335,10 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
             break;
 
         case ProcessColumn::GpuPercent:
-            renderRightAlignedText(fmt.gpuPercent);
+            renderRightAlignedPercentText(fmt.gpuPercent,
+                                          m_TextSizeCache.percentWholeWithDotWidths,
+                                          m_TextSizeCache.singleDigitWidth,
+                                          m_TextSizeCache.unitPercentWidth);
             break;
 
         case ProcessColumn::GpuMemory:

--- a/src/App/Panels/ProcessesPanel.cpp
+++ b/src/App/Panels/ProcessesPanel.cpp
@@ -123,8 +123,8 @@ void renderRightAlignedText(std::string_view text)
 {
     const auto parts = UI::Format::splitPercentForAlignment(percent);
 
-    constexpr std::size_t MAX_WHOLE_DIGITS = 3; // "100"
-    const std::size_t wholeDigits = parts.wholePart.size();
+    constexpr std::size_t MAX_WHOLE_DIGITS = 3;                                                 // "100"
+    const std::size_t wholeDigits = parts.wholePart.empty() ? 0 : (parts.wholePart.size() - 1); // Exclude trailing '.'
     const std::size_t leftPad = (wholeDigits < MAX_WHOLE_DIGITS) ? (MAX_WHOLE_DIGITS - wholeDigits) : 0;
 
     std::string out;

--- a/src/App/Panels/ProcessesPanel.cpp
+++ b/src/App/Panels/ProcessesPanel.cpp
@@ -168,22 +168,23 @@ void renderRightAlignedPercentText(std::string_view text,
         wholeWidth = ImGui::CalcTextSize(wholePart.data(), wholePart.data() + wholePart.size()).x;
     }
 
-    const float cellStartX = ImGui::GetCursorPosX();
+    const ImVec2 cursorScreen = ImGui::GetCursorScreenPos();
+    const float cellStartScreenX = cursorScreen.x;
     const float availWidth = ImGui::GetContentRegionAvail().x;
-    const float cellEndX = cellStartX + availWidth;
+    const float cellEndScreenX = cellStartScreenX + availWidth;
 
-    const float unitRegionStart = cellEndX - unitPercentWidth;
+    const float unitRegionStart = cellEndScreenX - unitPercentWidth;
     const float decimalRegionStart = unitRegionStart - decimalDigitWidth;
-    const float wholeStartX = decimalRegionStart - wholeWidth;
+    const float wholeStartX = std::max(cellStartScreenX, decimalRegionStart - wholeWidth);
 
-    ImGui::SetCursorPosX(std::max(cellStartX, wholeStartX));
-    ImGui::TextUnformatted(wholePart.data(), wholePart.data() + wholePart.size());
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    const ImU32 textColor = ImGui::GetColorU32(ImGuiCol_Text);
 
-    ImGui::SetCursorPosX(decimalRegionStart);
-    ImGui::TextUnformatted(decimalPart.data(), decimalPart.data() + decimalPart.size());
+    drawList->AddText(ImVec2(wholeStartX, cursorScreen.y), textColor, wholePart.data(), wholePart.data() + wholePart.size());
+    drawList->AddText(ImVec2(decimalRegionStart, cursorScreen.y), textColor, decimalPart.data(), decimalPart.data() + decimalPart.size());
+    drawList->AddText(ImVec2(unitRegionStart, cursorScreen.y), textColor, unitPart.data(), unitPart.data() + unitPart.size());
 
-    ImGui::SetCursorPosX(unitRegionStart);
-    ImGui::TextUnformatted(unitPart.data(), unitPart.data() + unitPart.size());
+    ImGui::Dummy(ImVec2(0.0F, ImGui::GetTextLineHeight()));
 }
 
 [[nodiscard]] auto formatAlignedBytesString(double bytes, UI::Format::ByteUnit unit) -> std::string

--- a/src/App/Panels/ProcessesPanel.cpp
+++ b/src/App/Panels/ProcessesPanel.cpp
@@ -119,133 +119,50 @@ void renderRightAlignedText(std::string_view text)
     ImGui::TextUnformatted(text.data(), text.data() + text.size());
 }
 
-/// Render a numeric value with decimal-point alignment.
-/// Layout (right to left):
-/// 1. Unit part - width based on cachedUnitWidth
-/// 2. Decimal part - width of single digit (if hasDecimals)
-/// 3. Whole part - right-aligned to fill remaining space
-///
-/// @param parts The split numeric parts to render
-/// @param cachedUnitWidth Pre-computed width of the unit region
-/// @param cachedDecimalWidth Pre-computed width of single digit (for decimal part)
-/// @param hasDecimals Whether to reserve space for decimal part (e.g., ".X")
-void renderDecimalAligned(const UI::Format::AlignedNumericParts& parts, float cachedUnitWidth, float cachedDecimalWidth, bool hasDecimals)
+[[nodiscard]] auto formatAlignedPercentString(double percent) -> std::string
 {
-    const float lineHeight = ImGui::GetTextLineHeight();
-    const float cellStartX = ImGui::GetCursorPosX();
-    const float availWidth = ImGui::GetContentRegionAvail().x;
-    const float cellEndX = cellStartX + availWidth;
-
-    // Use pre-computed unit width
-    const float unitRegionWidth = cachedUnitWidth;
-
-    // Decimal region: use pre-computed single digit width
-    const float decimalRegionWidth = hasDecimals ? cachedDecimalWidth : 0.0F;
-
-    // Calculate region boundaries (working right to left)
-    const float unitRegionStart = cellEndX - unitRegionWidth;
-    const float decimalRegionStart = unitRegionStart - decimalRegionWidth;
-
-    // Calculate whole part positioning (this must be computed per-value)
-    const float wholeWidth = ImGui::CalcTextSize(parts.wholePart.c_str()).x;
-    const float wholeStartX = decimalRegionStart - wholeWidth;
-
-    // Render whole part (right-aligned, ending at decimal region)
-    ImGui::SetCursorPosX(std::max(cellStartX, wholeStartX));
-    ImGui::TextUnformatted(parts.wholePart.c_str());
-
-    // Render decimal part (fixed position, left-aligned content)
-    if (hasDecimals)
-    {
-        ImGui::SameLine(0.0F, 0.0F);
-        ImGui::SetCursorPosX(decimalRegionStart);
-        if (!parts.decimalPart.empty())
-        {
-            ImGui::TextUnformatted(parts.decimalPart.c_str());
-        }
-        else
-        {
-            ImGui::Dummy(ImVec2(decimalRegionWidth, lineHeight));
-        }
-    }
-
-    // Render unit part (fixed position, left-aligned content)
-    ImGui::SameLine(0.0F, 0.0F);
-    ImGui::SetCursorPosX(unitRegionStart);
-    if (!parts.unitPart.empty())
-    {
-        ImGui::TextUnformatted(parts.unitPart.c_str());
-    }
-    else
-    {
-        ImGui::Dummy(ImVec2(unitRegionWidth, lineHeight));
-    }
+    const auto parts = UI::Format::splitPercentForAlignment(percent);
+    std::string out;
+    out.reserve(parts.wholePart.size() + 2);
+    out.append(parts.wholePart.data(), parts.wholePart.size());
+    out.push_back(parts.decimalDigit);
+    out.append(UI::Format::AlignedPercentParts::unitPart.data(), UI::Format::AlignedPercentParts::unitPart.size());
+    return out;
 }
 
-/// Optimized overload for AlignedPercentParts (zero-allocation percent rendering)
-/// Uses string_view for whole part and single char for decimal digit.
-void renderDecimalAligned(const UI::Format::AlignedPercentParts& parts, float cachedUnitWidth, float cachedDecimalWidth)
+[[nodiscard]] auto formatAlignedBytesString(double bytes, UI::Format::ByteUnit unit) -> std::string
 {
-    const float cellStartX = ImGui::GetCursorPosX();
-    const float availWidth = ImGui::GetContentRegionAvail().x;
-    const float cellEndX = cellStartX + availWidth;
-
-    // Calculate region boundaries (working right to left)
-    const float unitRegionStart = cellEndX - cachedUnitWidth;
-    const float decimalRegionStart = unitRegionStart - cachedDecimalWidth;
-
-    // Calculate whole part positioning (this must be computed per-value)
-    const float wholeWidth = ImGui::CalcTextSize(parts.wholePart.data(), parts.wholePart.data() + parts.wholePart.size()).x;
-    const float wholeStartX = decimalRegionStart - wholeWidth;
-
-    // Render whole part (right-aligned, ending at decimal region)
-    ImGui::SetCursorPosX(std::max(cellStartX, wholeStartX));
-    ImGui::TextUnformatted(parts.wholePart.data(), parts.wholePart.data() + parts.wholePart.size());
-
-    // Render decimal digit (single char, fixed position)
-    ImGui::SameLine(0.0F, 0.0F);
-    ImGui::SetCursorPosX(decimalRegionStart);
-    const std::array<char, 2> decimalStr = {parts.decimalDigit, '\0'};
-    ImGui::TextUnformatted(decimalStr.data());
-
-    // Render unit part (fixed "%" - static constexpr string_view)
-    ImGui::SameLine(0.0F, 0.0F);
-    ImGui::SetCursorPosX(unitRegionStart);
-    constexpr auto unitPart = UI::Format::AlignedPercentParts::unitPart;
-    ImGui::TextUnformatted(unitPart.data(), unitPart.data() + unitPart.size());
+    const auto parts = UI::Format::splitBytesForAlignmentFast(bytes, unit);
+    const auto wholePart = parts.wholePart();
+    std::string out;
+    out.reserve(wholePart.size() + parts.unitPart.size() + 1);
+    out.append(wholePart.data(), wholePart.size());
+    out.push_back(parts.decimalDigit);
+    out.append(parts.unitPart.data(), parts.unitPart.size());
+    return out;
 }
 
-/// Optimized overload for AlignedBytesParts (zero-allocation byte value rendering)
-/// Uses internal buffer for whole part and single char for decimal digit.
-void renderDecimalAligned(const UI::Format::AlignedBytesParts& parts, float cachedUnitWidth, float cachedDecimalWidth)
+[[nodiscard]] auto formatAlignedBytesPerSecString(double bytesPerSec, UI::Format::ByteUnit unit) -> std::string
 {
-    const float cellStartX = ImGui::GetCursorPosX();
-    const float availWidth = ImGui::GetContentRegionAvail().x;
-    const float cellEndX = cellStartX + availWidth;
+    const auto parts = UI::Format::splitBytesPerSecForAlignmentFast(bytesPerSec, unit);
+    const auto wholePart = parts.wholePart();
+    std::string out;
+    out.reserve(wholePart.size() + parts.unitPart.size() + 1);
+    out.append(wholePart.data(), wholePart.size());
+    out.push_back(parts.decimalDigit);
+    out.append(parts.unitPart.data(), parts.unitPart.size());
+    return out;
+}
 
-    // Calculate region boundaries (working right to left)
-    const float unitRegionStart = cellEndX - cachedUnitWidth;
-    const float decimalRegionStart = unitRegionStart - cachedDecimalWidth;
-
-    // Calculate whole part positioning using wholePart() accessor
-    const std::string_view wholePart = parts.wholePart();
-    const float wholeWidth = ImGui::CalcTextSize(wholePart.data(), wholePart.data() + wholePart.size()).x;
-    const float wholeStartX = decimalRegionStart - wholeWidth;
-
-    // Render whole part (right-aligned, ending at decimal region)
-    ImGui::SetCursorPosX(std::max(cellStartX, wholeStartX));
-    ImGui::TextUnformatted(wholePart.data(), wholePart.data() + wholePart.size());
-
-    // Render decimal digit (single char, fixed position)
-    ImGui::SameLine(0.0F, 0.0F);
-    ImGui::SetCursorPosX(decimalRegionStart);
-    const std::array<char, 2> decimalStr = {parts.decimalDigit, '\0'};
-    ImGui::TextUnformatted(decimalStr.data());
-
-    // Render unit part (string_view to " KB", " MB", " GB", etc.)
-    ImGui::SameLine(0.0F, 0.0F);
-    ImGui::SetCursorPosX(unitRegionStart);
-    ImGui::TextUnformatted(parts.unitPart.data(), parts.unitPart.data() + parts.unitPart.size());
+[[nodiscard]] auto formatAlignedPowerString(double watts) -> std::string
+{
+    const auto parts = UI::Format::splitPowerForAlignment(watts);
+    std::string out;
+    out.reserve(parts.wholePart.size() + parts.decimalPart.size() + parts.unitPart.size());
+    out.append(parts.wholePart);
+    out.append(parts.decimalPart);
+    out.append(parts.unitPart);
+    return out;
 }
 
 } // namespace
@@ -554,6 +471,57 @@ void ProcessesPanel::renderContent()
         }
     }
     const auto& currentSnapshots = m_CachedRenderSnapshots;
+
+    // Rebuild row format cache when snapshot data changes (~1Hz), never per frame (60fps).
+    // Eliminates heap allocations for slow-changing formatted columns in renderProcessRow.
+    if (m_CachedSnapshotVersion != m_RowFormatCacheVersion)
+    {
+        m_RowFormatCache.clear();
+        m_RowFormatCache.reserve(currentSnapshots.size());
+        for (const auto& proc : currentSnapshots)
+        {
+            RowFormatCache fmt;
+            fmt.ppid = UI::Format::formatId(proc.parentPid);
+            fmt.startTime = UI::Format::formatEpochDateTimeShort(proc.startTimeEpoch);
+            fmt.cpuTime = UI::Format::formatCpuTimeCompact(proc.cpuTimeSeconds);
+            fmt.cpuPercent = formatAlignedPercentString(proc.cpuPercent);
+            fmt.memPercent = formatAlignedPercentString(proc.memoryPercent);
+            fmt.virtualMem =
+                formatAlignedBytesString(static_cast<double>(proc.virtualBytes), UI::Format::unitForTotalBytes(proc.virtualBytes));
+            fmt.resident = formatAlignedBytesString(static_cast<double>(proc.memoryBytes), UI::Format::unitForTotalBytes(proc.memoryBytes));
+            fmt.peakRss =
+                formatAlignedBytesString(static_cast<double>(proc.peakMemoryBytes), UI::Format::unitForTotalBytes(proc.peakMemoryBytes));
+            fmt.shared = formatAlignedBytesString(static_cast<double>(proc.sharedBytes), UI::Format::unitForTotalBytes(proc.sharedBytes));
+            fmt.ioRead =
+                (proc.ioReadBytesPerSec > 0.0)
+                    ? formatAlignedBytesPerSecString(proc.ioReadBytesPerSec, UI::Format::unitForBytesPerSecond(proc.ioReadBytesPerSec))
+                    : "-";
+            fmt.ioWrite =
+                (proc.ioWriteBytesPerSec > 0.0)
+                    ? formatAlignedBytesPerSecString(proc.ioWriteBytesPerSec, UI::Format::unitForBytesPerSecond(proc.ioWriteBytesPerSec))
+                    : "-";
+            fmt.netSent =
+                (proc.netSentBytesPerSec > 0.0)
+                    ? formatAlignedBytesPerSecString(proc.netSentBytesPerSec, UI::Format::unitForBytesPerSecond(proc.netSentBytesPerSec))
+                    : "-";
+            fmt.netRecv = (proc.netReceivedBytesPerSec > 0.0)
+                            ? formatAlignedBytesPerSecString(proc.netReceivedBytesPerSec,
+                                                             UI::Format::unitForBytesPerSecond(proc.netReceivedBytesPerSec))
+                            : "-";
+            fmt.power = formatAlignedPowerString(proc.powerWatts);
+            fmt.gpuPercent = (proc.gpuUtilPercent > 0.0) ? formatAlignedPercentString(proc.gpuUtilPercent) : "-";
+            fmt.gpuMemory = (proc.gpuMemoryBytes > 0) ? formatAlignedBytesString(static_cast<double>(proc.gpuMemoryBytes),
+                                                                                 UI::Format::unitForTotalBytes(proc.gpuMemoryBytes))
+                                                      : "-";
+            fmt.threads = UI::Format::formatOrDash(proc.threadCount, [](auto v) { return UI::Format::formatIntLocalized(v); });
+            fmt.handles = UI::Format::formatOrDash(proc.handleCount, [](auto v) { return UI::Format::formatIntLocalized(v); });
+            fmt.pageFaults = UI::Format::formatOrDash(proc.pageFaults, [](auto v) { return UI::Format::formatIntLocalized(v); });
+            fmt.affinity = UI::Format::formatCpuAffinityMask(proc.cpuAffinityMask);
+            fmt.gdiObjects = proc.gdiObjectCount.has_value() ? UI::Format::formatIntLocalized(*proc.gdiObjectCount) : "-";
+            m_RowFormatCache.emplace(proc.uniqueKey, std::move(fmt));
+        }
+        m_RowFormatCacheVersion = m_CachedSnapshotVersion;
+    }
 
     // Search bar
     const auto& theme = UI::Theme::get();
@@ -1050,12 +1018,10 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
 {
     ImGui::TableNextRow();
 
-    // Cache references for decimal-aligned rendering (avoids repeated lookups in switch cases)
-    const float unitPercentW = m_TextSizeCache.unitPercentWidth;
-    const float unitBytesW = m_TextSizeCache.unitBytesWidth;
-    const float unitBytesPerSecW = m_TextSizeCache.unitBytesPerSecWidth;
-    const float unitPowerW = m_TextSizeCache.unitPowerWidth;
-    const float singleDigitW = m_TextSizeCache.singleDigitWidth;
+    // Look up pre-formatted strings for this row (built at 1Hz, not 60fps)
+    static const RowFormatCache s_EmptyRowCache{};
+    const auto fmtIt = m_RowFormatCache.find(proc.uniqueKey);
+    const RowFormatCache& fmt = (fmtIt != m_RowFormatCache.end()) ? fmtIt->second : s_EmptyRowCache;
 
     // Render all columns
     int colIdx = 0;
@@ -1128,7 +1094,12 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
                 Core::Application::get().raiseEvent(event);
             }
             ImGui::SameLine(0.0F, 0.0F);
-            renderRightAlignedText(label);
+            // Keep PID text right-aligned in its column in both list and tree modes.
+            const float pidTextWidth = ImGui::CalcTextSize(label.data(), label.data() + label.size()).x;
+            const float pidAvailWidth = ImGui::GetContentRegionAvail().x;
+            const float pidCurrentX = ImGui::GetCursorPosX();
+            ImGui::SetCursorPosX(pidCurrentX + std::max(0.0F, pidAvailWidth - pidTextWidth));
+            ImGui::TextUnformatted(label.data(), label.data() + label.size());
 
             if (m_TreeViewEnabled && depth > 0)
             {
@@ -1146,64 +1117,36 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
             break;
 
         case ProcessColumn::CpuPercent:
-        {
-            const auto parts = UI::Format::splitPercentForAlignment(proc.cpuPercent);
-            renderDecimalAligned(parts, unitPercentW, singleDigitW);
+            renderRightAlignedText(fmt.cpuPercent);
             break;
-        }
 
         case ProcessColumn::MemPercent:
-        {
-            const auto parts = UI::Format::splitPercentForAlignment(proc.memoryPercent);
-            renderDecimalAligned(parts, unitPercentW, singleDigitW);
+            renderRightAlignedText(fmt.memPercent);
             break;
-        }
 
         case ProcessColumn::Virtual:
-        {
-            const auto unit = UI::Format::unitForTotalBytes(proc.virtualBytes);
-            const auto parts = UI::Format::splitBytesForAlignmentFast(static_cast<double>(proc.virtualBytes), unit);
-            renderDecimalAligned(parts, unitBytesW, singleDigitW);
+            renderRightAlignedText(fmt.virtualMem);
             break;
-        }
 
         case ProcessColumn::Resident:
-        {
-            const auto unit = UI::Format::unitForTotalBytes(proc.memoryBytes);
-            const auto parts = UI::Format::splitBytesForAlignmentFast(static_cast<double>(proc.memoryBytes), unit);
-            renderDecimalAligned(parts, unitBytesW, singleDigitW);
+            renderRightAlignedText(fmt.resident);
             break;
-        }
 
         case ProcessColumn::PeakResident:
-        {
-            const auto unit = UI::Format::unitForTotalBytes(proc.peakMemoryBytes);
-            const auto parts = UI::Format::splitBytesForAlignmentFast(static_cast<double>(proc.peakMemoryBytes), unit);
-            renderDecimalAligned(parts, unitBytesW, singleDigitW);
+            renderRightAlignedText(fmt.peakRss);
             break;
-        }
 
         case ProcessColumn::Shared:
-        {
-            const auto unit = UI::Format::unitForTotalBytes(proc.sharedBytes);
-            const auto parts = UI::Format::splitBytesForAlignmentFast(static_cast<double>(proc.sharedBytes), unit);
-            renderDecimalAligned(parts, unitBytesW, singleDigitW);
+            renderRightAlignedText(fmt.shared);
             break;
-        }
 
         case ProcessColumn::CpuTime:
-        {
-            const std::string text = UI::Format::formatCpuTimeCompact(proc.cpuTimeSeconds);
-            renderRightAlignedText(text);
+            renderRightAlignedText(fmt.cpuTime);
             break;
-        }
 
         case ProcessColumn::StartTime:
-        {
-            const std::string text = UI::Format::formatEpochDateTimeShort(proc.startTimeEpoch);
-            renderRightAlignedText(text);
+            renderRightAlignedText(fmt.startTime);
             break;
-        }
 
         case ProcessColumn::State:
         {
@@ -1267,11 +1210,8 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
             break;
 
         case ProcessColumn::PPID:
-        {
-            const std::string text = UI::Format::formatId(proc.parentPid);
-            renderRightAlignedText(text);
+            renderRightAlignedText(fmt.ppid);
             break;
-        }
 
         case ProcessColumn::Priority:
             // getPriorityLabel returns string_view into static storage — no allocation needed
@@ -1279,34 +1219,20 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
             break;
 
         case ProcessColumn::Threads:
-        {
-            const std::string text =
-                UI::Format::formatOrDash(proc.threadCount, [](auto value) { return UI::Format::formatIntLocalized(value); });
-            renderRightAlignedText(text);
+            renderRightAlignedText(fmt.threads);
             break;
-        }
 
         case ProcessColumn::Handles:
-        {
-            const std::string text =
-                UI::Format::formatOrDash(proc.handleCount, [](auto value) { return UI::Format::formatIntLocalized(value); });
-            renderRightAlignedText(text);
+            renderRightAlignedText(fmt.handles);
             break;
-        }
 
         case ProcessColumn::PageFaults:
-        {
-            const std::string formatted =
-                UI::Format::formatOrDash(proc.pageFaults, [](auto value) { return UI::Format::formatIntLocalized(value); });
-            renderRightAlignedText(formatted);
+            renderRightAlignedText(fmt.pageFaults);
             break;
-        }
+
         case ProcessColumn::Affinity:
-        {
-            const std::string text = UI::Format::formatCpuAffinityMask(proc.cpuAffinityMask);
-            renderRightAlignedText(text);
+            renderRightAlignedText(fmt.affinity);
             break;
-        }
 
         case ProcessColumn::Command:
             if (!proc.command.empty())
@@ -1321,100 +1247,32 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
             break;
 
         case ProcessColumn::IoRead:
-        {
-            if (proc.ioReadBytesPerSec > 0.0)
-            {
-                const auto unit = UI::Format::unitForBytesPerSecond(proc.ioReadBytesPerSec);
-                const auto parts = UI::Format::splitBytesPerSecForAlignmentFast(proc.ioReadBytesPerSec, unit);
-                renderDecimalAligned(parts, unitBytesPerSecW, singleDigitW);
-            }
-            else
-            {
-                renderRightAlignedText("-");
-            }
+            renderRightAlignedText(fmt.ioRead);
             break;
-        }
 
         case ProcessColumn::IoWrite:
-        {
-            if (proc.ioWriteBytesPerSec > 0.0)
-            {
-                const auto unit = UI::Format::unitForBytesPerSecond(proc.ioWriteBytesPerSec);
-                const auto parts = UI::Format::splitBytesPerSecForAlignmentFast(proc.ioWriteBytesPerSec, unit);
-                renderDecimalAligned(parts, unitBytesPerSecW, singleDigitW);
-            }
-            else
-            {
-                renderRightAlignedText("-");
-            }
+            renderRightAlignedText(fmt.ioWrite);
             break;
-        }
 
         case ProcessColumn::NetSent:
-        {
-            if (proc.netSentBytesPerSec > 0.0)
-            {
-                const auto unit = UI::Format::unitForBytesPerSecond(proc.netSentBytesPerSec);
-                const auto parts = UI::Format::splitBytesPerSecForAlignmentFast(proc.netSentBytesPerSec, unit);
-                renderDecimalAligned(parts, unitBytesPerSecW, singleDigitW);
-            }
-            else
-            {
-                renderRightAlignedText("-");
-            }
+            renderRightAlignedText(fmt.netSent);
             break;
-        }
 
         case ProcessColumn::NetReceived:
-        {
-            if (proc.netReceivedBytesPerSec > 0.0)
-            {
-                const auto unit = UI::Format::unitForBytesPerSecond(proc.netReceivedBytesPerSec);
-                const auto parts = UI::Format::splitBytesPerSecForAlignmentFast(proc.netReceivedBytesPerSec, unit);
-                renderDecimalAligned(parts, unitBytesPerSecW, singleDigitW);
-            }
-            else
-            {
-                renderRightAlignedText("-");
-            }
+            renderRightAlignedText(fmt.netRecv);
             break;
-        }
 
         case ProcessColumn::Power:
-        {
-            const auto parts = UI::Format::splitPowerForAlignment(proc.powerWatts);
-            renderDecimalAligned(parts, unitPowerW, singleDigitW, true);
+            renderRightAlignedText(fmt.power);
             break;
-        }
 
         case ProcessColumn::GpuPercent:
-        {
-            if (proc.gpuUtilPercent > 0.0)
-            {
-                const auto parts = UI::Format::splitPercentForAlignment(proc.gpuUtilPercent);
-                renderDecimalAligned(parts, unitPercentW, singleDigitW);
-            }
-            else
-            {
-                renderRightAlignedText("-");
-            }
+            renderRightAlignedText(fmt.gpuPercent);
             break;
-        }
 
         case ProcessColumn::GpuMemory:
-        {
-            if (proc.gpuMemoryBytes > 0)
-            {
-                const auto unit = UI::Format::unitForTotalBytes(proc.gpuMemoryBytes);
-                const auto parts = UI::Format::splitBytesForAlignmentFast(static_cast<double>(proc.gpuMemoryBytes), unit);
-                renderDecimalAligned(parts, unitBytesW, singleDigitW);
-            }
-            else
-            {
-                renderRightAlignedText("-");
-            }
+            renderRightAlignedText(fmt.gpuMemory);
             break;
-        }
 
         case ProcessColumn::GpuEngine:
         {
@@ -1501,20 +1359,10 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
         }
 
         case ProcessColumn::GdiObjects:
-        {
             // Show "-" only when the probe could not read the count (process not accessible).
             // A count of 0 is a valid result for non-GUI background processes and is shown as "0".
-            if (proc.gdiObjectCount.has_value())
-            {
-                const std::string text = UI::Format::formatIntLocalized(*proc.gdiObjectCount);
-                renderRightAlignedText(text);
-            }
-            else
-            {
-                renderRightAlignedText("-");
-            }
+            renderRightAlignedText(fmt.gdiObjects);
             break;
-        }
 
         default:
             break;

--- a/src/App/Panels/ProcessesPanel.cpp
+++ b/src/App/Panels/ProcessesPanel.cpp
@@ -131,62 +131,6 @@ void renderRightAlignedText(std::string_view text)
     return out;
 }
 
-void renderRightAlignedPercentText(std::string_view text,
-                                   const std::array<float, 101>& wholeWithDotWidths,
-                                   float decimalDigitWidth,
-                                   float unitPercentWidth)
-{
-    if (text.empty() || text == "-")
-    {
-        renderRightAlignedText(text);
-        return;
-    }
-
-    const std::size_t dotPos = text.find('.');
-    if (dotPos == std::string_view::npos || (dotPos + 1) >= text.size())
-    {
-        renderRightAlignedText(text);
-        return;
-    }
-
-    const std::string_view wholePart = text.substr(0, dotPos + 1); // includes trailing '.'
-    const std::string_view decimalPart = text.substr(dotPos + 1, 1);
-    const std::string_view unitPart = (dotPos + 2 < text.size()) ? text.substr(dotPos + 2) : std::string_view{"%"};
-
-    std::int32_t wholeValue = -1;
-    const std::string_view wholeDigits = text.substr(0, dotPos);
-    const auto parseResult = std::from_chars(wholeDigits.data(), wholeDigits.data() + wholeDigits.size(), wholeValue);
-
-    float wholeWidth = 0.0F;
-    if (parseResult.ec == std::errc{} && parseResult.ptr == (wholeDigits.data() + wholeDigits.size()) && wholeValue >= 0 &&
-        wholeValue <= 100)
-    {
-        wholeWidth = wholeWithDotWidths[static_cast<std::size_t>(wholeValue)];
-    }
-    else
-    {
-        wholeWidth = ImGui::CalcTextSize(wholePart.data(), wholePart.data() + wholePart.size()).x;
-    }
-
-    const ImVec2 cursorScreen = ImGui::GetCursorScreenPos();
-    const float cellStartScreenX = cursorScreen.x;
-    const float availWidth = ImGui::GetContentRegionAvail().x;
-    const float cellEndScreenX = cellStartScreenX + availWidth;
-
-    const float unitRegionStart = cellEndScreenX - unitPercentWidth;
-    const float decimalRegionStart = unitRegionStart - decimalDigitWidth;
-    const float wholeStartX = std::max(cellStartScreenX, decimalRegionStart - wholeWidth);
-
-    ImDrawList* drawList = ImGui::GetWindowDrawList();
-    const ImU32 textColor = ImGui::GetColorU32(ImGuiCol_Text);
-
-    drawList->AddText(ImVec2(wholeStartX, cursorScreen.y), textColor, wholePart.data(), wholePart.data() + wholePart.size());
-    drawList->AddText(ImVec2(decimalRegionStart, cursorScreen.y), textColor, decimalPart.data(), decimalPart.data() + decimalPart.size());
-    drawList->AddText(ImVec2(unitRegionStart, cursorScreen.y), textColor, unitPart.data(), unitPart.data() + unitPart.size());
-
-    ImGui::Dummy(ImVec2(0.0F, ImGui::GetTextLineHeight()));
-}
-
 [[nodiscard]] auto formatAlignedBytesString(double bytes, UI::Format::ByteUnit unit) -> std::string
 {
     const auto parts = UI::Format::splitBytesForAlignmentFast(bytes, unit);
@@ -252,12 +196,6 @@ void ProcessesPanel::TextSizeCache::populate()
     unitBytesPerSecWidth = ImGui::CalcTextSize(UNIT_BYTES_PER_SEC.data(), UNIT_BYTES_PER_SEC.data() + UNIT_BYTES_PER_SEC.size()).x;
     unitPowerWidth = ImGui::CalcTextSize(UNIT_POWER.data(), UNIT_POWER.data() + UNIT_POWER.size()).x;
     singleDigitWidth = ImGui::CalcTextSize("0").x;
-    for (std::size_t i = 0; i < percentWholeWithDotWidths.size(); ++i)
-    {
-        std::string wholeWithDot = std::to_string(i);
-        wholeWithDot.push_back('.');
-        percentWholeWithDotWidths[i] = ImGui::CalcTextSize(wholeWithDot.c_str()).x;
-    }
 
     // Cache static label widths
     treeViewLabelWidth = ImGui::CalcTextSize(TREE_VIEW_LABEL.data(), TREE_VIEW_LABEL.data() + TREE_VIEW_LABEL.size()).x;
@@ -763,7 +701,7 @@ void ProcessesPanel::renderContent()
                           totalColumns,
                           ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Sortable | ImGuiTableFlags_SortMulti |
                               ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_ScrollY |
-                              ImGuiTableFlags_Hideable | ImGuiTableFlags_SizingFixedFit))
+                              ImGuiTableFlags_ScrollX | ImGuiTableFlags_Hideable | ImGuiTableFlags_SizingFixedFit))
     {
         ImGui::TableSetupScrollFreeze(0, 1); // Freeze header row
 
@@ -1180,17 +1118,11 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
             break;
 
         case ProcessColumn::CpuPercent:
-            renderRightAlignedPercentText(fmt.cpuPercent,
-                                          m_TextSizeCache.percentWholeWithDotWidths,
-                                          m_TextSizeCache.singleDigitWidth,
-                                          m_TextSizeCache.unitPercentWidth);
+            renderRightAlignedText(fmt.cpuPercent);
             break;
 
         case ProcessColumn::MemPercent:
-            renderRightAlignedPercentText(fmt.memPercent,
-                                          m_TextSizeCache.percentWholeWithDotWidths,
-                                          m_TextSizeCache.singleDigitWidth,
-                                          m_TextSizeCache.unitPercentWidth);
+            renderRightAlignedText(fmt.memPercent);
             break;
 
         case ProcessColumn::Virtual:
@@ -1336,10 +1268,7 @@ void ProcessesPanel::renderProcessRow(const Domain::ProcessSnapshot& proc, int d
             break;
 
         case ProcessColumn::GpuPercent:
-            renderRightAlignedPercentText(fmt.gpuPercent,
-                                          m_TextSizeCache.percentWholeWithDotWidths,
-                                          m_TextSizeCache.singleDigitWidth,
-                                          m_TextSizeCache.unitPercentWidth);
+            renderRightAlignedText(fmt.gpuPercent);
             break;
 
         case ProcessColumn::GpuMemory:

--- a/src/App/Panels/ProcessesPanel.cpp
+++ b/src/App/Panels/ProcessesPanel.cpp
@@ -122,8 +122,14 @@ void renderRightAlignedText(std::string_view text)
 [[nodiscard]] auto formatAlignedPercentString(double percent) -> std::string
 {
     const auto parts = UI::Format::splitPercentForAlignment(percent);
+
+    constexpr std::size_t MAX_WHOLE_DIGITS = 3; // "100"
+    const std::size_t wholeDigits = parts.wholePart.size();
+    const std::size_t leftPad = (wholeDigits < MAX_WHOLE_DIGITS) ? (MAX_WHOLE_DIGITS - wholeDigits) : 0;
+
     std::string out;
-    out.reserve(parts.wholePart.size() + 2);
+    out.reserve(leftPad + parts.wholePart.size() + 2);
+    out.append(leftPad, ' ');
     out.append(parts.wholePart.data(), parts.wholePart.size());
     out.push_back(parts.decimalDigit);
     out.append(UI::Format::AlignedPercentParts::unitPart.data(), UI::Format::AlignedPercentParts::unitPart.size());

--- a/src/App/Panels/ProcessesPanel.h
+++ b/src/App/Panels/ProcessesPanel.h
@@ -184,6 +184,37 @@ class ProcessesPanel : public Panel
 
     TextSizeCache m_TextSizeCache;
 
+    /// Cache of pre-formatted strings per process row, keyed by uniqueKey.
+    /// Rebuilt once when snapshot data changes (~1Hz), not per frame (60fps).
+    /// Eliminates heap allocations for slow-changing formatted columns in renderProcessRow.
+    struct RowFormatCache
+    {
+        std::string ppid;       // formatId(parentPid)          — immutable
+        std::string startTime;  // formatEpochDateTimeShort      — immutable
+        std::string cpuTime;    // formatCpuTimeCompact          — changes at 1Hz
+        std::string cpuPercent; // pre-formatted to avoid per-frame decimal alignment work
+        std::string memPercent; // pre-formatted to avoid per-frame decimal alignment work
+        std::string virtualMem; // pre-formatted to avoid per-frame decimal alignment work
+        std::string resident;   // pre-formatted to avoid per-frame decimal alignment work
+        std::string peakRss;    // pre-formatted to avoid per-frame decimal alignment work
+        std::string shared;     // pre-formatted to avoid per-frame decimal alignment work
+        std::string ioRead;     // pre-formatted to avoid per-frame decimal alignment work
+        std::string ioWrite;    // pre-formatted to avoid per-frame decimal alignment work
+        std::string netSent;    // pre-formatted to avoid per-frame decimal alignment work
+        std::string netRecv;    // pre-formatted to avoid per-frame decimal alignment work
+        std::string power;      // pre-formatted to avoid per-frame decimal alignment work
+        std::string gpuPercent; // pre-formatted to avoid per-frame decimal alignment work
+        std::string gpuMemory;  // pre-formatted to avoid per-frame decimal alignment work
+        std::string threads;    // formatOrDash/formatIntLocalized(threadCount)
+        std::string handles;    // formatOrDash/formatIntLocalized(handleCount)
+        std::string pageFaults; // formatOrDash/formatIntLocalized(pageFaults)
+        std::string affinity;   // formatCpuAffinityMask         — rarely changes
+        std::string gdiObjects; // formatIntLocalized(*gdiObjectCount) or "-"
+    };
+
+    std::unordered_map<std::uint64_t, RowFormatCache> m_RowFormatCache;
+    std::uint64_t m_RowFormatCacheVersion = std::numeric_limits<std::uint64_t>::max();
+
     /// Ensure text size cache is populated for current font
     void ensureTextSizeCacheValid();
 

--- a/src/App/Panels/ProcessesPanel.h
+++ b/src/App/Panels/ProcessesPanel.h
@@ -156,12 +156,11 @@ class ProcessesPanel : public Panel
 
         // Unit string widths for decimal-aligned rendering
         // (measured from actual rendered unit strings for accurate alignment)
-        float unitPercentWidth = 0.0F;                      // "%"
-        float unitBytesWidth = 0.0F;                        // " MB", " GB", etc.
-        float unitBytesPerSecWidth = 0.0F;                  // " MB/s", " GB/s", etc.
-        float unitPowerWidth = 0.0F;                        // " W", " mW", etc.
-        float singleDigitWidth = 0.0F;                      // "0" for decimal part
-        std::array<float, 101> percentWholeWithDotWidths{}; // "0." .. "100."
+        float unitPercentWidth = 0.0F;     // "%"
+        float unitBytesWidth = 0.0F;       // " MB", " GB", etc.
+        float unitBytesPerSecWidth = 0.0F; // " MB/s", " GB/s", etc.
+        float unitPowerWidth = 0.0F;       // " W", " mW", etc.
+        float singleDigitWidth = 0.0F;     // "0" for decimal part
 
         // Static label widths
         float treeViewLabelWidth = 0.0F;

--- a/src/App/Panels/ProcessesPanel.h
+++ b/src/App/Panels/ProcessesPanel.h
@@ -156,11 +156,12 @@ class ProcessesPanel : public Panel
 
         // Unit string widths for decimal-aligned rendering
         // (measured from actual rendered unit strings for accurate alignment)
-        float unitPercentWidth = 0.0F;     // "%"
-        float unitBytesWidth = 0.0F;       // " MB", " GB", etc.
-        float unitBytesPerSecWidth = 0.0F; // " MB/s", " GB/s", etc.
-        float unitPowerWidth = 0.0F;       // " W", " mW", etc.
-        float singleDigitWidth = 0.0F;     // "0" for decimal part
+        float unitPercentWidth = 0.0F;                      // "%"
+        float unitBytesWidth = 0.0F;                        // " MB", " GB", etc.
+        float unitBytesPerSecWidth = 0.0F;                  // " MB/s", " GB/s", etc.
+        float unitPowerWidth = 0.0F;                        // " W", " mW", etc.
+        float singleDigitWidth = 0.0F;                      // "0" for decimal part
+        std::array<float, 101> percentWholeWithDotWidths{}; // "0." .. "100."
 
         // Static label widths
         float treeViewLabelWidth = 0.0F;

--- a/src/Platform/Windows/WindowsProcessProbe.cpp
+++ b/src/Platform/Windows/WindowsProcessProbe.cpp
@@ -640,8 +640,6 @@ std::vector<ProcessCounters> WindowsProcessProbe::enumerate()
 
     std::erase_if(m_DetailCache,
                   [generation = m_DetailCacheGeneration](const auto& entry) { return entry.second.generation != generation; });
-    std::erase_if(m_OpenProcessRetryCache,
-                  [generation = m_DetailCacheGeneration](const auto& entry) { return entry.second.generation != generation; });
 
     // Attribute energy to processes if power monitoring is available
     if (m_HasPowerMonitoring)
@@ -658,30 +656,17 @@ std::vector<ProcessCounters> WindowsProcessProbe::enumerate()
 
 bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& counters)
 {
-    const auto now = std::chrono::steady_clock::now();
-    constexpr auto OPEN_PROCESS_RETRY_TTL = std::chrono::milliseconds{2000};
-
-    if (const auto retryIt = m_OpenProcessRetryCache.find(pid); retryIt != m_OpenProcessRetryCache.end())
-    {
-        retryIt->second.generation = m_DetailCacheGeneration;
-        if (now < retryIt->second.nextRetry)
-        {
-            counters.state = '?';
-            return false;
-        }
-    }
-
     // Open process with limited access - some system processes won't allow full access
     HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ, FALSE, pid);
 
     if (hProcess == nullptr)
     {
-        m_OpenProcessRetryCache[pid] = OpenProcessRetryEntry{now + OPEN_PROCESS_RETRY_TTL, m_DetailCacheGeneration};
         // Can't access this process - leave defaults
         counters.state = '?';
         return false;
     }
-    m_OpenProcessRetryCache.erase(pid);
+
+    const auto now = std::chrono::steady_clock::now();
 
     // Get CPU times (always read — required for CPU accounting every refresh)
     FILETIME ftCreation{};

--- a/src/Platform/Windows/WindowsProcessProbe.cpp
+++ b/src/Platform/Windows/WindowsProcessProbe.cpp
@@ -196,6 +196,21 @@ namespace
 
 using NtQueryInformationProcessFn = NTSTATUS(NTAPI*)(HANDLE, PROCESSINFOCLASS, PVOID, ULONG, PULONG);
 
+[[nodiscard]] NtQueryInformationProcessFn getNtQueryInformationProcessFn() noexcept
+{
+    static NtQueryInformationProcessFn cachedFn = []() -> NtQueryInformationProcessFn
+    {
+        HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+        if (ntdll == nullptr)
+        {
+            return nullptr;
+        }
+        return Windows::getProcAddress<NtQueryInformationProcessFn>(ntdll, "NtQueryInformationProcess");
+    }();
+
+    return cachedFn;
+}
+
 // Some Windows SDK versions omit VM_COUNTERS and/or the ProcessVmCounters enum value from public headers.
 // Define what we need locally for compatibility.
 struct TaskSmackVmCounters
@@ -228,13 +243,7 @@ struct ProcessVmInfo
         return std::nullopt;
     }
 
-    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if (ntdll == nullptr)
-    {
-        return std::nullopt;
-    }
-
-    auto* fn = Windows::getProcAddress<NtQueryInformationProcessFn>(ntdll, "NtQueryInformationProcess");
+    auto* fn = getNtQueryInformationProcessFn();
     if (fn == nullptr)
     {
         return std::nullopt;
@@ -285,13 +294,7 @@ constexpr ULONG PEBI_IS_BACKGROUND = 0x00000020; // Background process (efficien
         return {};
     }
 
-    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if (ntdll == nullptr)
-    {
-        return {};
-    }
-
-    auto* fn = Windows::getProcAddress<NtQueryInformationProcessFn>(ntdll, "NtQueryInformationProcess");
+    auto* fn = getNtQueryInformationProcessFn();
     if (fn == nullptr)
     {
         return {};
@@ -594,6 +597,7 @@ WindowsProcessProbe::~WindowsProcessProbe()
 std::vector<ProcessCounters> WindowsProcessProbe::enumerate()
 {
     std::vector<ProcessCounters> results;
+    results.reserve(m_LastEnumeratedProcessCount);
     ++m_DetailCacheGeneration;
 
     // Create snapshot of all processes
@@ -632,7 +636,11 @@ std::vector<ProcessCounters> WindowsProcessProbe::enumerate()
 
     CloseHandle(hSnapshot);
 
+    m_LastEnumeratedProcessCount = std::max<std::size_t>(results.size(), std::size_t{64});
+
     std::erase_if(m_DetailCache,
+                  [generation = m_DetailCacheGeneration](const auto& entry) { return entry.second.generation != generation; });
+    std::erase_if(m_OpenProcessRetryCache,
                   [generation = m_DetailCacheGeneration](const auto& entry) { return entry.second.generation != generation; });
 
     // Attribute energy to processes if power monitoring is available
@@ -650,47 +658,32 @@ std::vector<ProcessCounters> WindowsProcessProbe::enumerate()
 
 bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& counters)
 {
+    const auto now = std::chrono::steady_clock::now();
+    constexpr auto OPEN_PROCESS_RETRY_TTL = std::chrono::milliseconds{2000};
+
+    if (const auto retryIt = m_OpenProcessRetryCache.find(pid); retryIt != m_OpenProcessRetryCache.end())
+    {
+        retryIt->second.generation = m_DetailCacheGeneration;
+        if (now < retryIt->second.nextRetry)
+        {
+            counters.state = '?';
+            return false;
+        }
+    }
+
     // Open process with limited access - some system processes won't allow full access
     HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ, FALSE, pid);
 
     if (hProcess == nullptr)
     {
+        m_OpenProcessRetryCache[pid] = OpenProcessRetryEntry{now + OPEN_PROCESS_RETRY_TTL, m_DetailCacheGeneration};
         // Can't access this process - leave defaults
         counters.state = '?';
         return false;
     }
+    m_OpenProcessRetryCache.erase(pid);
 
-    // Get process state
-    counters.state = getProcessState(hProcess);
-
-    // Get process priority class and map to nice-like value
-    const DWORD priorityClass = GetPriorityClass(hProcess);
-    switch (priorityClass)
-    {
-    case IDLE_PRIORITY_CLASS:
-        counters.nice = 19;
-        break;
-    case BELOW_NORMAL_PRIORITY_CLASS:
-        counters.nice = 10;
-        break;
-    case NORMAL_PRIORITY_CLASS:
-        counters.nice = 0;
-        break;
-    case ABOVE_NORMAL_PRIORITY_CLASS:
-        counters.nice = -5;
-        break;
-    case HIGH_PRIORITY_CLASS:
-        counters.nice = -10;
-        break;
-    case REALTIME_PRIORITY_CLASS:
-        counters.nice = -20;
-        break;
-    default:
-        counters.nice = 0;
-        break;
-    }
-
-    // Get CPU times
+    // Get CPU times (always read — required for CPU accounting every refresh)
     FILETIME ftCreation{};
     FILETIME ftExit{};
     FILETIME ftKernel{};
@@ -704,8 +697,6 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
         counters.startTimeTicks = filetimeToTicks(ftCreation);
         counters.startTimeEpoch = filetimeToUnixEpoch(ftCreation);
     }
-
-    const auto now = std::chrono::steady_clock::now();
 
     // When startTimeTicks is 0, GetProcessTimes failed. Treat as always-miss:
     // skip caching to prevent {pid, 0} from collapsing multiple processes onto
@@ -729,6 +720,19 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
         counters.publisher = cache.publisher;
         counters.processType = cache.processType;
         counters.gdiObjectCount = cache.gdiObjectCount;
+        // Restore slow-changing fields that are now TTL-cached.
+        // Sentinel values (-1 / '\0') indicate the cache entry was inserted but not yet populated;
+        // in that case the fields remain at their zero-initialised defaults.
+        if (cache.handleCount >= 0)
+        {
+            counters.handleCount = cache.handleCount;
+        }
+        counters.cpuAffinityMask = cache.cpuAffinityMask;
+        if (cache.state != '\0')
+        {
+            counters.state = cache.state;
+        }
+        counters.nice = cache.nice;
     }
 
     const bool refreshLightDetails = inserted || (now >= cache.nextLightRefresh);
@@ -746,6 +750,46 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
 
         // getFilePublisher() has its own path cache; this outer TTL avoids repeated path lookups.
         counters.publisher = getProcessPublisher(hProcess);
+
+        // CPU affinity rarely changes — refresh alongside heavy details.
+        DWORD_PTR processAffinityMask = 0;
+        DWORD_PTR systemAffinityMask = 0;
+        if (GetProcessAffinityMask(hProcess, &processAffinityMask, &systemAffinityMask) != 0)
+        {
+            // Safe: DWORD_PTR is pointer-sized (64-bit on x64); uint64_t can hold all values.
+            counters.cpuAffinityMask = static_cast<std::uint64_t>(processAffinityMask);
+        }
+        else
+        {
+            counters.cpuAffinityMask = 0;
+        }
+
+        // Priority class rarely changes — refresh alongside heavy details.
+        const DWORD priorityClass = GetPriorityClass(hProcess);
+        switch (priorityClass)
+        {
+        case IDLE_PRIORITY_CLASS:
+            counters.nice = 19;
+            break;
+        case BELOW_NORMAL_PRIORITY_CLASS:
+            counters.nice = 10;
+            break;
+        case NORMAL_PRIORITY_CLASS:
+            counters.nice = 0;
+            break;
+        case ABOVE_NORMAL_PRIORITY_CLASS:
+            counters.nice = -5;
+            break;
+        case HIGH_PRIORITY_CLASS:
+            counters.nice = -10;
+            break;
+        case REALTIME_PRIORITY_CLASS:
+            counters.nice = -20;
+            break;
+        default:
+            counters.nice = 0;
+            break;
+        }
     }
     else if (counters.command.empty())
     {
@@ -766,11 +810,25 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
     {
         counters.rssBytes = pmc.base.WorkingSetSize;
         counters.peakRssBytes = pmc.base.PeakWorkingSetSize;
+        counters.pageFaultCount = Domain::Numeric::narrowOr<std::uint64_t>(pmc.base.PageFaultCount, std::uint64_t{0});
 
-        if (auto vmInfo = queryProcessVmInfo(hProcess))
+        if (refreshHeavyDetails)
         {
-            counters.virtualBytes = vmInfo->virtualSizeBytes;
-            counters.pageFaultCount = vmInfo->pageFaultCount;
+            if (auto vmInfo = queryProcessVmInfo(hProcess))
+            {
+                counters.virtualBytes = vmInfo->virtualSizeBytes;
+                counters.pageFaultCount = vmInfo->pageFaultCount;
+            }
+            else if (pmc.base.PagefileUsage != 0)
+            {
+                // Fallback: commit charge (not virtual address space size, but avoids reporting RSS/Private bytes as VIRT).
+                counters.virtualBytes = pmc.base.PagefileUsage;
+            }
+            else
+            {
+                // Last resort: private bytes.
+                counters.virtualBytes = pmc.privateUsage;
+            }
         }
         else if (pmc.base.PagefileUsage != 0)
         {
@@ -792,37 +850,29 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
         counters.writeBytes = ioCounters.WriteTransferCount;
     }
 
-    // Get handle count
-    DWORD handleCount = 0;
-    if (GetProcessHandleCount(hProcess, &handleCount) != 0)
-    {
-        counters.handleCount = Domain::Numeric::narrowOr<std::int32_t>(handleCount, std::int32_t{0});
-    }
-    else
-    {
-        const auto errorCode = ::GetLastError();
-        spdlog::debug("WindowsProcessProbe: GetProcessHandleCount failed (error code: {})", errorCode);
-    }
-
-    // Get CPU affinity mask
-    DWORD_PTR processAffinityMask = 0;
-    DWORD_PTR systemAffinityMask = 0;
-    if (GetProcessAffinityMask(hProcess, &processAffinityMask, &systemAffinityMask) != 0)
-    {
-        // Convert DWORD_PTR to uint64_t (may truncate on 32-bit, but we support 64-bit only)
-        counters.cpuAffinityMask = static_cast<std::uint64_t>(processAffinityMask);
-    }
-    else
-    {
-        counters.cpuAffinityMask = 0;
-    }
-
     if (refreshLightDetails || refreshHeavyDetails)
     {
         // Medium-cost data refreshed more frequently than heavy details.
         counters.status = getProcessStatus(hProcess);
 
-        // Get GDI object count (best-effort; zero for protected/system processes).
+        // Process state (R/Z/?) changes infrequently; refresh at light TTL cadence.
+        counters.state = getProcessState(hProcess);
+
+        // Handle count changes occasionally; refresh at light TTL cadence.
+        DWORD handleCount = 0;
+        if (GetProcessHandleCount(hProcess, &handleCount) != 0)
+        {
+            counters.handleCount = Domain::Numeric::narrowOr<std::int32_t>(handleCount, std::int32_t{0});
+        }
+        else
+        {
+            spdlog::debug("WindowsProcessProbe: GetProcessHandleCount failed (error code: {})", ::GetLastError());
+        }
+    }
+
+    if (refreshHeavyDetails)
+    {
+        // Expensive classification metadata changes rarely; refresh only on heavy cadence.
         // Open a PROCESS_QUERY_INFORMATION handle — required by GetGuiResources — and share
         // it with classifyProcessType to avoid two consecutive OpenProcess calls for the same PID.
         HANDLE hQueryInfo = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, static_cast<DWORD>(pid));
@@ -842,6 +892,10 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
         cache.user = counters.user;
         cache.command = counters.command;
         cache.publisher = counters.publisher;
+        cache.processType = counters.processType;
+        cache.gdiObjectCount = counters.gdiObjectCount;
+        cache.cpuAffinityMask = counters.cpuAffinityMask;
+        cache.nice = counters.nice;
         if (canCache)
         {
             cache.nextHeavyRefresh = now + m_HeavyDetailTTL;
@@ -851,8 +905,8 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
     if (refreshLightDetails || refreshHeavyDetails)
     {
         cache.status = counters.status;
-        cache.processType = counters.processType;
-        cache.gdiObjectCount = counters.gdiObjectCount;
+        cache.state = counters.state;
+        cache.handleCount = counters.handleCount;
         if (canCache)
         {
             cache.nextLightRefresh = now + m_LightDetailTTL;
@@ -1029,41 +1083,41 @@ void WindowsProcessProbe::calculateDetailTTLsFromTotalRAM(std::chrono::milliseco
     const uint64_t totalBytes = memStatus.ullTotalPhys;
 
     // Tier thresholds and corresponding TTLs (based on total physical RAM):
-    // - < 2 GB total: Aggressive caching (preserve memory on low-end systems)
-    // - 2-4 GB: Conservative refresh (typical older laptops)
-    // - 4-8 GB: Normal refresh (typical workstations)
-    // - 8-16 GB: Frequent refresh (modern workstations)
-    // - > 16 GB: Very frequent refresh (high-performance systems)
+    // - < 2 GB total: Aggressive caching (preserve CPU/memory on low-end systems)
+    // - 2-4 GB: Conservative refresh
+    // - 4-8 GB: Balanced refresh
+    // - 8-16 GB: Slightly more frequent, but still avoids per-frame thrash
+    // - >= 16 GB: Keep responsive while preventing expensive detail recompute every sample
 
     if (totalBytes < (2ULL * 1024 * 1024 * 1024))
     {
         // < 2 GB: Cache longer to reduce CPU load on memory-constrained systems
         lightTTL = std::chrono::milliseconds(4000);
-        heavyTTL = std::chrono::milliseconds(10000);
+        heavyTTL = std::chrono::milliseconds(15000);
     }
     else if (totalBytes < (4ULL * 1024 * 1024 * 1024))
     {
         // 2-4 GB: Conservative but not aggressive
-        lightTTL = std::chrono::milliseconds(2000);
-        heavyTTL = std::chrono::milliseconds(5000);
+        lightTTL = std::chrono::milliseconds(3000);
+        heavyTTL = std::chrono::milliseconds(10000);
     }
     else if (totalBytes < (8ULL * 1024 * 1024 * 1024))
     {
-        // 4-8 GB: Normal refresh (baseline)
-        lightTTL = std::chrono::milliseconds(1000);
-        heavyTTL = std::chrono::milliseconds(3000);
+        // 4-8 GB: Balanced refresh
+        lightTTL = std::chrono::milliseconds(2000);
+        heavyTTL = std::chrono::milliseconds(8000);
     }
     else if (totalBytes < (16ULL * 1024 * 1024 * 1024))
     {
-        // 8-16 GB: Frequent refresh
-        lightTTL = std::chrono::milliseconds(500);
-        heavyTTL = std::chrono::milliseconds(2000);
+        // 8-16 GB: Moderate refresh
+        lightTTL = std::chrono::milliseconds(1500);
+        heavyTTL = std::chrono::milliseconds(6000);
     }
     else
     {
-        // >= 16 GB: Very frequent refresh for near-real-time accuracy
-        lightTTL = std::chrono::milliseconds(300);
-        heavyTTL = std::chrono::milliseconds(1000);
+        // >= 16 GB: Responsive, but avoid 1Hz+ heavy metadata refresh churn
+        lightTTL = std::chrono::milliseconds(1000);
+        heavyTTL = std::chrono::milliseconds(4000);
     }
 }
 

--- a/src/Platform/Windows/WindowsProcessProbe.cpp
+++ b/src/Platform/Windows/WindowsProcessProbe.cpp
@@ -705,6 +705,10 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
         counters.publisher = cache.publisher;
         counters.processType = cache.processType;
         counters.gdiObjectCount = cache.gdiObjectCount;
+        if (cache.virtualSizeBytes.has_value())
+        {
+            counters.virtualBytes = cache.virtualSizeBytes.value();
+        }
         // Restore slow-changing fields that are now TTL-cached.
         // Sentinel values (-1 / '\0') indicate the cache entry was inserted but not yet populated;
         // in that case the fields remain at their zero-initialised defaults.
@@ -790,6 +794,8 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
 
     ProcessMemoryCountersEx pmc{};
     pmc.base.cb = sizeof(pmc);
+    bool vmQuerySucceeded = false;
+    std::uint64_t vmVirtualSizeBytes = 0;
 
     if (GetProcessMemoryInfo(hProcess, &pmc.base, sizeof(pmc)) != 0)
     {
@@ -803,6 +809,12 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
             {
                 counters.virtualBytes = vmInfo->virtualSizeBytes;
                 counters.pageFaultCount = vmInfo->pageFaultCount;
+                vmQuerySucceeded = true;
+                vmVirtualSizeBytes = vmInfo->virtualSizeBytes;
+            }
+            else if (cache.virtualSizeBytes.has_value())
+            {
+                counters.virtualBytes = cache.virtualSizeBytes.value();
             }
             else if (pmc.base.PagefileUsage != 0)
             {
@@ -814,6 +826,10 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
                 // Last resort: private bytes.
                 counters.virtualBytes = pmc.privateUsage;
             }
+        }
+        else if (cache.virtualSizeBytes.has_value())
+        {
+            counters.virtualBytes = cache.virtualSizeBytes.value();
         }
         else if (pmc.base.PagefileUsage != 0)
         {
@@ -879,6 +895,10 @@ bool WindowsProcessProbe::getProcessDetails(uint32_t pid, ProcessCounters& count
         cache.publisher = counters.publisher;
         cache.processType = counters.processType;
         cache.gdiObjectCount = counters.gdiObjectCount;
+        if (vmQuerySucceeded)
+        {
+            cache.virtualSizeBytes = vmVirtualSizeBytes;
+        }
         cache.cpuAffinityMask = counters.cpuAffinityMask;
         cache.nice = counters.nice;
         if (canCache)

--- a/src/Platform/Windows/WindowsProcessProbe.h
+++ b/src/Platform/Windows/WindowsProcessProbe.h
@@ -101,8 +101,20 @@ class WindowsProcessProbe : public IProcessProbe
         std::string publisher;
         std::string processType;
         std::optional<std::int32_t> gdiObjectCount;
+        // Slow-changing fields cached with light/heavy TTL to avoid redundant Win32 calls.
+        // Sentinel: handleCount == -1 means "not yet populated".
+        std::int32_t handleCount = -1;     // GetProcessHandleCount (light TTL)
+        std::uint64_t cpuAffinityMask = 0; // GetProcessAffinityMask (heavy TTL)
+        std::int32_t nice = 0;             // GetPriorityClass → nice value (heavy TTL)
+        char state = '\0';                 // GetExitCodeProcess → R/Z/? (light TTL); '\0' = not yet populated
         std::chrono::steady_clock::time_point nextLightRefresh;
         std::chrono::steady_clock::time_point nextHeavyRefresh;
+        std::uint64_t generation = 0;
+    };
+
+    struct OpenProcessRetryEntry
+    {
+        std::chrono::steady_clock::time_point nextRetry;
         std::uint64_t generation = 0;
     };
 
@@ -134,7 +146,9 @@ class WindowsProcessProbe : public IProcessProbe
 
     void applyNetworkCounters(std::vector<ProcessCounters>& processes) const;
     std::unordered_map<DetailCacheKey, DetailCacheEntry, DetailCacheKeyHash> m_DetailCache;
+    std::unordered_map<std::uint32_t, OpenProcessRetryEntry> m_OpenProcessRetryCache;
     std::uint64_t m_DetailCacheGeneration = 0;
+    std::size_t m_LastEnumeratedProcessCount = 256;
 };
 
 } // namespace Platform

--- a/src/Platform/Windows/WindowsProcessProbe.h
+++ b/src/Platform/Windows/WindowsProcessProbe.h
@@ -112,12 +112,6 @@ class WindowsProcessProbe : public IProcessProbe
         std::uint64_t generation = 0;
     };
 
-    struct OpenProcessRetryEntry
-    {
-        std::chrono::steady_clock::time_point nextRetry;
-        std::uint64_t generation = 0;
-    };
-
     /// Get detailed info for a single process
     [[nodiscard]] bool getProcessDetails(uint32_t pid, ProcessCounters& counters);
 
@@ -146,7 +140,6 @@ class WindowsProcessProbe : public IProcessProbe
 
     void applyNetworkCounters(std::vector<ProcessCounters>& processes) const;
     std::unordered_map<DetailCacheKey, DetailCacheEntry, DetailCacheKeyHash> m_DetailCache;
-    std::unordered_map<std::uint32_t, OpenProcessRetryEntry> m_OpenProcessRetryCache;
     std::uint64_t m_DetailCacheGeneration = 0;
     std::size_t m_LastEnumeratedProcessCount = 256;
 };

--- a/src/Platform/Windows/WindowsProcessProbe.h
+++ b/src/Platform/Windows/WindowsProcessProbe.h
@@ -101,6 +101,7 @@ class WindowsProcessProbe : public IProcessProbe
         std::string publisher;
         std::string processType;
         std::optional<std::int32_t> gdiObjectCount;
+        std::optional<std::uint64_t> virtualSizeBytes;
         // Slow-changing fields cached with light/heavy TTL to avoid redundant Win32 calls.
         // Sentinel: handleCount == -1 means "not yet populated".
         std::int32_t handleCount = -1;     // GetProcessHandleCount (light TTL)

--- a/tools/analyze-etw.ps1
+++ b/tools/analyze-etw.ps1
@@ -116,10 +116,12 @@ $moduleReport = Join-Path $perfDir "$baseName-profile-modules.txt"
 $functionReport = Join-Path $perfDir "$baseName-profile-functions.txt"
 $summaryPath = Join-Path $perfDir "$baseName-summary.txt"
 
-$symbolDir = if ($SymbolPath) { $SymbolPath } else { Join-Path $repoRoot 'build\win-profile\bin' }
-$resolvedSymbolDir = Resolve-Path $symbolDir -ErrorAction Stop
-$env:_NT_SYMBOL_PATH = $resolvedSymbolDir.Path
 $env:_NT_SYMCACHE_PATH = Join-Path $perfDir 'SymCache'
+if (-not $SkipFunctions) {
+    $symbolDir = if ($SymbolPath) { $SymbolPath } else { Join-Path $repoRoot 'build\win-profile\bin' }
+    $resolvedSymbolDir = Resolve-Path $symbolDir -ErrorAction Stop
+    $env:_NT_SYMBOL_PATH = $resolvedSymbolDir.Path
+}
 New-Item -ItemType Directory -Path $env:_NT_SYMCACHE_PATH -Force | Out-Null
 
 & xperf -i $traceFile -quiet -tle -a profile -detail 2>&1 | Set-Content -Path $moduleReport

--- a/tools/analyze-etw.ps1
+++ b/tools/analyze-etw.ps1
@@ -1,0 +1,190 @@
+<#
+.SYNOPSIS
+    Analyze a TaskSmack ETW CPU trace using xperf.
+.DESCRIPTION
+    Exports module-level and function-level sampled CPU reports, then prints the top
+    TaskSmack-specific modules and functions for a chosen process name / PID.
+.PARAMETER TracePath
+    Path to the ETW trace (.etl).
+.PARAMETER ProcessName
+    Process name to filter in the exported xperf reports. Defaults to TaskSmack.exe.
+.PARAMETER ProcessId
+    Optional PID to disambiguate multiple processes with the same name.
+.PARAMETER SymbolPath
+    Optional symbol path used for function decoding. Defaults to build/win-profile/bin.
+    When analyzing traces captured from win-optimized, function decoding may be limited.
+.PARAMETER Top
+    Number of rows to print in each summary.
+.PARAMETER SkipFunctions
+    Skip function-level symbol decoding and only export module-level hotspots.
+.EXAMPLE
+    pwsh tools/analyze-etw.ps1 -TracePath .\perf-data\etw-app-20260604-104009.etl
+.EXAMPLE
+    pwsh tools/analyze-etw.ps1 -TracePath .\perf-data\etw-app-20260604-104009.etl -ProcessId 7412
+.EXAMPLE
+    pwsh tools/analyze-etw.ps1 -TracePath .\perf-data\etw-app-20260604-104009.etl -SkipFunctions
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TracePath,
+
+    [string]$ProcessName = 'TaskSmack.exe',
+
+    [int]$ProcessId,
+
+    [string]$SymbolPath,
+
+    [int]$Top = 20,
+
+    [switch]$SkipFunctions
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Exe,
+
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    & $Exe @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: $Exe $($Arguments -join ' ')"
+    }
+}
+
+function Parse-XperfRows {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TargetProcessName,
+
+        [int]$TargetProcessId
+    )
+
+    $pattern = if ($TargetProcessId -ne 0) {
+        '^\s*(?:.+?) \(' + [regex]::Escape([string]$TargetProcessId) + '\),\s*([0-9]+),\s*([0-9.]+),\s*(.+)$'
+    }
+    else {
+        '^\s*' + [regex]::Escape($TargetProcessName) + ' \(([0-9]+)\),\s*([0-9]+),\s*([0-9.]+),\s*(.+)$'
+    }
+
+    foreach ($line in Get-Content $FilePath) {
+        if ($line -match $pattern) {
+            if ($TargetProcessId -ne 0) {
+                [pscustomobject]@{
+                    ProcessName = $TargetProcessName
+                    ProcessId   = $TargetProcessId
+                    Weight      = [int64]$Matches[1]
+                    Usage       = [double]$Matches[2]
+                    Symbol      = $Matches[3].Trim()
+                }
+            }
+            else {
+                [pscustomobject]@{
+                    ProcessName = $TargetProcessName
+                    ProcessId   = [int]$Matches[1]
+                    Weight      = [int64]$Matches[2]
+                    Usage       = [double]$Matches[3]
+                    Symbol      = $Matches[4].Trim()
+                }
+            }
+        }
+    }
+}
+
+$xperf = Get-Command xperf -ErrorAction SilentlyContinue
+if (-not $xperf) {
+    throw 'xperf not found on PATH.'
+}
+
+$resolvedTrace = Resolve-Path $TracePath
+$traceFile = $resolvedTrace.Path
+$baseName = [IO.Path]::GetFileNameWithoutExtension($traceFile)
+$perfDir = Split-Path -Parent $traceFile
+$moduleReport = Join-Path $perfDir "$baseName-profile-modules.txt"
+$functionReport = Join-Path $perfDir "$baseName-profile-functions.txt"
+$summaryPath = Join-Path $perfDir "$baseName-summary.txt"
+
+$symbolDir = if ($SymbolPath) { $SymbolPath } else { Join-Path $repoRoot 'build\win-profile\bin' }
+$resolvedSymbolDir = Resolve-Path $symbolDir -ErrorAction Stop
+$env:_NT_SYMBOL_PATH = $resolvedSymbolDir.Path
+$env:_NT_SYMCACHE_PATH = Join-Path $perfDir 'SymCache'
+New-Item -ItemType Directory -Path $env:_NT_SYMCACHE_PATH -Force | Out-Null
+
+& xperf -i $traceFile -quiet -tle -a profile -detail 2>&1 | Set-Content -Path $moduleReport
+if ($LASTEXITCODE -ne 0) {
+    throw "xperf module export failed with exit code $LASTEXITCODE"
+}
+
+if (-not $SkipFunctions) {
+    & xperf -i $traceFile -quiet -tle -symbols -a profile -detail 2>&1 | Set-Content -Path $functionReport
+    if ($LASTEXITCODE -ne 0) {
+        throw "xperf function export failed with exit code $LASTEXITCODE"
+    }
+}
+
+$parseParams = @{ FilePath = $moduleReport; TargetProcessName = $ProcessName }
+if ($PSBoundParameters.ContainsKey('ProcessId')) {
+    $parseParams.TargetProcessId = $ProcessId
+}
+
+$moduleRows = @(Parse-XperfRows @parseParams)
+if ($moduleRows.Count -eq 0) {
+    throw "No rows found for $ProcessName in $moduleReport"
+}
+
+if (-not $PSBoundParameters.ContainsKey('ProcessId')) {
+    $selected = $moduleRows | Group-Object ProcessId | ForEach-Object {
+        [pscustomobject]@{
+            ProcessId = [int]$_.Name
+            Weight = ($_.Group | Measure-Object -Property Weight -Sum).Sum
+        }
+    } | Sort-Object Weight -Descending | Select-Object -First 1
+    $ProcessId = $selected.ProcessId
+    $moduleRows = $moduleRows | Where-Object { $_.ProcessId -eq $ProcessId }
+}
+
+$functionRows = @()
+if ((-not $SkipFunctions) -and (Test-Path $functionReport)) {
+    $functionRows = @(Parse-XperfRows -FilePath $functionReport -TargetProcessName $ProcessName -TargetProcessId $ProcessId)
+}
+
+$moduleTotal = ($moduleRows | Measure-Object -Property Weight -Sum).Sum
+$topModules = $moduleRows | Sort-Object Weight -Descending | Select-Object -First $Top @{n='ProcessSharePct';e={[math]::Round(($_.Weight / $moduleTotal) * 100, 2)}}, Weight, Usage, @{n='Module';e={$_.Symbol}}
+
+$summaryLines = @()
+$summaryLines += "Trace: $traceFile"
+$summaryLines += "Process: $ProcessName ($ProcessId)"
+$summaryLines += "Module report: $moduleReport"
+if (-not $SkipFunctions) {
+    $summaryLines += "Function report: $functionReport"
+}
+$summaryLines += ''
+$summaryLines += 'Top Modules'
+$summaryLines += ($topModules | Format-Table -AutoSize | Out-String -Width 240).TrimEnd()
+
+if ($functionRows.Count -gt 0) {
+    $appFunctions = $functionRows | Where-Object { $_.Symbol -like "$ProcessName!*" }
+    $functionTotal = ($appFunctions | Measure-Object -Property Weight -Sum).Sum
+    $topFunctions = $appFunctions | Sort-Object Weight -Descending | Select-Object -First $Top @{n='CodeSharePct';e={[math]::Round(($_.Weight / $functionTotal) * 100, 2)}}, Weight, Usage, @{n='Function';e={$_.Symbol}}
+    $summaryLines += ''
+    $summaryLines += 'Top Functions'
+    $summaryLines += ($topFunctions | Format-Table -AutoSize | Out-String -Width 240).TrimEnd()
+}
+
+$summaryText = $summaryLines -join [Environment]::NewLine
+$summaryText | Set-Content -Path $summaryPath
+Write-Host $summaryText
+Write-Host ''
+Write-Host "SUMMARY=$summaryPath"

--- a/tools/check-prereqs.ps1
+++ b/tools/check-prereqs.ps1
@@ -403,6 +403,39 @@ else {
     # Don't fail for optional coverage tools
 }
 
+# Optional Windows profiling tools
+$wprPath = Get-ToolPath "wpr"
+if ($wprPath) {
+    Write-Status -Name "wpr" -Status "ok" -Version "available" -Path $wprPath -Required ""
+}
+else {
+    Write-Status -Name "wpr" -Status "fail" -Version $null -Path $wprPath -Required ""
+}
+
+$xperfPath = Get-ToolPath "xperf"
+if ($xperfPath) {
+    Write-Status -Name "xperf" -Status "ok" -Version "available" -Path $xperfPath -Required ""
+}
+else {
+    Write-Status -Name "xperf" -Status "fail" -Version $null -Path $xperfPath -Required ""
+}
+
+$wpaPath = Get-ToolPath "wpa"
+if ($wpaPath) {
+    Write-Status -Name "wpa" -Status "ok" -Version "available" -Path $wpaPath -Required ""
+}
+else {
+    Write-Status -Name "wpa" -Status "fail" -Version $null -Path $wpaPath -Required ""
+}
+
+$wpaExporterPath = Get-ToolPath "wpaexporter"
+if ($wpaExporterPath) {
+    Write-Status -Name "wpaexporter" -Status "ok" -Version "available" -Path $wpaExporterPath -Required ""
+}
+else {
+    Write-Status -Name "wpaexporter" -Status "fail" -Version $null -Path $wpaExporterPath -Required ""
+}
+
 # Check Python 3 (required for GLAD OpenGL loader generation)
 $python3Ver = Get-Python3Version
 $pythonCmd = Get-WorkingPythonCommand

--- a/tools/profile-etw.ps1
+++ b/tools/profile-etw.ps1
@@ -1,0 +1,214 @@
+<#
+.SYNOPSIS
+    Capture a reusable ETW CPU trace for TaskSmack on Windows.
+.DESCRIPTION
+    Self-elevates if needed, starts a WPR CPU trace, runs either the real app or a
+    focused benchmark workload, then stops tracing and writes artifacts under perf-data/.
+.PARAMETER Mode
+    app   - launch TaskSmack.exe and wait until it exits
+    bench - run TaskSmackBenchmarks.exe with the supplied benchmark filter
+.PARAMETER Preset
+        Build preset that contains the binaries to run. Defaults depend on mode:
+            - app   -> win-optimized for production-like timings
+            - bench -> win-benchmark for non-debug-info benchmark binaries
+        Use win-profile explicitly when you want a symbol-rich frame-pointer build for
+        deeper follow-up analysis.
+.PARAMETER SkipBuild
+    Skip configure/build and use the existing binaries.
+.PARAMETER BenchmarkFilter
+    Google Benchmark filter used when Mode=bench.
+.PARAMETER BenchmarkRepetitions
+    Repetition count for benchmark-mode capture.
+.PARAMETER BenchmarkMinTime
+    Minimum time per benchmark repetition for benchmark-mode capture.
+.EXAMPLE
+    pwsh tools/profile-etw.ps1 app
+.EXAMPLE
+    pwsh tools/profile-etw.ps1 bench -BenchmarkFilter 'BM_SystemModel_Refresh$'
+.EXAMPLE
+    pwsh tools/profile-etw.ps1 app -Preset win-profile
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('app', 'bench')]
+    [string]$Mode = 'app',
+
+    [string]$Preset = '',
+
+    [string]$Timestamp,
+
+    [switch]$SkipBuild,
+
+    [string]$BenchmarkFilter = 'BM_(ProcessProbe_Enumerate|ProcessModel_Refresh|SystemProbe_Sample|SystemModel_Refresh|GPUProbe_ReadCounters|GPUModel_Refresh)$',
+
+    [int]$BenchmarkRepetitions = 5,
+
+    [string]$BenchmarkMinTime = '0.5s'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$perfDir = Join-Path $repoRoot 'perf-data'
+
+if ([string]::IsNullOrWhiteSpace($Preset)) {
+    $Preset = if ($Mode -eq 'app') { 'win-optimized' } else { 'win-benchmark' }
+}
+
+if (-not $Timestamp) {
+    $Timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+}
+
+$prefix = if ($Mode -eq 'app') { 'etw-app' } else { 'etw-bench' }
+$tracePath = Join-Path $perfDir "$prefix-$Timestamp.etl"
+$childLogPath = Join-Path $perfDir "$prefix-child-$Timestamp.log"
+$launcherLogPath = Join-Path $perfDir "$prefix-launch-$Timestamp.log"
+$benchJsonPath = Join-Path $perfDir "$prefix-$Timestamp.json"
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Exe,
+
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    & $Exe @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: $Exe $($Arguments -join ' ')"
+    }
+}
+
+function Test-IsAdministrator {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Ensure-Tool {
+    param([Parameter(Mandatory = $true)][string]$Command)
+    $cmd = Get-Command $Command -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        throw "Required command not found on PATH: $Command"
+    }
+    return $cmd.Source
+}
+
+function Ensure-Binary {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Required binary not found: $Path"
+    }
+}
+
+if (-not (Test-IsAdministrator)) {
+    New-Item -ItemType Directory -Path $perfDir -Force | Out-Null
+
+    if (-not $SkipBuild) {
+        Invoke-Native cmake '--preset' $Preset
+        Invoke-Native cmake '--build' '--preset' $Preset
+    }
+
+    # Validate WPR availability before prompting for elevation so failures are immediate.
+    $null = Ensure-Tool 'wpr'
+
+    # Relaunch using the current PowerShell host (pwsh or powershell) for consistent behavior.
+    $hostExe = (Get-Process -Id $PID).Path
+    if ([string]::IsNullOrWhiteSpace($hostExe)) {
+        throw 'Unable to resolve current PowerShell host executable path for elevation.'
+    }
+
+    # Child run always uses -SkipBuild: if needed, parent already built before elevation.
+    $argList = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath, '-Mode', $Mode, '-Preset', $Preset, '-Timestamp', $Timestamp, '-BenchmarkFilter', $BenchmarkFilter, '-BenchmarkRepetitions', "$BenchmarkRepetitions", '-BenchmarkMinTime', $BenchmarkMinTime, '-SkipBuild')
+
+    $launchCommand = "$hostExe $($argList -join ' ')"
+    "LAUNCH=$launchCommand" | Set-Content -Path $launcherLogPath -Encoding utf8
+
+    $childProcess = Start-Process -FilePath $hostExe -Verb RunAs -ArgumentList $argList -WorkingDirectory $repoRoot -Wait -PassThru
+    "EXIT_CODE=$($childProcess.ExitCode)" | Add-Content -Path $launcherLogPath -Encoding utf8
+
+    if ($childProcess.ExitCode -ne 0) {
+        throw "Elevated ETW capture child process failed with exit code $($childProcess.ExitCode). Check $launcherLogPath and $childLogPath when present."
+    }
+
+    $missingArtifacts = @()
+    if (-not (Test-Path -LiteralPath $childLogPath)) {
+        $missingArtifacts += $childLogPath
+    }
+    if (-not (Test-Path -LiteralPath $tracePath)) {
+        $missingArtifacts += $tracePath
+    }
+    if (($Mode -eq 'bench') -and (-not (Test-Path -LiteralPath $benchJsonPath))) {
+        $missingArtifacts += $benchJsonPath
+    }
+
+    if ($missingArtifacts.Count -gt 0) {
+        $artifactList = $missingArtifacts -join ', '
+        throw "Elevated ETW capture did not produce expected artifact(s): $artifactList. This usually means the UAC prompt was denied or the elevated child failed before trace shutdown. Check $launcherLogPath and $childLogPath when present."
+    }
+
+    Write-Host "TRACE=$tracePath"
+    Write-Host "CHILD_LOG=$childLogPath"
+    Write-Host "LAUNCHER_LOG=$launcherLogPath"
+    Write-Host "PRESET=$Preset"
+    if ($Mode -eq 'bench') {
+        Write-Host "BENCH=$benchJsonPath"
+    }
+    return
+}
+
+New-Item -ItemType Directory -Path $perfDir -Force | Out-Null
+
+$null = Ensure-Tool 'wpr'
+
+if (-not $SkipBuild) {
+    Invoke-Native cmake '--preset' $Preset
+    Invoke-Native cmake '--build' '--preset' $Preset
+}
+
+$binaryName = if ($Mode -eq 'app') { 'TaskSmack.exe' } else { 'TaskSmackBenchmarks.exe' }
+$binaryPath = Join-Path $repoRoot "build/$Preset/bin/$binaryName"
+Ensure-Binary $binaryPath
+
+$logPath = $childLogPath
+
+Start-Transcript -Path $logPath -Force | Out-Null
+try {
+    Write-Host "Starting ETW capture ($Mode)"
+    Write-Host "Trace: $tracePath"
+    Write-Host "Preset: $Preset"
+
+    cmd /c "wpr -cancel >nul 2>&1" | Out-Null
+
+    Invoke-Native wpr '-start' 'CPU' '-filemode'
+
+    if ($Mode -eq 'app') {
+        $proc = Start-Process -FilePath $binaryPath -PassThru
+        Write-Host "Launched app PID: $($proc.Id)"
+        Write-Host 'Exercise the application, then close it to finish the trace.'
+        Wait-Process -Id $proc.Id
+    }
+    else {
+        Invoke-Native $binaryPath "--benchmark_filter=$BenchmarkFilter" "--benchmark_repetitions=$BenchmarkRepetitions" "--benchmark_min_time=$BenchmarkMinTime" '--benchmark_report_aggregates_only=true' '--benchmark_display_aggregates_only=true' "--benchmark_out=$benchJsonPath" '--benchmark_out_format=json'
+        Write-Host "Benchmark JSON: $benchJsonPath"
+    }
+
+    Invoke-Native wpr '-stop' $tracePath
+    Write-Host "ETW_TRACE=$tracePath"
+    if ($Mode -eq 'bench') {
+        Write-Host "ETW_BENCH=$benchJsonPath"
+    }
+}
+finally {
+    Stop-Transcript | Out-Null
+}
+
+Write-Host "TRACE=$tracePath"
+Write-Host "CHILD_LOG=$logPath"
+Write-Host "PRESET=$Preset"
+if ($Mode -eq 'bench') {
+    Write-Host "BENCH=$benchJsonPath"
+}

--- a/tools/profile-etw.ps1
+++ b/tools/profile-etw.ps1
@@ -122,7 +122,7 @@ if (-not (Test-IsAdministrator)) {
     }
 
     # Child run always uses -SkipBuild: if needed, parent already built before elevation.
-    $argList = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath, '-Mode', $Mode, '-Preset', $Preset, '-Timestamp', $Timestamp, '-BenchmarkFilter', $BenchmarkFilter, '-BenchmarkRepetitions', "$BenchmarkRepetitions", '-BenchmarkMinTime', $BenchmarkMinTime, '-SkipBuild')
+    $argList = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "$PSCommandPath", '-Mode', $Mode, '-Preset', $Preset, '-Timestamp', $Timestamp, '-BenchmarkFilter', $BenchmarkFilter, '-BenchmarkRepetitions', "$BenchmarkRepetitions", '-BenchmarkMinTime', $BenchmarkMinTime, '-SkipBuild')
 
     $launchCommand = "$hostExe $($argList -join ' ')"
     "LAUNCH=$launchCommand" | Set-Content -Path $launcherLogPath -Encoding utf8
@@ -203,6 +203,7 @@ try {
     }
 }
 finally {
+    cmd /c "wpr -cancel >nul 2>&1" | Out-Null
     Stop-Transcript | Out-Null
 }
 


### PR DESCRIPTION
## Summary
- optimize Windows process probing hot path in `WindowsProcessProbe::getProcessDetails`
- reduce VM counter query frequency to heavy refresh cadence while keeping per-sample memory/page-fault updates
- improve process panel rendering performance and alignment updates
- add ETW profiling helper scripts and prerequisites checks
- update profiling presets/docs used by profiling workflow

## Notes
- generated perf-data JSON artifacts are intentionally excluded from this commit
- direct pushes to `main` are blocked by repository rules, so this PR is from a feature branch