### PR TITLE
perf: Optimize ImPlot chart rendering (wins #2 & #3)

### DIFF
--- a/src/App/Panels/CpuCoresSection.cpp
+++ b/src/App/Panels/CpuCoresSection.cpp
@@ -160,7 +160,11 @@ void renderCpuCoresSection(RenderContext& ctx)
                                                  timeData.data(),
                                                  sampleData.data(),
                                                  UI::Format::checkedCount(timeData.size()),
-                                                 themeRef.scheme().chartCpu);
+                                                 themeRef.scheme().chartCpu,
+                                                 std::nullopt,
+                                                 2.0F,
+                                                 true,
+                                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
                                 if (ImPlot::IsPlotHovered() && !timeData.empty())
                                 {

--- a/src/App/Panels/GpuSection.cpp
+++ b/src/App/Panels/GpuSection.cpp
@@ -242,7 +242,7 @@ void renderGpuSection(RenderContext& ctx)
                                   timeData.data(),
                                   clockPercentBuf.data(),
                                   UI::Format::checkedCount(clockPercentBuf.size()),
-                                  theme.scheme().gpuClockFill);
+                                  theme.scheme().gpuClock);
                 }
 
                 // Encoder utilization

--- a/src/App/Panels/GpuSection.cpp
+++ b/src/App/Panels/GpuSection.cpp
@@ -34,6 +34,7 @@ using UI::Widgets::initializeOrSmooth;
 using UI::Widgets::makeTimeAxisConfig;
 using UI::Widgets::NowBar;
 using UI::Widgets::PLOT_FLAGS_DEFAULT;
+using UI::Widgets::plotDenseLine;
 using UI::Widgets::plotLineWithFill;
 using UI::Widgets::renderHistoryWithNowBars;
 using UI::Widgets::X_AXIS_FLAGS_DEFAULT;
@@ -220,71 +221,48 @@ void renderGpuSection(RenderContext& ctx)
 
                 if (!utilHist.empty())
                 {
-                    plotLineWithFill("Utilization",
-                                     timeData.data(),
-                                     utilHist.data(),
-                                     UI::Format::checkedCount(utilHist.size()),
-                                     theme.scheme().gpuUtilization,
-                                     std::nullopt,
-                                     2.0F,
-                                     false,
-                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                    plotDenseLine("Utilization",
+                                  timeData.data(),
+                                  utilHist.data(),
+                                  UI::Format::checkedCount(utilHist.size()),
+                                  theme.scheme().gpuUtilization);
                 }
 
                 if (!memHist.empty())
                 {
-                    plotLineWithFill("Memory",
-                                     timeData.data(),
-                                     memHist.data(),
-                                     UI::Format::checkedCount(memHist.size()),
-                                     theme.scheme().gpuMemory,
-                                     std::nullopt,
-                                     2.0F,
-                                     false,
-                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                    plotDenseLine(
+                        "Memory", timeData.data(), memHist.data(), UI::Format::checkedCount(memHist.size()), theme.scheme().gpuMemory);
                 }
 
                 // Plot clock as normalized percentage (0-maxClockMHz mapped to 0-100)
                 if (caps.hasClockSpeeds && !clockHist.empty())
                 {
                     normalizeToPercent(clockHist, maxClockMHz, clockPercentBuf);
-                    plotLineWithFill("Clock",
-                                     timeData.data(),
-                                     clockPercentBuf.data(),
-                                     UI::Format::checkedCount(clockPercentBuf.size()),
-                                     theme.scheme().gpuClockFill,
-                                     std::nullopt,
-                                     2.0F,
-                                     false,
-                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                    plotDenseLine("Clock",
+                                  timeData.data(),
+                                  clockPercentBuf.data(),
+                                  UI::Format::checkedCount(clockPercentBuf.size()),
+                                  theme.scheme().gpuClockFill);
                 }
 
                 // Encoder utilization
                 if (caps.hasEncoderDecoder && !encoderHist.empty())
                 {
-                    plotLineWithFill("Encoder",
-                                     timeData.data(),
-                                     encoderHist.data(),
-                                     UI::Format::checkedCount(encoderHist.size()),
-                                     theme.scheme().gpuEncoder,
-                                     std::nullopt,
-                                     2.0F,
-                                     false,
-                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                    plotDenseLine("Encoder",
+                                  timeData.data(),
+                                  encoderHist.data(),
+                                  UI::Format::checkedCount(encoderHist.size()),
+                                  theme.scheme().gpuEncoder);
                 }
 
                 // Decoder utilization
                 if (caps.hasEncoderDecoder && !decoderHist.empty())
                 {
-                    plotLineWithFill("Decoder",
-                                     timeData.data(),
-                                     decoderHist.data(),
-                                     UI::Format::checkedCount(decoderHist.size()),
-                                     theme.scheme().gpuDecoder,
-                                     std::nullopt,
-                                     2.0F,
-                                     false,
-                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                    plotDenseLine("Decoder",
+                                  timeData.data(),
+                                  decoderHist.data(),
+                                  UI::Format::checkedCount(decoderHist.size()),
+                                  theme.scheme().gpuDecoder);
                 }
 
                 // Tooltip on hover

--- a/src/App/Panels/GpuSection.cpp
+++ b/src/App/Panels/GpuSection.cpp
@@ -224,13 +224,24 @@ void renderGpuSection(RenderContext& ctx)
                                      timeData.data(),
                                      utilHist.data(),
                                      UI::Format::checkedCount(utilHist.size()),
-                                     theme.scheme().gpuUtilization);
+                                     theme.scheme().gpuUtilization,
+                                     std::nullopt,
+                                     2.0F,
+                                     false,
+                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                 }
 
                 if (!memHist.empty())
                 {
-                    plotLineWithFill(
-                        "Memory", timeData.data(), memHist.data(), UI::Format::checkedCount(memHist.size()), theme.scheme().gpuMemory);
+                    plotLineWithFill("Memory",
+                                     timeData.data(),
+                                     memHist.data(),
+                                     UI::Format::checkedCount(memHist.size()),
+                                     theme.scheme().gpuMemory,
+                                     std::nullopt,
+                                     2.0F,
+                                     false,
+                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                 }
 
                 // Plot clock as normalized percentage (0-maxClockMHz mapped to 0-100)
@@ -241,7 +252,11 @@ void renderGpuSection(RenderContext& ctx)
                                      timeData.data(),
                                      clockPercentBuf.data(),
                                      UI::Format::checkedCount(clockPercentBuf.size()),
-                                     theme.scheme().gpuClockFill);
+                                     theme.scheme().gpuClockFill,
+                                     std::nullopt,
+                                     2.0F,
+                                     false,
+                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                 }
 
                 // Encoder utilization
@@ -251,7 +266,11 @@ void renderGpuSection(RenderContext& ctx)
                                      timeData.data(),
                                      encoderHist.data(),
                                      UI::Format::checkedCount(encoderHist.size()),
-                                     theme.scheme().gpuEncoder);
+                                     theme.scheme().gpuEncoder,
+                                     std::nullopt,
+                                     2.0F,
+                                     false,
+                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                 }
 
                 // Decoder utilization
@@ -261,7 +280,11 @@ void renderGpuSection(RenderContext& ctx)
                                      timeData.data(),
                                      decoderHist.data(),
                                      UI::Format::checkedCount(decoderHist.size()),
-                                     theme.scheme().gpuDecoder);
+                                     theme.scheme().gpuDecoder,
+                                     std::nullopt,
+                                     2.0F,
+                                     false,
+                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                 }
 
                 // Tooltip on hover
@@ -462,7 +485,11 @@ void renderGpuSection(RenderContext& ctx)
                                          timeData.data(),
                                          tempPercentBuf.data(),
                                          UI::Format::checkedCount(tempPercentBuf.size()),
-                                         theme.scheme().gpuTemperature);
+                                         theme.scheme().gpuTemperature,
+                                         std::nullopt,
+                                         2.0F,
+                                         false,
+                                         UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                     }
 
                     // Power (normalized to power limit percentage)
@@ -473,14 +500,25 @@ void renderGpuSection(RenderContext& ctx)
                                          timeData.data(),
                                          powerPercentBuf.data(),
                                          UI::Format::checkedCount(powerPercentBuf.size()),
-                                         theme.scheme().gpuPower);
+                                         theme.scheme().gpuPower,
+                                         std::nullopt,
+                                         2.0F,
+                                         false,
+                                         UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                     }
 
                     // Fan speed (already a percentage)
                     if (caps.hasFanSpeed && !fanHist.empty())
                     {
-                        plotLineWithFill(
-                            "Fan", timeData.data(), fanHist.data(), UI::Format::checkedCount(fanHist.size()), theme.scheme().gpuFan);
+                        plotLineWithFill("Fan",
+                                         timeData.data(),
+                                         fanHist.data(),
+                                         UI::Format::checkedCount(fanHist.size()),
+                                         theme.scheme().gpuFan,
+                                         std::nullopt,
+                                         2.0F,
+                                         false,
+                                         UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                     }
 
                     // Tooltip on hover

--- a/src/App/Panels/MemorySection.cpp
+++ b/src/App/Panels/MemorySection.cpp
@@ -112,21 +112,42 @@ void renderMemorySection(RenderContext& ctx, const std::vector<double>& timestam
 
             if (!memHist.empty())
             {
-                plotLineWithFill(
-                    "Used", timeData.data(), memHist.data(), UI::Format::checkedCount(memHist.size()), theme.scheme().chartMemory);
+                plotLineWithFill("Used",
+                                 timeData.data(),
+                                 memHist.data(),
+                                 UI::Format::checkedCount(memHist.size()),
+                                 theme.scheme().chartMemory,
+                                 std::nullopt,
+                                 2.0F,
+                                 true,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                 peakMemPercent = static_cast<double>(*std::ranges::max_element(memHist));
             }
 
             if (!cachedHist.empty())
             {
-                plotLineWithFill(
-                    "Cached", timeData.data(), cachedHist.data(), UI::Format::checkedCount(cachedHist.size()), theme.scheme().chartCpu);
+                plotLineWithFill("Cached",
+                                 timeData.data(),
+                                 cachedHist.data(),
+                                 UI::Format::checkedCount(cachedHist.size()),
+                                 theme.scheme().chartCpu,
+                                 std::nullopt,
+                                 2.0F,
+                                 true,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
             }
 
             if (!swapHist.empty())
             {
-                plotLineWithFill(
-                    "Swap", timeData.data(), swapHist.data(), UI::Format::checkedCount(swapHist.size()), theme.scheme().chartIo);
+                plotLineWithFill("Swap",
+                                 timeData.data(),
+                                 swapHist.data(),
+                                 UI::Format::checkedCount(swapHist.size()),
+                                 theme.scheme().chartIo,
+                                 std::nullopt,
+                                 2.0F,
+                                 true,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
             }
 
             // Peak memory reference line

--- a/src/App/Panels/NetworkSection.cpp
+++ b/src/App/Panels/NetworkSection.cpp
@@ -318,34 +318,21 @@ void renderNetworkSection(RenderContext& ctx)
             // When an interface is selected, show both total (muted) and interface (bright)
             if (showingInterface && !ifaceSentData.empty() && !ifaceRecvData.empty())
             {
-                // Total lines (muted, in background) — scale fill alpha to match the muted line alpha
-                const auto ifaceSentFill = UI::withAlpha(theme.scheme().chartNetTxFill, theme.scheme().chartNetTxFill.w * 0.7F);
-                const auto ifaceRecvFill = UI::withAlpha(theme.scheme().chartNetRxFill, theme.scheme().chartNetRxFill.w * 0.7F);
-                plotDenseLine("Sent (Total)", netTimes.data(), sentData.data(), count, ifaceSentColor, ifaceSentFill);
-                plotDenseLine("Received (Total)", netTimes.data(), recvData.data(), count, ifaceRecvColor, ifaceRecvFill);
+                // Total lines (muted, in background) — line-only, no fill
+                plotDenseLine("Sent (Total)", netTimes.data(), sentData.data(), count, ifaceSentColor);
+                plotDenseLine("Received (Total)", netTimes.data(), recvData.data(), count, ifaceRecvColor);
 
                 // Interface-specific lines (bright, in foreground)
                 const auto ifaceSentLabel = std::format("{} Sent", ifaceDisplayName);
                 const auto ifaceRecvLabel = std::format("{} Received", ifaceDisplayName);
-                plotDenseLine(ifaceSentLabel.c_str(),
-                              netTimes.data(),
-                              ifaceSentData.data(),
-                              count,
-                              theme.scheme().chartNetTx,
-                              theme.scheme().chartNetTxFill);
-                plotDenseLine(ifaceRecvLabel.c_str(),
-                              netTimes.data(),
-                              ifaceRecvData.data(),
-                              count,
-                              theme.scheme().chartNetRx,
-                              theme.scheme().chartNetRxFill);
+                plotDenseLine(ifaceSentLabel.c_str(), netTimes.data(), ifaceSentData.data(), count, theme.scheme().chartNetTx);
+                plotDenseLine(ifaceRecvLabel.c_str(), netTimes.data(), ifaceRecvData.data(), count, theme.scheme().chartNetRx);
             }
             else
             {
                 // Just total
-                plotDenseLine("Sent", netTimes.data(), sentData.data(), count, theme.scheme().chartNetTx, theme.scheme().chartNetTxFill);
-                plotDenseLine(
-                    "Received", netTimes.data(), recvData.data(), count, theme.scheme().chartNetRx, theme.scheme().chartNetRxFill);
+                plotDenseLine("Sent", netTimes.data(), sentData.data(), count, theme.scheme().chartNetTx);
+                plotDenseLine("Received", netTimes.data(), recvData.data(), count, theme.scheme().chartNetRx);
             }
 
             if (ImPlot::IsPlotHovered())

--- a/src/App/Panels/NetworkSection.cpp
+++ b/src/App/Panels/NetworkSection.cpp
@@ -321,8 +321,24 @@ void renderNetworkSection(RenderContext& ctx)
                 // Total lines (muted, in background) — scale fill alpha to match the muted line alpha
                 const auto ifaceSentFill = UI::withAlpha(theme.scheme().chartNetTxFill, theme.scheme().chartNetTxFill.w * 0.7F);
                 const auto ifaceRecvFill = UI::withAlpha(theme.scheme().chartNetRxFill, theme.scheme().chartNetRxFill.w * 0.7F);
-                plotLineWithFill("Sent (Total)", netTimes.data(), sentData.data(), count, ifaceSentColor, ifaceSentFill);
-                plotLineWithFill("Received (Total)", netTimes.data(), recvData.data(), count, ifaceRecvColor, ifaceRecvFill);
+                plotLineWithFill("Sent (Total)",
+                                 netTimes.data(),
+                                 sentData.data(),
+                                 count,
+                                 ifaceSentColor,
+                                 ifaceSentFill,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotLineWithFill("Received (Total)",
+                                 netTimes.data(),
+                                 recvData.data(),
+                                 count,
+                                 ifaceRecvColor,
+                                 ifaceRecvFill,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
                 // Interface-specific lines (bright, in foreground)
                 const auto ifaceSentLabel = std::format("{} Sent", ifaceDisplayName);
@@ -332,20 +348,41 @@ void renderNetworkSection(RenderContext& ctx)
                                  ifaceSentData.data(),
                                  count,
                                  theme.scheme().chartNetTx,
-                                 theme.scheme().chartNetTxFill);
+                                 theme.scheme().chartNetTxFill,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                 plotLineWithFill(ifaceRecvLabel.c_str(),
                                  netTimes.data(),
                                  ifaceRecvData.data(),
                                  count,
                                  theme.scheme().chartNetRx,
-                                 theme.scheme().chartNetRxFill);
+                                 theme.scheme().chartNetRxFill,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
             }
             else
             {
                 // Just total
-                plotLineWithFill("Sent", netTimes.data(), sentData.data(), count, theme.scheme().chartNetTx, theme.scheme().chartNetTxFill);
-                plotLineWithFill(
-                    "Received", netTimes.data(), recvData.data(), count, theme.scheme().chartNetRx, theme.scheme().chartNetRxFill);
+                plotLineWithFill("Sent",
+                                 netTimes.data(),
+                                 sentData.data(),
+                                 count,
+                                 theme.scheme().chartNetTx,
+                                 theme.scheme().chartNetTxFill,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotLineWithFill("Received",
+                                 netTimes.data(),
+                                 recvData.data(),
+                                 count,
+                                 theme.scheme().chartNetRx,
+                                 theme.scheme().chartNetRxFill,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
             }
 
             if (ImPlot::IsPlotHovered())

--- a/src/App/Panels/NetworkSection.cpp
+++ b/src/App/Panels/NetworkSection.cpp
@@ -36,7 +36,7 @@ using UI::Widgets::hoveredIndexFromPlotX;
 using UI::Widgets::initializeOrSmooth;
 using UI::Widgets::makeTimeAxisConfig;
 using UI::Widgets::NowBar;
-using UI::Widgets::plotLineWithFill;
+using UI::Widgets::plotDenseLine;
 using UI::Widgets::renderHistoryWithNowBars;
 using UI::Widgets::X_AXIS_FLAGS_DEFAULT;
 using UI::Widgets::Y_AXIS_FLAGS_DEFAULT;
@@ -321,68 +321,31 @@ void renderNetworkSection(RenderContext& ctx)
                 // Total lines (muted, in background) — scale fill alpha to match the muted line alpha
                 const auto ifaceSentFill = UI::withAlpha(theme.scheme().chartNetTxFill, theme.scheme().chartNetTxFill.w * 0.7F);
                 const auto ifaceRecvFill = UI::withAlpha(theme.scheme().chartNetRxFill, theme.scheme().chartNetRxFill.w * 0.7F);
-                plotLineWithFill("Sent (Total)",
-                                 netTimes.data(),
-                                 sentData.data(),
-                                 count,
-                                 ifaceSentColor,
-                                 ifaceSentFill,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
-                plotLineWithFill("Received (Total)",
-                                 netTimes.data(),
-                                 recvData.data(),
-                                 count,
-                                 ifaceRecvColor,
-                                 ifaceRecvFill,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotDenseLine("Sent (Total)", netTimes.data(), sentData.data(), count, ifaceSentColor, ifaceSentFill);
+                plotDenseLine("Received (Total)", netTimes.data(), recvData.data(), count, ifaceRecvColor, ifaceRecvFill);
 
                 // Interface-specific lines (bright, in foreground)
                 const auto ifaceSentLabel = std::format("{} Sent", ifaceDisplayName);
                 const auto ifaceRecvLabel = std::format("{} Received", ifaceDisplayName);
-                plotLineWithFill(ifaceSentLabel.c_str(),
-                                 netTimes.data(),
-                                 ifaceSentData.data(),
-                                 count,
-                                 theme.scheme().chartNetTx,
-                                 theme.scheme().chartNetTxFill,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
-                plotLineWithFill(ifaceRecvLabel.c_str(),
-                                 netTimes.data(),
-                                 ifaceRecvData.data(),
-                                 count,
-                                 theme.scheme().chartNetRx,
-                                 theme.scheme().chartNetRxFill,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotDenseLine(ifaceSentLabel.c_str(),
+                              netTimes.data(),
+                              ifaceSentData.data(),
+                              count,
+                              theme.scheme().chartNetTx,
+                              theme.scheme().chartNetTxFill);
+                plotDenseLine(ifaceRecvLabel.c_str(),
+                              netTimes.data(),
+                              ifaceRecvData.data(),
+                              count,
+                              theme.scheme().chartNetRx,
+                              theme.scheme().chartNetRxFill);
             }
             else
             {
                 // Just total
-                plotLineWithFill("Sent",
-                                 netTimes.data(),
-                                 sentData.data(),
-                                 count,
-                                 theme.scheme().chartNetTx,
-                                 theme.scheme().chartNetTxFill,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
-                plotLineWithFill("Received",
-                                 netTimes.data(),
-                                 recvData.data(),
-                                 count,
-                                 theme.scheme().chartNetRx,
-                                 theme.scheme().chartNetRxFill,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotDenseLine("Sent", netTimes.data(), sentData.data(), count, theme.scheme().chartNetTx, theme.scheme().chartNetTxFill);
+                plotDenseLine(
+                    "Received", netTimes.data(), recvData.data(), count, theme.scheme().chartNetRx, theme.scheme().chartNetRxFill);
             }
 
             if (ImPlot::IsPlotHovered())

--- a/src/App/Panels/ProcessDetailsPanel.cpp
+++ b/src/App/Panels/ProcessDetailsPanel.cpp
@@ -1023,7 +1023,7 @@ void ProcessDetailsPanel::renderThreadAndFaultHistory()
             ImPlot::SetupAxisLimits(ImAxis_X1, axisConfig.xMin, axisConfig.xMax, ImPlotCond_Always);
 
             const int plotCount = UI::Format::checkedCount(alignedCount);
-            plotDenseLine("Threads", timeData.data(), threadData.data(), plotCount, theme.scheme().chartCpu, theme.scheme().chartCpuFill);
+            plotDenseLine("Threads", timeData.data(), threadData.data(), plotCount, theme.scheme().chartCpu);
             plotDenseLine(handleLabel, timeData.data(), handleData.data(), plotCount, theme.scheme().chartMemory);
             plotDenseLine("Page Faults/s", timeData.data(), faultData.data(), plotCount, theme.accentColor(3));
 

--- a/src/App/Panels/ProcessDetailsPanel.cpp
+++ b/src/App/Panels/ProcessDetailsPanel.cpp
@@ -46,6 +46,7 @@ using UI::Widgets::hoveredIndexFromPlotX;
 using UI::Widgets::initializeOrSmooth;
 using UI::Widgets::makeTimeAxisConfig;
 using UI::Widgets::NowBar;
+using UI::Widgets::plotDenseLine;
 using UI::Widgets::plotLineWithFill;
 using UI::Widgets::renderHistoryWithNowBars;
 using UI::Widgets::setupLegendDefault;
@@ -1022,49 +1023,15 @@ void ProcessDetailsPanel::renderThreadAndFaultHistory()
             ImPlot::SetupAxisLimits(ImAxis_X1, axisConfig.xMin, axisConfig.xMax, ImPlotCond_Always);
 
             const int plotCount = UI::Format::checkedCount(alignedCount);
-            plotLineWithFill("Threads",
-                             timeData.data(),
-                             threadData.data(),
-                             plotCount,
-                             theme.scheme().chartCpu,
-                             theme.scheme().chartCpuFill,
-                             2.0F,
-                             false,
-                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
-
-            plotLineWithFill(handleLabel,
-                             timeData.data(),
-                             handleData.data(),
-                             plotCount,
-                             theme.scheme().chartMemory,
-                             std::nullopt,
-                             2.0F,
-                             false,
-                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
-
-            plotLineWithFill("Page Faults/s",
-                             timeData.data(),
-                             faultData.data(),
-                             plotCount,
-                             theme.accentColor(3),
-                             std::nullopt,
-                             2.0F,
-                             false,
-                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+            plotDenseLine("Threads", timeData.data(), threadData.data(), plotCount, theme.scheme().chartCpu, theme.scheme().chartCpuFill);
+            plotDenseLine(handleLabel, timeData.data(), handleData.data(), plotCount, theme.scheme().chartMemory);
+            plotDenseLine("Page Faults/s", timeData.data(), faultData.data(), plotCount, theme.accentColor(3));
 
 #ifdef _WIN32
             if (!gdiData.empty())
             {
                 const int gdiPlotCount = UI::Format::checkedCount(std::min(gdiAlignedCount, timeData.size()));
-                plotLineWithFill("GDI Objects",
-                                 timeData.data(),
-                                 gdiData.data(),
-                                 gdiPlotCount,
-                                 theme.accentColor(4),
-                                 std::nullopt,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotDenseLine("GDI Objects", timeData.data(), gdiData.data(), gdiPlotCount, theme.accentColor(4));
             }
 #endif
 
@@ -1178,10 +1145,25 @@ void ProcessDetailsPanel::renderIoStats(const Domain::ProcessSnapshot& proc)
             ImPlot::SetupAxisLimits(ImAxis_X1, axisConfig.xMin, axisConfig.xMax, ImPlotCond_Always);
 
             const int plotCount = UI::Format::checkedCount(alignedCount);
-            plotLineWithFill("Read", timeData.data(), readData.data(), plotCount, theme.scheme().chartIo, theme.scheme().chartIoFill);
+            plotLineWithFill("Read",
+                             timeData.data(),
+                             readData.data(),
+                             plotCount,
+                             theme.scheme().chartIo,
+                             theme.scheme().chartIoFill,
+                             2.0F,
+                             true,
+                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
-            plotLineWithFill(
-                "Write", timeData.data(), writeData.data(), plotCount, theme.scheme().chartIoWrite, theme.scheme().chartIoWriteFill);
+            plotLineWithFill("Write",
+                             timeData.data(),
+                             writeData.data(),
+                             plotCount,
+                             theme.scheme().chartIoWrite,
+                             theme.scheme().chartIoWriteFill,
+                             2.0F,
+                             true,
+                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
             if (ImPlot::IsPlotHovered())
             {
@@ -1267,10 +1249,25 @@ void ProcessDetailsPanel::renderNetworkStats(const Domain::ProcessSnapshot& proc
             ImPlot::SetupAxisLimits(ImAxis_X1, axisConfig.xMin, axisConfig.xMax, ImPlotCond_Always);
 
             const int plotCount = UI::Format::checkedCount(alignedCount);
-            plotLineWithFill("Sent", timeData.data(), sentData.data(), plotCount, theme.scheme().chartNetTx, theme.scheme().chartNetTxFill);
+            plotLineWithFill("Sent",
+                             timeData.data(),
+                             sentData.data(),
+                             plotCount,
+                             theme.scheme().chartNetTx,
+                             theme.scheme().chartNetTxFill,
+                             2.0F,
+                             true,
+                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
-            plotLineWithFill(
-                "Received", timeData.data(), recvData.data(), plotCount, theme.scheme().chartNetRx, theme.scheme().chartNetRxFill);
+            plotLineWithFill("Received",
+                             timeData.data(),
+                             recvData.data(),
+                             plotCount,
+                             theme.scheme().chartNetRx,
+                             theme.scheme().chartNetRxFill,
+                             2.0F,
+                             true,
+                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
             if (ImPlot::IsPlotHovered())
             {
@@ -1588,7 +1585,10 @@ void ProcessDetailsPanel::renderGpuUsage(const Domain::ProcessSnapshot& proc)
                                      gpuUtilVec.data(),
                                      plotCount,
                                      theme.scheme().gpuUtilization,
-                                     theme.scheme().gpuUtilizationFill);
+                                     theme.scheme().gpuUtilizationFill,
+                                     2.0F,
+                                     true,
+                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
                     // Tooltip
                     if (ImPlot::IsPlotHovered())
@@ -1632,8 +1632,15 @@ void ProcessDetailsPanel::renderGpuUsage(const Domain::ProcessSnapshot& proc)
 
                 if (plotCount > 0)
                 {
-                    plotLineWithFill(
-                        "GPU Memory", timeData.data(), gpuMemVec.data(), plotCount, theme.scheme().gpuMemory, theme.scheme().gpuMemoryFill);
+                    plotLineWithFill("GPU Memory",
+                                     timeData.data(),
+                                     gpuMemVec.data(),
+                                     plotCount,
+                                     theme.scheme().gpuMemory,
+                                     theme.scheme().gpuMemoryFill,
+                                     2.0F,
+                                     true,
+                                     UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
                     // Tooltip
                     if (ImPlot::IsPlotHovered())

--- a/src/App/Panels/ProcessDetailsPanel.cpp
+++ b/src/App/Panels/ProcessDetailsPanel.cpp
@@ -1022,18 +1022,49 @@ void ProcessDetailsPanel::renderThreadAndFaultHistory()
             ImPlot::SetupAxisLimits(ImAxis_X1, axisConfig.xMin, axisConfig.xMax, ImPlotCond_Always);
 
             const int plotCount = UI::Format::checkedCount(alignedCount);
-            plotLineWithFill(
-                "Threads", timeData.data(), threadData.data(), plotCount, theme.scheme().chartCpu, theme.scheme().chartCpuFill);
+            plotLineWithFill("Threads",
+                             timeData.data(),
+                             threadData.data(),
+                             plotCount,
+                             theme.scheme().chartCpu,
+                             theme.scheme().chartCpuFill,
+                             2.0F,
+                             false,
+                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
-            plotLineWithFill(handleLabel, timeData.data(), handleData.data(), plotCount, theme.scheme().chartMemory);
+            plotLineWithFill(handleLabel,
+                             timeData.data(),
+                             handleData.data(),
+                             plotCount,
+                             theme.scheme().chartMemory,
+                             std::nullopt,
+                             2.0F,
+                             false,
+                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
-            plotLineWithFill("Page Faults/s", timeData.data(), faultData.data(), plotCount, theme.accentColor(3));
+            plotLineWithFill("Page Faults/s",
+                             timeData.data(),
+                             faultData.data(),
+                             plotCount,
+                             theme.accentColor(3),
+                             std::nullopt,
+                             2.0F,
+                             false,
+                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
 #ifdef _WIN32
             if (!gdiData.empty())
             {
                 const int gdiPlotCount = UI::Format::checkedCount(std::min(gdiAlignedCount, timeData.size()));
-                plotLineWithFill("GDI Objects", timeData.data(), gdiData.data(), gdiPlotCount, theme.accentColor(4));
+                plotLineWithFill("GDI Objects",
+                                 timeData.data(),
+                                 gdiData.data(),
+                                 gdiPlotCount,
+                                 theme.accentColor(4),
+                                 std::nullopt,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
             }
 #endif
 

--- a/src/App/Panels/StorageSection.cpp
+++ b/src/App/Panels/StorageSection.cpp
@@ -81,9 +81,24 @@ void renderDiskCell(std::string_view deviceName,
             ImPlot::SetupAxisLimits(ImAxis_X1, axisConfig.xMin, axisConfig.xMax, ImPlotCond_Always);
 
             const int count = UI::Format::checkedCount(timeData.size());
-            plotLineWithFill("Read", timeData.data(), readData.data(), count, theme.scheme().chartIo, theme.scheme().chartIoFill);
-            plotLineWithFill(
-                "Write", timeData.data(), writeData.data(), count, theme.scheme().chartIoWrite, theme.scheme().chartIoWriteFill);
+            plotLineWithFill("Read",
+                             timeData.data(),
+                             readData.data(),
+                             count,
+                             theme.scheme().chartIo,
+                             theme.scheme().chartIoFill,
+                             2.0F,
+                             true,
+                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+            plotLineWithFill("Write",
+                             timeData.data(),
+                             writeData.data(),
+                             count,
+                             theme.scheme().chartIoWrite,
+                             theme.scheme().chartIoWriteFill,
+                             2.0F,
+                             true,
+                             UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
             if (ImPlot::IsPlotHovered() && !timeData.empty())
             {
@@ -302,9 +317,24 @@ void renderStorageSection(RenderContext& ctx)
                 ImPlot::SetupAxisLimits(ImAxis_X1, diskAxis.xMin, diskAxis.xMax, ImPlotCond_Always);
 
                 const int count = UI::Format::checkedCount(alignedDisk);
-                plotLineWithFill("Read", diskTimes.data(), readData.data(), count, theme.scheme().chartIo, theme.scheme().chartIoFill);
-                plotLineWithFill(
-                    "Write", diskTimes.data(), writeData.data(), count, theme.scheme().chartIoWrite, theme.scheme().chartIoWriteFill);
+                plotLineWithFill("Read",
+                                 diskTimes.data(),
+                                 readData.data(),
+                                 count,
+                                 theme.scheme().chartIo,
+                                 theme.scheme().chartIoFill,
+                                 2.0F,
+                                 true,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotLineWithFill("Write",
+                                 diskTimes.data(),
+                                 writeData.data(),
+                                 count,
+                                 theme.scheme().chartIoWrite,
+                                 theme.scheme().chartIoWriteFill,
+                                 2.0F,
+                                 true,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
                 if (ImPlot::IsPlotHovered())
                 {

--- a/src/App/Panels/SystemMetricsPanel.cpp
+++ b/src/App/Panels/SystemMetricsPanel.cpp
@@ -871,7 +871,11 @@ void SystemMetricsPanel::renderOverview()
                                          timeData.data() + static_cast<std::ptrdiff_t>(powerOffset),
                                          powerHist.data(),
                                          UI::Format::checkedCount(powerHist.size()),
-                                         theme.scheme().chartCpu);
+                                         theme.scheme().chartCpu,
+                                         std::nullopt,
+                                         2.0F,
+                                         false,
+                                         UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                     }
 
                     // Plot battery charge on secondary Y-axis
@@ -882,7 +886,11 @@ void SystemMetricsPanel::renderOverview()
                                          timeData.data() + static_cast<std::ptrdiff_t>(batteryOffset),
                                          batteryHist.data(),
                                          UI::Format::checkedCount(batteryHist.size()),
-                                         theme.scheme().chartMemory);
+                                         theme.scheme().chartMemory,
+                                         std::nullopt,
+                                         2.0F,
+                                         false,
+                                         UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
                         ImPlot::SetAxes(ImAxis_X1, ImAxis_Y1); // Reset to primary
                     }
 
@@ -1090,9 +1098,33 @@ void SystemMetricsPanel::renderOverview()
                 ImPlot::SetupAxisLimits(ImAxis_X1, axis.xMin, axis.xMax, ImPlotCond_Always);
 
                 const int count = UI::Format::checkedCount(alignedCount);
-                plotLineWithFill("Threads", timeData.data(), threadData.data(), count, theme.scheme().chartCpu);
-                plotLineWithFill("Page Faults/s", timeData.data(), faultData.data(), count, theme.accentColor(3));
-                plotLineWithFill(handleLabel, timeData.data(), handleData.data(), count, theme.scheme().chartMemory);
+                plotLineWithFill("Threads",
+                                 timeData.data(),
+                                 threadData.data(),
+                                 count,
+                                 theme.scheme().chartCpu,
+                                 std::nullopt,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotLineWithFill("Page Faults/s",
+                                 timeData.data(),
+                                 faultData.data(),
+                                 count,
+                                 theme.accentColor(3),
+                                 std::nullopt,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotLineWithFill(handleLabel,
+                                 timeData.data(),
+                                 handleData.data(),
+                                 count,
+                                 theme.scheme().chartMemory,
+                                 std::nullopt,
+                                 2.0F,
+                                 false,
+                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
 
                 if (ImPlot::IsPlotHovered())
                 {

--- a/src/App/Panels/SystemMetricsPanel.cpp
+++ b/src/App/Panels/SystemMetricsPanel.cpp
@@ -71,7 +71,7 @@ using UI::Widgets::formatAxisLocalized;
 using UI::Widgets::formatAxisWatts;
 using UI::Widgets::HISTORY_PLOT_HEIGHT_DEFAULT;
 using UI::Widgets::PLOT_FLAGS_DEFAULT;
-using UI::Widgets::plotLineWithFill;
+using UI::Widgets::plotDenseLine;
 using UI::Widgets::smoothTowards;
 using UI::Widgets::X_AXIS_FLAGS_DEFAULT;
 using UI::Widgets::Y_AXIS_FLAGS_DEFAULT;
@@ -867,30 +867,22 @@ void SystemMetricsPanel::renderOverview()
                     // Plot power on primary Y-axis
                     if (!powerHist.empty())
                     {
-                        plotLineWithFill("Power",
-                                         timeData.data() + static_cast<std::ptrdiff_t>(powerOffset),
-                                         powerHist.data(),
-                                         UI::Format::checkedCount(powerHist.size()),
-                                         theme.scheme().chartCpu,
-                                         std::nullopt,
-                                         2.0F,
-                                         false,
-                                         UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                        plotDenseLine("Power",
+                                      timeData.data() + static_cast<std::ptrdiff_t>(powerOffset),
+                                      powerHist.data(),
+                                      UI::Format::checkedCount(powerHist.size()),
+                                      theme.scheme().chartCpu);
                     }
 
                     // Plot battery charge on secondary Y-axis
                     if (snap.power.hasBattery && !batteryHist.empty())
                     {
                         ImPlot::SetAxes(ImAxis_X1, ImAxis_Y2);
-                        plotLineWithFill("Battery",
-                                         timeData.data() + static_cast<std::ptrdiff_t>(batteryOffset),
-                                         batteryHist.data(),
-                                         UI::Format::checkedCount(batteryHist.size()),
-                                         theme.scheme().chartMemory,
-                                         std::nullopt,
-                                         2.0F,
-                                         false,
-                                         UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                        plotDenseLine("Battery",
+                                      timeData.data() + static_cast<std::ptrdiff_t>(batteryOffset),
+                                      batteryHist.data(),
+                                      UI::Format::checkedCount(batteryHist.size()),
+                                      theme.scheme().chartMemory);
                         ImPlot::SetAxes(ImAxis_X1, ImAxis_Y1); // Reset to primary
                     }
 
@@ -1098,33 +1090,9 @@ void SystemMetricsPanel::renderOverview()
                 ImPlot::SetupAxisLimits(ImAxis_X1, axis.xMin, axis.xMax, ImPlotCond_Always);
 
                 const int count = UI::Format::checkedCount(alignedCount);
-                plotLineWithFill("Threads",
-                                 timeData.data(),
-                                 threadData.data(),
-                                 count,
-                                 theme.scheme().chartCpu,
-                                 std::nullopt,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
-                plotLineWithFill("Page Faults/s",
-                                 timeData.data(),
-                                 faultData.data(),
-                                 count,
-                                 theme.accentColor(3),
-                                 std::nullopt,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
-                plotLineWithFill(handleLabel,
-                                 timeData.data(),
-                                 handleData.data(),
-                                 count,
-                                 theme.scheme().chartMemory,
-                                 std::nullopt,
-                                 2.0F,
-                                 false,
-                                 UI::Widgets::LINE_PLOT_MAX_POINTS_DENSE);
+                plotDenseLine("Threads", timeData.data(), threadData.data(), count, theme.scheme().chartCpu);
+                plotDenseLine("Page Faults/s", timeData.data(), faultData.data(), count, theme.accentColor(3));
+                plotDenseLine(handleLabel, timeData.data(), handleData.data(), count, theme.scheme().chartMemory);
 
                 if (ImPlot::IsPlotHovered())
                 {

--- a/src/UI/ChartWidgets.h
+++ b/src/UI/ChartWidgets.h
@@ -121,35 +121,32 @@ inline void plotLineWithFill(const char* label,
     const TX* plotXData = xData;
     const TY* plotYData = yData;
     int plotCount = count;
-    std::optional<std::array<TX, LINE_PLOT_MAX_POINTS_DENSE>> reducedXData;
-    std::optional<std::array<TY, LINE_PLOT_MAX_POINTS_DENSE>> reducedYData;
+    std::array<TX, LINE_PLOT_MAX_POINTS_DENSE> reducedXData;
+    std::array<TY, LINE_PLOT_MAX_POINTS_DENSE> reducedYData;
 
     // Clamp effective max so stride math and buffer capacity stay in sync.
     const int effectiveMax = (maxPointCount > 1) ? std::min(maxPointCount, static_cast<int>(LINE_PLOT_MAX_POINTS_DENSE)) : maxPointCount;
     if ((effectiveMax > 1) && (count > effectiveMax))
     {
-        reducedXData.emplace();
-        reducedYData.emplace();
-
         for (int resultIdx = 0; resultIdx < effectiveMax; ++resultIdx)
         {
             const std::size_t numerator = static_cast<std::size_t>(resultIdx) * static_cast<std::size_t>(count - 1);
             const std::size_t denominator = static_cast<std::size_t>(effectiveMax - 1);
             const int sourceIdx = static_cast<int>(numerator / denominator);
 
-            (*reducedXData)[static_cast<std::size_t>(resultIdx)] = xData[sourceIdx];
-            (*reducedYData)[static_cast<std::size_t>(resultIdx)] = yData[sourceIdx];
+            reducedXData[static_cast<std::size_t>(resultIdx)] = xData[sourceIdx];
+            reducedYData[static_cast<std::size_t>(resultIdx)] = yData[sourceIdx];
         }
 
-        plotXData = reducedXData->data();
-        plotYData = reducedYData->data();
+        plotXData = reducedXData.data();
+        plotYData = reducedYData.data();
         plotCount = effectiveMax;
     }
 
     if (drawFill)
     {
         const ImVec4 fill = fillColor.value_or(ImVec4{lineColor.x, lineColor.y, lineColor.z, lineColor.w * 0.35F});
-        // Use PushID to ensure unique ImPlot item ID even if label is long or truncates.
+        // Keep fallback shaded label IDs unique when snprintf truncates to the shared "##Fill" fallback.
         ImGui::PushID(label);
         std::array<char, 128> shadedLabel{};
         const int shadedLabelLen = std::snprintf(shadedLabel.data(), shadedLabel.size(), "##%sFill", label);

--- a/src/UI/ChartWidgets.h
+++ b/src/UI/ChartWidgets.h
@@ -122,45 +122,62 @@ inline void plotLineWithFill(const char* label,
     const TY* plotYData = yData;
     int plotCount = count;
 
-    std::vector<TX> reducedXData;
-    std::vector<TY> reducedYData;
+    std::array<TX, LINE_PLOT_MAX_POINTS_DENSE> reducedXData{};
+    std::array<TY, LINE_PLOT_MAX_POINTS_DENSE> reducedYData{};
     if ((maxPointCount > 1) && (count > maxPointCount))
     {
         const int stride = std::max((count + maxPointCount - 1) / maxPointCount, 1);
-        const int reducedCount = ((count - 1) / stride) + 1;
-        reducedXData.reserve(static_cast<size_t>(reducedCount));
-        reducedYData.reserve(static_cast<size_t>(reducedCount));
 
+        int resultIdx = 0;
         for (int i = 0; i < count; i += stride)
         {
-            reducedXData.push_back(xData[i]);
-            reducedYData.push_back(yData[i]);
+            if (resultIdx < static_cast<int>(LINE_PLOT_MAX_POINTS_DENSE))
+            {
+                reducedXData[static_cast<std::size_t>(resultIdx)] = xData[i];
+                reducedYData[static_cast<std::size_t>(resultIdx)] = yData[i];
+                ++resultIdx;
+            }
         }
 
         if ((count > 0) && ((count - 1) % stride != 0))
         {
-            reducedXData.push_back(xData[count - 1]);
-            reducedYData.push_back(yData[count - 1]);
+            if (resultIdx < static_cast<int>(LINE_PLOT_MAX_POINTS_DENSE))
+            {
+                reducedXData[static_cast<std::size_t>(resultIdx)] = xData[count - 1];
+                reducedYData[static_cast<std::size_t>(resultIdx)] = yData[count - 1];
+                ++resultIdx;
+            }
         }
 
         plotXData = reducedXData.data();
         plotYData = reducedYData.data();
-        plotCount = Domain::Numeric::narrowOr<int>(reducedXData.size(), count);
+        plotCount = resultIdx;
     }
-
-    const ImVec4 fill = fillColor.value_or(ImVec4{lineColor.x, lineColor.y, lineColor.z, lineColor.w * 0.35F});
 
     if (drawFill)
     {
+        const ImVec4 fill = fillColor.value_or(ImVec4{lineColor.x, lineColor.y, lineColor.z, lineColor.w * 0.35F});
+        // Use PushID to ensure unique ImPlot item ID even if label is long or truncates.
+        ImGui::PushID(label);
         std::array<char, 128> shadedLabel{};
         const int shadedLabelLen = std::snprintf(shadedLabel.data(), shadedLabel.size(), "##%sFill", label);
         const char* shadedLabelPtr =
-            (shadedLabelLen > 0 && shadedLabelLen < static_cast<int>(shadedLabel.size())) ? shadedLabel.data() : "##SeriesFill";
+            (shadedLabelLen > 0 && shadedLabelLen < static_cast<int>(shadedLabel.size())) ? shadedLabel.data() : "##Fill";
 
         ImPlot::PlotShaded(shadedLabelPtr, plotXData, plotYData, plotCount, 0.0, {ImPlotProp_FillColor, fill});
+        ImGui::PopID();
     }
 
     ImPlot::PlotLine(label, plotXData, plotYData, plotCount, {ImPlotProp_LineColor, lineColor, ImPlotProp_LineWeight, lineThickness});
+}
+
+// Helper for dense-line mode: line only, no fill, with stride downsampling to 720 points
+// Commonly used across overview/resource charts for performance
+template<typename TX, typename TY>
+inline void plotDenseLine(
+    const char* label, const TX* xData, const TY* yData, int count, const ImVec4& lineColor, std::optional<ImVec4> fillColor = std::nullopt)
+{
+    plotLineWithFill(label, xData, yData, count, lineColor, fillColor, 2.0F, false, LINE_PLOT_MAX_POINTS_DENSE);
 }
 
 // ============================================================================

--- a/src/UI/ChartWidgets.h
+++ b/src/UI/ChartWidgets.h
@@ -124,9 +124,11 @@ inline void plotLineWithFill(const char* label,
 
     std::array<TX, LINE_PLOT_MAX_POINTS_DENSE> reducedXData{};
     std::array<TY, LINE_PLOT_MAX_POINTS_DENSE> reducedYData{};
-    if ((maxPointCount > 1) && (count > maxPointCount))
+    // Clamp effective max so stride math and buffer capacity stay in sync.
+    const int effectiveMax = (maxPointCount > 1) ? std::min(maxPointCount, static_cast<int>(LINE_PLOT_MAX_POINTS_DENSE)) : maxPointCount;
+    if ((effectiveMax > 1) && (count > effectiveMax))
     {
-        const int stride = std::max((count + maxPointCount - 1) / maxPointCount, 1);
+        const int stride = std::max((count + effectiveMax - 1) / effectiveMax, 1);
 
         int resultIdx = 0;
         for (int i = 0; i < count; i += stride)
@@ -171,13 +173,12 @@ inline void plotLineWithFill(const char* label,
     ImPlot::PlotLine(label, plotXData, plotYData, plotCount, {ImPlotProp_LineColor, lineColor, ImPlotProp_LineWeight, lineThickness});
 }
 
-// Helper for dense-line mode: line only, no fill, with stride downsampling to 720 points
-// Commonly used across overview/resource charts for performance
+// Helper for dense-line mode: line only, no fill, with stride downsampling to LINE_PLOT_MAX_POINTS_DENSE points.
+// Fills are intentionally disabled; pass only the line color.
 template<typename TX, typename TY>
-inline void plotDenseLine(
-    const char* label, const TX* xData, const TY* yData, int count, const ImVec4& lineColor, std::optional<ImVec4> fillColor = std::nullopt)
+inline void plotDenseLine(const char* label, const TX* xData, const TY* yData, int count, const ImVec4& lineColor)
 {
-    plotLineWithFill(label, xData, yData, count, lineColor, fillColor, 2.0F, false, LINE_PLOT_MAX_POINTS_DENSE);
+    plotLineWithFill(label, xData, yData, count, lineColor, std::nullopt, 2.0F, false, LINE_PLOT_MAX_POINTS_DENSE);
 }
 
 // ============================================================================

--- a/src/UI/ChartWidgets.h
+++ b/src/UI/ChartWidgets.h
@@ -118,16 +118,31 @@ inline void plotLineWithFill(const char* label,
         return;
     }
 
-    const TX* plotXData = xData;
-    const TY* plotYData = yData;
-    int plotCount = count;
-    std::array<TX, LINE_PLOT_MAX_POINTS_DENSE> reducedXData;
-    std::array<TY, LINE_PLOT_MAX_POINTS_DENSE> reducedYData;
+    const auto renderSeries = [&](const TX* plotXData, const TY* plotYData, int plotCount)
+    {
+        if (drawFill)
+        {
+            const ImVec4 fill = fillColor.value_or(ImVec4{lineColor.x, lineColor.y, lineColor.z, lineColor.w * 0.35F});
+            // Keep fallback shaded label IDs unique when snprintf truncates to the shared "##Fill" fallback.
+            ImGui::PushID(label);
+            std::array<char, 128> shadedLabel{};
+            const int shadedLabelLen = std::snprintf(shadedLabel.data(), shadedLabel.size(), "##%sFill", label);
+            const char* shadedLabelPtr =
+                (shadedLabelLen > 0 && shadedLabelLen < static_cast<int>(shadedLabel.size())) ? shadedLabel.data() : "##Fill";
+
+            ImPlot::PlotShaded(shadedLabelPtr, plotXData, plotYData, plotCount, 0.0, {ImPlotProp_FillColor, fill});
+            ImGui::PopID();
+        }
+
+        ImPlot::PlotLine(label, plotXData, plotYData, plotCount, {ImPlotProp_LineColor, lineColor, ImPlotProp_LineWeight, lineThickness});
+    };
 
     // Clamp effective max so stride math and buffer capacity stay in sync.
     const int effectiveMax = (maxPointCount > 1) ? std::min(maxPointCount, static_cast<int>(LINE_PLOT_MAX_POINTS_DENSE)) : maxPointCount;
     if ((effectiveMax > 1) && (count > effectiveMax))
     {
+        std::array<TX, LINE_PLOT_MAX_POINTS_DENSE> reducedXData;
+        std::array<TY, LINE_PLOT_MAX_POINTS_DENSE> reducedYData;
         for (int resultIdx = 0; resultIdx < effectiveMax; ++resultIdx)
         {
             const std::size_t numerator = static_cast<std::size_t>(resultIdx) * static_cast<std::size_t>(count - 1);
@@ -138,26 +153,11 @@ inline void plotLineWithFill(const char* label,
             reducedYData[static_cast<std::size_t>(resultIdx)] = yData[sourceIdx];
         }
 
-        plotXData = reducedXData.data();
-        plotYData = reducedYData.data();
-        plotCount = effectiveMax;
+        renderSeries(reducedXData.data(), reducedYData.data(), effectiveMax);
+        return;
     }
 
-    if (drawFill)
-    {
-        const ImVec4 fill = fillColor.value_or(ImVec4{lineColor.x, lineColor.y, lineColor.z, lineColor.w * 0.35F});
-        // Keep fallback shaded label IDs unique when snprintf truncates to the shared "##Fill" fallback.
-        ImGui::PushID(label);
-        std::array<char, 128> shadedLabel{};
-        const int shadedLabelLen = std::snprintf(shadedLabel.data(), shadedLabel.size(), "##%sFill", label);
-        const char* shadedLabelPtr =
-            (shadedLabelLen > 0 && shadedLabelLen < static_cast<int>(shadedLabel.size())) ? shadedLabel.data() : "##Fill";
-
-        ImPlot::PlotShaded(shadedLabelPtr, plotXData, plotYData, plotCount, 0.0, {ImPlotProp_FillColor, fill});
-        ImGui::PopID();
-    }
-
-    ImPlot::PlotLine(label, plotXData, plotYData, plotCount, {ImPlotProp_LineColor, lineColor, ImPlotProp_LineWeight, lineThickness});
+    renderSeries(xData, yData, count);
 }
 
 // Helper for dense-line mode: line only, no fill, with stride downsampling to LINE_PLOT_MAX_POINTS_DENSE points.

--- a/src/UI/ChartWidgets.h
+++ b/src/UI/ChartWidgets.h
@@ -121,14 +121,16 @@ inline void plotLineWithFill(const char* label,
     const TX* plotXData = xData;
     const TY* plotYData = yData;
     int plotCount = count;
+    std::optional<std::array<TX, LINE_PLOT_MAX_POINTS_DENSE>> reducedXData;
+    std::optional<std::array<TY, LINE_PLOT_MAX_POINTS_DENSE>> reducedYData;
 
     // Clamp effective max so stride math and buffer capacity stay in sync.
     const int effectiveMax = (maxPointCount > 1) ? std::min(maxPointCount, static_cast<int>(LINE_PLOT_MAX_POINTS_DENSE)) : maxPointCount;
     if ((effectiveMax > 1) && (count > effectiveMax))
     {
-        std::array<TX, LINE_PLOT_MAX_POINTS_DENSE> reducedXData{};
-        std::array<TY, LINE_PLOT_MAX_POINTS_DENSE> reducedYData{};
-        const int stride = std::max((count + effectiveMax - 1) / effectiveMax, 1);
+        reducedXData.emplace();
+        reducedYData.emplace();
+        const int stride = std::max(count / effectiveMax, 1);
 
         int resultIdx = 0;
         bool includedLastSample = false;
@@ -139,8 +141,8 @@ inline void plotLineWithFill(const char* label,
                 break;
             }
 
-            reducedXData[static_cast<std::size_t>(resultIdx)] = xData[i];
-            reducedYData[static_cast<std::size_t>(resultIdx)] = yData[i];
+            (*reducedXData)[static_cast<std::size_t>(resultIdx)] = xData[i];
+            (*reducedYData)[static_cast<std::size_t>(resultIdx)] = yData[i];
             includedLastSample = (i == (count - 1));
             ++resultIdx;
         }
@@ -150,20 +152,20 @@ inline void plotLineWithFill(const char* label,
             const int lastSampleIdx = count - 1;
             if (resultIdx < effectiveMax)
             {
-                reducedXData[static_cast<std::size_t>(resultIdx)] = xData[lastSampleIdx];
-                reducedYData[static_cast<std::size_t>(resultIdx)] = yData[lastSampleIdx];
+                (*reducedXData)[static_cast<std::size_t>(resultIdx)] = xData[lastSampleIdx];
+                (*reducedYData)[static_cast<std::size_t>(resultIdx)] = yData[lastSampleIdx];
                 ++resultIdx;
             }
             else
             {
                 const std::size_t overwriteIdx = static_cast<std::size_t>(effectiveMax - 1);
-                reducedXData[overwriteIdx] = xData[lastSampleIdx];
-                reducedYData[overwriteIdx] = yData[lastSampleIdx];
+                (*reducedXData)[overwriteIdx] = xData[lastSampleIdx];
+                (*reducedYData)[overwriteIdx] = yData[lastSampleIdx];
             }
         }
 
-        plotXData = reducedXData.data();
-        plotYData = reducedYData.data();
+        plotXData = reducedXData->data();
+        plotYData = reducedYData->data();
         plotCount = resultIdx;
     }
 

--- a/src/UI/ChartWidgets.h
+++ b/src/UI/ChartWidgets.h
@@ -9,9 +9,11 @@
 #include <implot.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
+#include <cstdio>
 #include <format>
 #include <functional>
 #include <limits>
@@ -32,6 +34,7 @@ inline constexpr float BAR_WIDTH = 24.0F;
 inline constexpr double SMOOTH_FACTOR = 0.5; // fraction of refresh interval used for tau
 inline constexpr double TAU_MS_MIN = 20.0;
 inline constexpr double TAU_MS_MAX = 400.0;
+inline constexpr int LINE_PLOT_MAX_POINTS_DENSE = 720;
 
 /// RAII guard to push smaller font for chart axis labels and legends
 /// RAII guard that pushes smaller font for chart rendering.
@@ -106,19 +109,58 @@ inline void plotLineWithFill(const char* label,
                              int count,
                              const ImVec4& lineColor,
                              std::optional<ImVec4> fillColor = std::nullopt,
-                             float lineThickness = 2.0F)
+                             float lineThickness = 2.0F,
+                             bool drawFill = true,
+                             int maxPointCount = 0)
 {
     if (count <= 0)
     {
         return;
     }
 
+    const TX* plotXData = xData;
+    const TY* plotYData = yData;
+    int plotCount = count;
+
+    std::vector<TX> reducedXData;
+    std::vector<TY> reducedYData;
+    if ((maxPointCount > 1) && (count > maxPointCount))
+    {
+        const int stride = std::max((count + maxPointCount - 1) / maxPointCount, 1);
+        const int reducedCount = ((count - 1) / stride) + 1;
+        reducedXData.reserve(static_cast<size_t>(reducedCount));
+        reducedYData.reserve(static_cast<size_t>(reducedCount));
+
+        for (int i = 0; i < count; i += stride)
+        {
+            reducedXData.push_back(xData[i]);
+            reducedYData.push_back(yData[i]);
+        }
+
+        if ((count > 0) && ((count - 1) % stride != 0))
+        {
+            reducedXData.push_back(xData[count - 1]);
+            reducedYData.push_back(yData[count - 1]);
+        }
+
+        plotXData = reducedXData.data();
+        plotYData = reducedYData.data();
+        plotCount = Domain::Numeric::narrowOr<int>(reducedXData.size(), count);
+    }
+
     const ImVec4 fill = fillColor.value_or(ImVec4{lineColor.x, lineColor.y, lineColor.z, lineColor.w * 0.35F});
 
-    const std::string shadedLabel = std::format("##{}Fill", label);
+    if (drawFill)
+    {
+        std::array<char, 128> shadedLabel{};
+        const int shadedLabelLen = std::snprintf(shadedLabel.data(), shadedLabel.size(), "##%sFill", label);
+        const char* shadedLabelPtr =
+            (shadedLabelLen > 0 && shadedLabelLen < static_cast<int>(shadedLabel.size())) ? shadedLabel.data() : "##SeriesFill";
 
-    ImPlot::PlotShaded(shadedLabel.c_str(), xData, yData, count, 0.0, {ImPlotProp_FillColor, fill});
-    ImPlot::PlotLine(label, xData, yData, count, {ImPlotProp_LineColor, lineColor, ImPlotProp_LineWeight, lineThickness});
+        ImPlot::PlotShaded(shadedLabelPtr, plotXData, plotYData, plotCount, 0.0, {ImPlotProp_FillColor, fill});
+    }
+
+    ImPlot::PlotLine(label, plotXData, plotYData, plotCount, {ImPlotProp_LineColor, lineColor, ImPlotProp_LineWeight, lineThickness});
 }
 
 // ============================================================================

--- a/src/UI/ChartWidgets.h
+++ b/src/UI/ChartWidgets.h
@@ -130,43 +130,20 @@ inline void plotLineWithFill(const char* label,
     {
         reducedXData.emplace();
         reducedYData.emplace();
-        const int stride = std::max(count / effectiveMax, 1);
 
-        int resultIdx = 0;
-        bool includedLastSample = false;
-        for (int i = 0; i < count; i += stride)
+        for (int resultIdx = 0; resultIdx < effectiveMax; ++resultIdx)
         {
-            if (resultIdx >= effectiveMax)
-            {
-                break;
-            }
+            const std::size_t numerator = static_cast<std::size_t>(resultIdx) * static_cast<std::size_t>(count - 1);
+            const std::size_t denominator = static_cast<std::size_t>(effectiveMax - 1);
+            const int sourceIdx = static_cast<int>(numerator / denominator);
 
-            (*reducedXData)[static_cast<std::size_t>(resultIdx)] = xData[i];
-            (*reducedYData)[static_cast<std::size_t>(resultIdx)] = yData[i];
-            includedLastSample = (i == (count - 1));
-            ++resultIdx;
-        }
-
-        if (!includedLastSample)
-        {
-            const int lastSampleIdx = count - 1;
-            if (resultIdx < effectiveMax)
-            {
-                (*reducedXData)[static_cast<std::size_t>(resultIdx)] = xData[lastSampleIdx];
-                (*reducedYData)[static_cast<std::size_t>(resultIdx)] = yData[lastSampleIdx];
-                ++resultIdx;
-            }
-            else
-            {
-                const std::size_t overwriteIdx = static_cast<std::size_t>(effectiveMax - 1);
-                (*reducedXData)[overwriteIdx] = xData[lastSampleIdx];
-                (*reducedYData)[overwriteIdx] = yData[lastSampleIdx];
-            }
+            (*reducedXData)[static_cast<std::size_t>(resultIdx)] = xData[sourceIdx];
+            (*reducedYData)[static_cast<std::size_t>(resultIdx)] = yData[sourceIdx];
         }
 
         plotXData = reducedXData->data();
         plotYData = reducedYData->data();
-        plotCount = resultIdx;
+        plotCount = effectiveMax;
     }
 
     if (drawFill)

--- a/src/UI/ChartWidgets.h
+++ b/src/UI/ChartWidgets.h
@@ -122,32 +122,43 @@ inline void plotLineWithFill(const char* label,
     const TY* plotYData = yData;
     int plotCount = count;
 
-    std::array<TX, LINE_PLOT_MAX_POINTS_DENSE> reducedXData{};
-    std::array<TY, LINE_PLOT_MAX_POINTS_DENSE> reducedYData{};
     // Clamp effective max so stride math and buffer capacity stay in sync.
     const int effectiveMax = (maxPointCount > 1) ? std::min(maxPointCount, static_cast<int>(LINE_PLOT_MAX_POINTS_DENSE)) : maxPointCount;
     if ((effectiveMax > 1) && (count > effectiveMax))
     {
+        std::array<TX, LINE_PLOT_MAX_POINTS_DENSE> reducedXData{};
+        std::array<TY, LINE_PLOT_MAX_POINTS_DENSE> reducedYData{};
         const int stride = std::max((count + effectiveMax - 1) / effectiveMax, 1);
 
         int resultIdx = 0;
+        bool includedLastSample = false;
         for (int i = 0; i < count; i += stride)
         {
-            if (resultIdx < static_cast<int>(LINE_PLOT_MAX_POINTS_DENSE))
+            if (resultIdx >= effectiveMax)
             {
-                reducedXData[static_cast<std::size_t>(resultIdx)] = xData[i];
-                reducedYData[static_cast<std::size_t>(resultIdx)] = yData[i];
-                ++resultIdx;
+                break;
             }
+
+            reducedXData[static_cast<std::size_t>(resultIdx)] = xData[i];
+            reducedYData[static_cast<std::size_t>(resultIdx)] = yData[i];
+            includedLastSample = (i == (count - 1));
+            ++resultIdx;
         }
 
-        if ((count > 0) && ((count - 1) % stride != 0))
+        if (!includedLastSample)
         {
-            if (resultIdx < static_cast<int>(LINE_PLOT_MAX_POINTS_DENSE))
+            const int lastSampleIdx = count - 1;
+            if (resultIdx < effectiveMax)
             {
-                reducedXData[static_cast<std::size_t>(resultIdx)] = xData[count - 1];
-                reducedYData[static_cast<std::size_t>(resultIdx)] = yData[count - 1];
+                reducedXData[static_cast<std::size_t>(resultIdx)] = xData[lastSampleIdx];
+                reducedYData[static_cast<std::size_t>(resultIdx)] = yData[lastSampleIdx];
                 ++resultIdx;
+            }
+            else
+            {
+                const std::size_t overwriteIdx = static_cast<std::size_t>(effectiveMax - 1);
+                reducedXData[overwriteIdx] = xData[lastSampleIdx];
+                reducedYData[overwriteIdx] = yData[lastSampleIdx];
             }
         }
 


### PR DESCRIPTION
## Summary
Implements optimization wins #2 and #3 from issue #575: line-only mode for dense charts and visible-density downsampling.

## Changes
**ChartWidgets.h (shared helper):**
- Add `drawFill` parameter to skip fill rendering when not needed
- Add stride-based downsampling with configurable max point count (720 points)
- Downsampling preserves first and last samples for accuracy

**Applied to dense multi-series charts:**
- GPU Core chart: Utilization, Memory, Clock, Encoder, Decoder
- GPU Thermal chart: Temperature, Power, Fan speed
- Network chart: Sent/Received (total + per-interface)
- System resources: Threads, Page Faults, Handles
- Process resources: Threads, Handles, Page Faults, GDI Objects

## Performance Impact
- **Win #1** (already merged): Removed per-frame shaded-label allocation
- **Win #2** (this PR): Skip invisible fill rendering in 4-6 series charts
- **Win #3** (this PR): Caps point geometry at ~720 samples via stride downsampling
- **Expected improvement:** 10-20% GPU overhead reduction in dense tabs

## Testing
- ✅ Debug build successful
- ✅ Visual verification with app run
- ✅ clang-format compliance verified

Resolves #575 (partial - win #2 and #3)